### PR TITLE
rename NPM packages to be under @jupyter-ai org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jupyter/ai-monorepo",
+  "name": "@jupyter-ai/monorepo",
   "version": "0.0.1",
   "private": true,
   "workspaces": [

--- a/packages/jupyter-ai-dalle/package.json
+++ b/packages/jupyter-ai-dalle/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jupyter/ai-dalle",
+  "name": "@jupyter-ai/dalle",
   "version": "0.0.1",
   "description": "A JupyterLab extension that adds a DALL-E model engine and image insertion modes.",
   "keywords": [
@@ -79,7 +79,7 @@
     "stylelint-prettier": "^2.0.0",
     "typescript": "~4.1.3",
     "ts-jest": "^26.0.0",
-    "@jupyter/ai": "^0.0.1"
+    "@jupyter-ai/core": "^0.0.1"
   },
   "sideEffects": [
     "style/*.css",

--- a/packages/jupyter-ai-dalle/pyproject.toml
+++ b/packages/jupyter-ai-dalle/pyproject.toml
@@ -50,8 +50,8 @@ artifacts = ["jupyter_ai_dalle/labextension"]
 exclude = [".github", "binder"]
 
 [tool.hatch.build.targets.wheel.shared-data]
-"jupyter_ai_dalle/labextension" = "share/jupyter/labextensions/@jupyter/ai-dalle"
-"install.json" = "share/jupyter/labextensions/@jupyter/ai-dalle/install.json"
+"jupyter_ai_dalle/labextension" = "share/jupyter/labextensions/@jupyter-ai/dalle"
+"install.json" = "share/jupyter/labextensions/@jupyter-ai/dalle/install.json"
 
 [tool.hatch.build.hooks.version]
 path = "jupyter_ai_dalle/_version.py"

--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jupyter/ai",
+  "name": "@jupyter-ai/core",
   "version": "0.0.1",
   "description": "A generative AI extension for JupyterLab",
   "keywords": [

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -55,8 +55,8 @@ artifacts = ["jupyter_ai/labextension"]
 exclude = [".github", "binder"]
 
 [tool.hatch.build.targets.wheel.shared-data]
-"jupyter_ai/labextension" = "share/jupyter/labextensions/@jupyter/ai"
-"install.json" = "share/jupyter/labextensions/@jupyter/ai/install.json"
+"jupyter_ai/labextension" = "share/jupyter/labextensions/@jupyter-ai/core"
+"install.json" = "share/jupyter/labextensions/@jupyter-ai/core/install.json"
 "jupyter-config/server-config" = "etc/jupyter/jupyter_server_config.d"
 "jupyter-config/nb-config" = "etc/jupyter/jupyter_notebook_config.d"
 


### PR DESCRIPTION
Renames NPM packages to be under the `@jupyter-ai/` org.

`@jupyter/ai` => `@jupyter-ai/core`
`@jupyter/ai-dalle` => `@jupyter-ai/dalle`