### PR TITLE
Add root package as Nx project

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "devDependencies": {
     "lerna": "^6.4.1",
     "@jupyterlab/builder": "^3.1.0"
+  },
+  "nx": {
+    "includedScripts": []
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "workspaces": [
+    ".",
     "packages/*"
   ],
   "scripts": {


### PR DESCRIPTION
`lerna version` [does not bump the version of the root package by default](https://github.com/lerna/lerna/issues/2879). It requires the root package to be listed as an Nx project by declaring it as a workspace in `package.json`.