### PR TITLE
disable check-release for PRs

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -2,8 +2,8 @@ name: Check Release
 on:
   push:
     branches: ["*"]
-  pull_request:
-    branches: ["*"]
+  # pull_request:
+  #   branches: ["*"]
   release:
     types: [published]
   schedule:


### PR DESCRIPTION
The `check-release` workflow can take upwards of 20 minutes because it is doing a dry run of the entire release workflow. While this definitely makes sense for larger projects like JupyterLab, where it can be very difficult to debug CI failures from unknown PRs, it doesn't make sense for a project this size. Manual release via Jupyter Releaser stops broken releases from being published anyways, so intermittently failing CI on `main` poses no risk to users.

We can re-enable this in the future if necessary.