### PR TITLE
bump all project versions in bump-version

### DIFF
--- a/.jupyter-releaser.toml
+++ b/.jupyter-releaser.toml
@@ -9,7 +9,7 @@ before-build-python = [
 ]
 
 [options]
-version-cmd = "npx -p lerna -y lerna version --no-git-tag-version --no-push -y"
+version-cmd = "../../scripts/bump-version.sh"
 python_packages = [
     "packages/jupyter-ai:jupyter-ai",
     "packages/jupyter-ai-dalle:jupyter-ai-dalle"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,16 @@
+# script that bumps version for all projects regardless of whether they were
+# changed since last release. needed because `lerna version` only bumps versions for projects
+# listed by `lerna changed` by default.
+#
+# see: https://github.com/lerna/lerna/issues/2369
+
+for package in ../*; do
+    touch $package/TEMP
+    git add $package/TEMP
+done
+
+(npx -p lerna -y lerna version --no-git-tag-version --no-push -y $1) || exit 1
+
+for package in ../*; do
+    git rm -f $package/TEMP
+done


### PR DESCRIPTION
By default, `lerna version` [doesn't bump the version of projects that weren't changed since the last git-tagged release commit](https://github.com/lerna/lerna/issues/2369).

This PR adds a shell script that creates and stages a temporary file in each workspace, bumps the version, and then deletes the temporary file. This ensures all project versions are bumped in lock-step.

The only side-effect, besides the obvious performance degradation, is that `jupyter releaser bump-version` now bumps a few extra patch versions, because this command is run once per Python package listed under `tool.jupyter-releaser.options.python_packages`. See below:

```
% jupyter releaser bump-version
jupyter-releaser configuration loaded from .jupyter-releaser.toml.


--------------------------------------------------


bump-version




--------------------------------------------------
Using default value for version_spec: ''
Adding option override for --version-cmd: '../../scripts/bump-version.sh
Using default value for changelog_path: 'CHANGELOG.md'
Adding option override for --python-packages: '['packages/jupyter-ai:jupyter-ai', 'packages/jupyter-ai-dalle:jupyter-ai-dalle']
Using default value for help: 'False'
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


COMMAND: ../../scripts/bump-version.sh patch
lerna notice cli v6.5.1
lerna info current version 0.1.0
lerna notice FYI git repository validation has been skipped, please ensure your version bumps are correct
lerna info Looking for changed packages since v0.1.0
lerna info version rooted leaf detected, skipping synthetic root lifecycles
lerna WARN version Skipping working tree validation, proceed at your own risk

Changes:
 - @jupyter-ai/monorepo: 0.1.0 => 0.1.1 (private)
 - @jupyter-ai/dalle: 0.1.0 => 0.1.1
 - @jupyter-ai/core: 0.1.0 => 0.1.1

lerna info auto-confirmed
lerna info execute Skipping git tag/commit
lerna info execute Skipping git push
lerna info execute Skipping releases
lerna success version finished
rm 'packages/jupyter-ai/TEMP'
rm 'packages/jupyter-ai-dalle/TEMP'
0.1.1
0.1.1
COMMAND: ../../scripts/bump-version.sh patch
lerna notice cli v6.5.1
lerna info current version 0.1.1
lerna notice FYI git repository validation has been skipped, please ensure your version bumps are correct
lerna info Looking for changed packages since v0.1.0
lerna info version rooted leaf detected, skipping synthetic root lifecycles
lerna WARN version Skipping working tree validation, proceed at your own risk

Changes:
 - @jupyter-ai/monorepo: 0.1.1 => 0.1.2 (private)
 - @jupyter-ai/dalle: 0.1.1 => 0.1.2
 - @jupyter-ai/core: 0.1.1 => 0.1.2

lerna info auto-confirmed
lerna info execute Skipping git tag/commit
lerna info execute Skipping git push
lerna info execute Skipping releases
lerna success version finished
rm 'packages/jupyter-ai/TEMP'
rm 'packages/jupyter-ai-dalle/TEMP'
0.1.2
0.1.2
```

However, bumping the version with an explicit version specified by `--version-spec` still behaves as expected 😁 