### PR TITLE
Improve development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,5 +118,5 @@ dmypy.json
 # OSX files
 .DS_Store
 
-# notebooks folder
-notebooks/
+# playground folder
+playground/

--- a/README.md
+++ b/README.md
@@ -3,13 +3,56 @@
 [![Github Actions Status](https://github.com/jupyterlab/jupyter_ai/workflows/Build/badge.svg)](https://github.com/jupyterlab/jupyter_ai/actions/workflows/build.yml)
 A generative AI extension for JupyterLab
 
-### Dev setup
-```shell
-hatch -e default shell # once, "exit" will escape from shell
-jlpm run build # for each change
+This is a monorepo that houses the core `jupyter_ai` package in addition to the
+default supported AI modules. To learn more about the core package, please refer
+to the [README](packages/jupyter-ai/README.md).
+
+### Development install
+
+Install the Hatch CLI, which installs the Hatchling build backend automatically.
+
+```
+pip install hatch
 ```
 
+Then, simply enter the default hatch environment, which automatically installs
+all dependencies and executes development setup when entering for the first
+time. This command must be run with the current directory set to the root of the
+monorepo (`<jupyter-ai-top>`).
+
+```
+cd <jupyter-ai-top>
+hatch shell
+```
+
+Set up your development environment and start the server:
+
+```
+jlpm build
+jlpm setup:dev # only needs to be run once
+jlpm dev
+```
+
+Finally, in a separate shell, enter the hatch environment and build the project
+after making any changes.
+
+```
+cd <jupyter-ai-top>
+hatch shell
+jlpm build
+```
+
+To exit the hatch environment at any time, exit like you would normally exit a
+shell process, via the `exit` command or `Ctrl+D`.
+
+If installation fails for any reason, you will have to first uninstall the hatch
+environment and then test your fix by reinstalling. See "Uninstall" procedure
+below.
+
 ### Uninstall
-```shell
+
+Just remove the hatch environment:
+
+```
 hatch env remove default
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ hatch shell
 Set up your development environment and start the server:
 
 ```
-jlpm build
 jlpm setup:dev # only needs to be run once
 jlpm dev
 ```

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-    "useWorkspaces": true,
-    "version": "0.0.0",
-    "npmClient": "yarn"
-  }
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+  "useWorkspaces": true,
+  "version": "0.0.0",
+  "npmClient": "yarn"
+}

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,10 @@
+{
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "cacheableOperations": ["build", "test"]
+      }
+    }
+  }
+}

--- a/nx.json
+++ b/nx.json
@@ -1,4 +1,9 @@
 {
+  "targetDefaults": {
+    "setup:dev": {
+      "dependsOn": ["build"]
+    }
+  },
   "tasksRunnerOptions": {
     "default": {
       "runner": "nx/tasks-runners/default",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "lerna run build --stream --concurrency=1",
     "clean": "lerna run clean",
     "clean:all": "lerna run clean:all",
-    "dev": "jupyter lab --config playground/config.example.py",
+    "dev": "jupyter lab --config playground/config.py",
     "lint": "jlpm && lerna run prettier && lerna run eslint",
     "lint:check": "lerna run prettier:check && lerna run eslint:check",
     "watch": "lerna run watch --parallel --stream"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "lerna run build --stream --concurrency=1",
     "clean": "lerna run clean",
     "clean:all": "lerna run clean:all",
-    "dev": "jupyter lab --ip 0.0.0.0 --config playground/config.py",
+    "dev": "jupyter lab --config playground/config.example.py",
     "lint": "jlpm && lerna run prettier && lerna run eslint",
     "lint:check": "lerna run prettier:check && lerna run eslint:check",
     "watch": "lerna run watch --parallel --stream"

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
-    "name": "root",
-    "private": true,
-    "workspaces": [
-      "packages/*"
-    ],
-    "scripts": {
-      "setup": "lerna run setup:dev --stream --concurrency=1",
-      "build": "lerna run build --stream --concurrency=1",
-      "lint": "jlpm && lerna run prettier && lerna run eslint",
-      "lint:check": "lerna run prettier:check && lerna run eslint:check",
-      "clean": "lerna run clean",
-      "watch": "lerna run watch --parallel --stream"
-    },
-    "devDependencies": {
-      "lerna": "^6.4.1",
-      "@jupyterlab/builder": "^3.1.0"
-    }
+  "name": "root",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "setup:dev": "lerna run setup:dev --stream --concurrency=1",
+    "build": "lerna run build --stream --concurrency=1",
+    "clean": "lerna run clean",
+    "clean:all": "lerna run clean:all",
+    "dev": "jupyter lab --ip 0.0.0.0 --config playground/config.py",
+    "lint": "jlpm && lerna run prettier && lerna run eslint",
+    "lint:check": "lerna run prettier:check && lerna run eslint:check",
+    "watch": "lerna run watch --parallel --stream"
+  },
+  "devDependencies": {
+    "lerna": "^6.4.1",
+    "@jupyterlab/builder": "^3.1.0"
   }
-  
+}

--- a/packages/jupyter-ai-dalle/package.json
+++ b/packages/jupyter-ai-dalle/package.json
@@ -78,7 +78,8 @@
     "stylelint-config-standard": "~24.0.0",
     "stylelint-prettier": "^2.0.0",
     "typescript": "~4.1.3",
-    "ts-jest": "^26.0.0"
+    "ts-jest": "^26.0.0",
+    "jupyter_ai": "^0.1.0"
   },
   "sideEffects": [
     "style/*.css",

--- a/packages/jupyter-ai-dalle/pyproject.toml
+++ b/packages/jupyter-ai-dalle/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "openai~=0.26",
 ]
+
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]

--- a/packages/jupyter-ai-dalle/tsconfig.json
+++ b/packages/jupyter-ai-dalle/tsconfig.json
@@ -17,6 +17,7 @@
     "rootDir": "src",
     "strict": true,
     "strictNullChecks": true,
+    "skipLibCheck": true,
     "target": "ES2018",
     "types": ["jest"]
   },

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,5 @@
+# jupyter-ai playground
+
+Contents root that should be served by JupyterLab when developing Jupyter AI. To
+use the GPT-3 and DALL-E model engines, an example configuration is provided in
+`config.py`.

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,5 +1,4 @@
 # jupyter-ai playground
 
-Contents root that should be served by JupyterLab when developing Jupyter AI. To
-use the GPT-3 and DALL-E model engines, an example configuration is provided in
-`config.py`.
+Contents root that should be served by JupyterLab when developing Jupyter AI. An
+example configuration is provided in `config.example.py`.

--- a/playground/config.example.py
+++ b/playground/config.example.py
@@ -1,7 +1,9 @@
 # JupyterLab configuration file for Jupyter AI local development
 # Reference: https://jupyter-server.readthedocs.io/en/latest/other/full-config.html
 
-# c.GPT3ModelEngine.api_key  = "<YOUR-API-KEY-HERE>"
-# c.DalleModelEngine.api_key = "<YOUR-API-KEY-HERE>"
+#c.GPT3ModelEngine.api_key  = "<YOUR-API-KEY-HERE>"
+#c.DalleModelEngine.api_key = "<YOUR-API-KEY-HERE>"
 
-asdf
+# Specify full path to the notebook dir if running jupyter lab from
+# outside of the jupyter-ai project root directory 
+c["notebook-dir"] = "./playground"

--- a/playground/config.example.py
+++ b/playground/config.example.py
@@ -1,0 +1,7 @@
+# JupyterLab configuration file for Jupyter AI local development
+# Reference: https://jupyter-server.readthedocs.io/en/latest/other/full-config.html
+
+# c.GPT3ModelEngine.api_key  = "<YOUR-API-KEY-HERE>"
+# c.DalleModelEngine.api_key = "<YOUR-API-KEY-HERE>"
+
+asdf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.4.0", "jupyterlab>=3.4.7,<4.0.0", "hatch-nodejs-version"]
+requires = ["hatchling>=1.4.0", "jupyterlab~=3.4", "hatch-nodejs-version"]
 build-backend = "hatchling.build"
 
 [project]
@@ -28,14 +28,11 @@ text = "BSD 3-Clause License"
 Homepage = "https://jupyter.org"
 
 [tool.hatch.envs.default]
-pre-install-commands = [
-    "pip install jupyterlab",
-    "jlpm install"
-]
+dependencies = ["jupyterlab~=3.4"]
 post-install-commands = [
-    "scripts/install.sh"
+    "jlpm install",       # install JS dependencies
+    "scripts/install.sh", # install Jupyter server extensions and their Python dependencies
 ]
-dependencies = ["jupyterlab>=3.4.7,<4.0.0"]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ text = "BSD 3-Clause License"
 Homepage = "https://jupyter.org"
 
 [tool.hatch.envs.default]
-dependencies = ["jupyterlab~=3.4"]
+pre-install-commands = [
+    "pip install jupyterlab~=3.4"
+]
 post-install-commands = [
     "jlpm install",       # install JS dependencies
     "scripts/install.sh", # install Jupyter server extensions and their Python dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ Homepage = "https://jupyter.org"
 
 [tool.hatch.envs.default]
 pre-install-commands = [
-    "pip install jupyterlab~=3.4"
+    "pip install jupyterlab~=3.4",
+    "cp playground/config.example.py playground/config.py"
 ]
 post-install-commands = [
     "jlpm install",       # install JS dependencies


### PR DESCRIPTION
# Description

- Fixes hatch environment setup
- Adds `playground/` directory
- Corrects and expands on `README.md`

# Testing

- Fetch and checkout this branch locally
- Follow instructions in `README.md` to verify development setup process

# Known issues

- `jlpm setup:dev` when run as a post install command does not properly link labextensions
  - Partly because `setup:dev` requires `build`, which fails because of incompatible `@jupyterlab/builder` versions, which fails because [hatch doesn't seem to respect build dependencies](https://github.com/pypa/hatch/issues/758)
  - Likely also due to different application directory (`jupyter lab path`) during installation procedure
- Pressing Ctrl-C to shut down Jupyter Server in hatch shell causes really weird behavior where Jupyter Server continues to run in background and prints output to terminal
  - Requires further investigation
  - Server can be killed manually by finding its PID with `ps u` and then doing `kill <PID>`.
  - This seems to fail freeing up the port though; Jupyter Server bug?