### PR TITLE
Fix check-release workflow

### DIFF
--- a/.jupyter-releaser.toml
+++ b/.jupyter-releaser.toml
@@ -9,6 +9,7 @@ before-build-python = [
 ]
 
 [options]
+version-cmd = "npx -p lerna -y lerna version --no-git-tag-version --no-push -y"
 python_packages = [
     "packages/jupyter-ai:jupyter-ai",
     "packages/jupyter-ai-dalle:jupyter-ai-dalle"


### PR DESCRIPTION
The `check-release` workflow was failing because `hatch-nodejs-plugin` doesn't bump intra-monorepo dependency versions in `package.json`. For example, running `hatch version 0.0.2` would not update the dependency declaration

```
"devDependencies": {
  ...,
  "@jupyter/ai": "^0.0.1"
}
```

in `packages/jupyter-ai-dalle/package.json`.

Thankfully, `lerna version` can handle such a case.