### PR TITLE
Decouple tasks from model engines and introduce modalities

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -2,8 +2,8 @@ name: Check Release
 on:
   push:
     branches: ["*"]
-  # pull_request:
-  #   branches: ["*"]
+  pull_request:
+    branches: ["*"]
   release:
     types: [published]
   schedule:

--- a/packages/jupyter-ai-chatgpt/jupyter_ai_chatgpt/__init__.py
+++ b/packages/jupyter-ai-chatgpt/jupyter_ai_chatgpt/__init__.py
@@ -1,9 +1,8 @@
 from ._version import __version__
 
-# expose ChatGptModelEngine on the root module so that it may be declared as an
-# entrypoint in `pyproject.toml`
+# expose engines and tasks on the module root so that they may be declared as
+# entrypoints in `pyproject.toml`
 from .engine import ChatGptModelEngine
-
 
 def _jupyter_labextension_paths():
     return [{

--- a/packages/jupyter-ai-chatgpt/jupyter_ai_chatgpt/engine.py
+++ b/packages/jupyter-ai-chatgpt/jupyter_ai_chatgpt/engine.py
@@ -1,56 +1,23 @@
 import openai
 from traitlets.config import Unicode
 
-from typing import List, Dict
+from typing import Dict
 
-from jupyter_ai.engine import BaseModelEngine, DefaultTaskDefinition
+from jupyter_ai.engine import BaseModelEngine
 from jupyter_ai.models import DescribeTaskResponse
 
 class ChatGptModelEngine(BaseModelEngine):
-    name = "chatgpt"
-    input_type = "txt"
-    output_type = "txt"
+    id = "chatgpt"
+    name = "ChatGPT"
+    modalities = [
+        "txt2txt"
+    ]
 
     api_key = Unicode(
         config=True,
         help="OpenAI API key",
         allow_none=False
     )
-
-    def list_default_tasks(self) -> List[DefaultTaskDefinition]:
-        # Tasks your model engine provides by default.
-        return [
-            {
-                "id": "explain-code",
-                "name": "Explain code",
-                "prompt_template": "Explain the following Python 3 code. The first sentence must begin with the phrase \"The code below\".\n{body}",
-                "insertion_mode": "above"
-            },
-            {
-                "id": "generate-code",
-                "name": "Generate code",
-                "prompt_template": "Generate Python 3 code in Markdown according to the following definition.\n{body}",
-                "insertion_mode": "below"
-            },
-            {
-                "id": "explain-code-in-cells-above",
-                "name": "Explain code in cells above",
-                "prompt_template": "Explain the following Python 3 code. The first sentence must begin with the phrase \"The code below\".\n{body}",
-                "insertion_mode": "above-in-cells"
-            },
-            {
-                "id": "generate-code-in-cells-below",
-                "name": "Generate code in cells below",
-                "prompt_template": "Generate Python 3 code in Markdown according to the following definition.\n{body}",
-                "insertion_mode": "below-in-cells"
-            },
-            {
-                "id": "freeform",
-                "name": "Freeform prompt",
-                "prompt_template": "{body}",
-                "insertion_mode": "below"
-            }
-        ]
 
     async def execute(self, task: DescribeTaskResponse, prompt_variables: Dict[str, str]):
         if "body" not in prompt_variables:

--- a/packages/jupyter-ai-chatgpt/pyproject.toml
+++ b/packages/jupyter-ai-chatgpt/pyproject.toml
@@ -36,8 +36,8 @@ test = [
     "pytest-cov"
 ]
 
-[project.entry-points."jupyter_ai.model_engine_class"]
-test = "jupyter_ai_chatgpt:ChatGptModelEngine"
+[project.entry-points."jupyter_ai.model_engine_classes"]
+ChatGptModelEngine = "jupyter_ai_chatgpt:ChatGptModelEngine"
 
 [tool.hatch.version]
 source = "nodejs"

--- a/packages/jupyter-ai-dalle/jupyter_ai_dalle/__init__.py
+++ b/packages/jupyter-ai-dalle/jupyter_ai_dalle/__init__.py
@@ -1,12 +1,12 @@
 from ._version import __version__
 
-# expose DalleModelEngine on the root module so that it may be declared as an
-# entrypoint in `pyproject.toml`
+# expose engines and tasks on the module root so that they may be declared as
+# entrypoints in `pyproject.toml`
 from .engine import DalleModelEngine
-
+from .tasks import tasks
 
 def _jupyter_labextension_paths():
     return [{
         "src": "labextension",
-        "dest": "jupyter_ai_dalle"
+        "dest": "@jupyter-ai/dalle"
     }]

--- a/packages/jupyter-ai-dalle/jupyter_ai_dalle/engine.py
+++ b/packages/jupyter-ai-dalle/jupyter_ai_dalle/engine.py
@@ -1,42 +1,22 @@
-from typing import List, Dict
+from typing import Dict
 from traitlets.config import Unicode
 import openai
 
-from jupyter_ai.engine import BaseModelEngine, DefaultTaskDefinition
+from jupyter_ai.engine import BaseModelEngine
 from jupyter_ai.models import DescribeTaskResponse
 
 class DalleModelEngine(BaseModelEngine):
-    name = "dalle"
-    input_type = "txt"
-    output_type = "img"
+    id = "dalle"
+    name = "DALL-E"
+    modalities = [
+        "txt2img"
+    ]
 
     api_key = Unicode(
         config=True,
         help="OpenAI API key",
         allow_none=False
     )
-
-    def list_default_tasks(self) -> List[DefaultTaskDefinition]:
-        return [
-            {
-                "id": "generate-image",
-                "name": "Generate image below",
-                "prompt_template": "{body}",
-                "insertion_mode": "below-in-image"
-            },
-            {
-                "id": "generate-photorealistic-image",
-                "name": "Generate photorealistic image below",
-                "prompt_template": "{body} in a photorealistic style",
-                "insertion_mode": "below-in-image"
-            },
-            {
-                "id": "generate-cartoon-image",
-                "name": "Generate cartoon image below",
-                "prompt_template": "{body} in the style of a cartoon",
-                "insertion_mode": "below-in-image"
-            }
-        ]
 
     async def execute(self, task: DescribeTaskResponse, prompt_variables: Dict[str, str]) -> str:
         if "body" not in prompt_variables:

--- a/packages/jupyter-ai-dalle/pyproject.toml
+++ b/packages/jupyter-ai-dalle/pyproject.toml
@@ -38,8 +38,11 @@ test = [
     "pytest-cov"
 ]
 
-[project.entry-points."jupyter_ai.model_engine_class"]
-test = "jupyter_ai_dalle:DalleModelEngine"
+[project.entry-points."jupyter_ai.model_engine_classes"]
+DalleModelEngine = "jupyter_ai_dalle:DalleModelEngine"
+
+[project.entry-points."jupyter_ai.default_tasks"]
+dalle_default_tasks = "jupyter_ai_dalle:tasks"
 
 [tool.hatch.version]
 source = "nodejs"

--- a/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.labextension_name}}/pyproject.toml
+++ b/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.labextension_name}}/pyproject.toml
@@ -37,8 +37,11 @@ dependencies = [
     "jupyter_ai"
 ]
 
-[project.entry-points."jupyter_ai.model_engine_class"]
-test = "{{ cookiecutter.python_name }}:TestModelEngine"
+[project.entry-points."jupyter_ai.model_engine_classes"]
+TestModelEngine = "{{ cookiecutter.python_name }}:TestModelEngine"
+
+[project.entry-points."jupyter_ai.default_tasks"]
+TestDefaultTasks = "{{ cookiecutter.python_name }}:tasks"
 
 [tool.hatch.version]
 source = "nodejs"

--- a/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.labextension_name}}/{{cookiecutter.python_name}}/__init__.py
+++ b/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.labextension_name}}/{{cookiecutter.python_name}}/__init__.py
@@ -1,8 +1,9 @@
 from ._version import __version__
 
-# expose TestModelEngine on the root module so that it may be declared as an
-# entrypoint in `pyproject.toml`
+# expose engines and tasks on the module root so that they may be declared as
+# entrypoints in `pyproject.toml`
 from .engine import TestModelEngine
+from .tasks import tasks
 
 
 def _jupyter_labextension_paths():

--- a/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.labextension_name}}/{{cookiecutter.python_name}}/engine.py
+++ b/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.labextension_name}}/{{cookiecutter.python_name}}/engine.py
@@ -1,6 +1,6 @@
-from typing import List, Dict
+from typing import Dict
 
-from jupyter_ai.engine import BaseModelEngine, DefaultTaskDefinition
+from jupyter_ai.engine import BaseModelEngine
 from jupyter_ai.models import DescribeTaskResponse
 
 class TestModelEngine(BaseModelEngine):
@@ -17,17 +17,6 @@ class TestModelEngine(BaseModelEngine):
     #     allow_none=False
     # )
     #
-
-    def list_default_tasks(self) -> List[DefaultTaskDefinition]:
-        # Tasks your model engine provides by default.
-        return [
-            {
-                "id": "test",
-                "name": "Test task",
-                "prompt_template": "{body}",
-                "insertion_mode": "test"
-            }
-        ]
 
     async def execute(self, task: DescribeTaskResponse, prompt_variables: Dict[str, str]):
         # Core method that executes a model when provided with a task

--- a/packages/jupyter-ai/jupyter_ai/__init__.py
+++ b/packages/jupyter-ai/jupyter_ai/__init__.py
@@ -1,11 +1,17 @@
 from ._version import __version__
 from .extension import AiExtension
+
+# imports to expose entry points. DO NOT REMOVE.
 from .engine import GPT3ModelEngine
+from .tasks import tasks
+
+# imports to expose types to other AI modules. DO NOT REMOVE.
+from .tasks import DefaultTaskDefinition
 
 def _jupyter_labextension_paths():
     return [{
         "src": "labextension",
-        "dest": "jupyter_ai"
+        "dest": "@jupyter-ai/core"
     }]
 
 def _jupyter_server_extension_points():

--- a/packages/jupyter-ai/jupyter_ai/engine.py
+++ b/packages/jupyter-ai/jupyter_ai/engine.py
@@ -1,35 +1,30 @@
 from abc import abstractmethod, ABC, ABCMeta
-from typing import Dict, TypedDict, Literal, List
+from typing import Dict
 import openai
 from traitlets.config import LoggingConfigurable, Unicode
 from .task_manager import DescribeTaskResponse
-
-class DefaultTaskDefinition(TypedDict):
-    id: str
-    name: str
-    prompt_template: str
-    insertion_mode: str
 
 class BaseModelEngineMetaclass(ABCMeta, type(LoggingConfigurable)):
     pass
 
 class BaseModelEngine(ABC, LoggingConfigurable, metaclass=BaseModelEngineMetaclass):
+    id: str
     name: str
+
+    # these two attributes are currently reserved but unused.
     input_type: str
     output_type: str
   
-    @abstractmethod
-    def list_default_tasks(self) -> List[DefaultTaskDefinition]:
-        pass
-
     @abstractmethod
     async def execute(self, task: DescribeTaskResponse, prompt_variables: Dict[str, str]):
         pass
 
 class GPT3ModelEngine(BaseModelEngine):
-    name = "gpt3"
-    input_type = "txt"
-    output_type = "txt"
+    id = "gpt3"
+    name = "GPT-3"
+    modalities = [
+        "txt2txt"
+    ]
 
     api_key = Unicode(
         config=True,
@@ -39,9 +34,6 @@ class GPT3ModelEngine(BaseModelEngine):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-    def list_default_tasks(self) -> List[DefaultTaskDefinition]:
-        return []
 
     async def execute(self, task: DescribeTaskResponse, prompt_variables: Dict[str, str]):
         if "body" not in prompt_variables:

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -20,11 +20,14 @@ class AiExtension(ExtensionApp):
         return self.settings["ai_engines"]
 
     def initialize_settings(self):
+        # EP := entry point
         eps = entry_points()
-        model_engine_class_eps = eps.select(group="jupyter_ai.model_engine_class")
+        
+        ## step 1: instantiate model engines and bind them to settings
+        model_engine_class_eps = eps.select(group="jupyter_ai.model_engine_classes")
         
         if not model_engine_class_eps:
-            self.log.error("No model engines found for jupyter_ai.model_engine_class group. One or more model engines are required for AI extension to work.")
+            self.log.error("No model engines found for jupyter_ai.model_engine_classes group. One or more model engines are required for AI extension to work.")
             return
 
         for model_engine_class_ep in model_engine_class_eps:
@@ -39,11 +42,32 @@ class AiExtension(ExtensionApp):
                 continue
 
             try:
-                self.ai_engines[Engine.name] = Engine(config=self.config, log=self.log)
+                self.ai_engines[Engine.id] = Engine(config=self.config, log=self.log)
             except:
                 self.log.error(f"Unable to instantiate model engine class from entry point `{model_engine_class_ep.name}`.")
                 continue
 
-            self.log.info(f"Registered engine `{Engine.name}`.")
+            self.log.info(f"Registered engine `{Engine.id}`.")
+
+        ## step 2: load default tasks and bind them to settings
+        module_default_tasks_eps = eps.select(group="jupyter_ai.default_tasks")
+
+        if not module_default_tasks_eps:
+            self.settings["ai_default_tasks"] = []
+            return
+        
+        default_tasks = []
+        for module_default_tasks_ep in module_default_tasks_eps:
+            try:
+                module_default_tasks = module_default_tasks_ep.load()
+            except:
+                self.log.error(f"Unable to load task from entry point `{module_default_tasks_ep.name}`")
+                continue
+            
+            default_tasks += module_default_tasks
+
+        self.settings["ai_default_tasks"] = default_tasks
+        self.log.info("Registered all default tasks.")
 
         self.log.info(f"Registered {self.name} server extension")
+    

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -3,18 +3,22 @@ from typing import Dict, List
 
 class PromptRequest(BaseModel):
     task_id: str
+    engine_id: str
     prompt_variables: Dict[str, str]
+
+class ListEnginesEntry(BaseModel):
+    id: str
+    name: str
 
 class ListTasksEntry(BaseModel):
     id: str
     name: str
-    engine: str
 
 class ListTasksResponse(BaseModel):
     tasks: List[ListTasksEntry]
 
 class DescribeTaskResponse(BaseModel):
     name: str
-    engine: str
     insertion_mode: str
     prompt_template: str
+    engines: List[ListEnginesEntry]

--- a/packages/jupyter-ai/jupyter_ai/task_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/task_manager.py
@@ -1,16 +1,17 @@
 import asyncio
 import aiosqlite
 import os
-from typing import Optional
+from typing import Optional, List
 
 from jupyter_core.paths import jupyter_data_dir
-from .models import ListTasksResponse, ListTasksEntry, DescribeTaskResponse
+from .models import ListTasksResponse, ListTasksEntry, DescribeTaskResponse, ListEnginesEntry
 
 class TaskManager:
     db_path = os.path.join(jupyter_data_dir(), "ai_task_manager.db")
 
-    def __init__(self, ai_engines):
-        self.ai_engines = ai_engines
+    def __init__(self, engines, default_tasks):
+        self.engines = engines
+        self.default_tasks = default_tasks
         self.db_initialized = asyncio.create_task(self.init_db())
  
     async def init_db(self):
@@ -19,24 +20,21 @@ class TaskManager:
                 "CREATE TABLE IF NOT EXISTS tasks ("
                 "id TEXT NOT NULL PRIMARY KEY, "
                 "name TEXT NOT NULL, "
-                "engine TEXT NOT NULL, "
                 "prompt_template TEXT NOT NULL, "
+                "modality TEXT NOT NULL, "
                 "insertion_mode TEXT NOT NULL, "
                 "is_default INTEGER NOT NULL"
                 ")"
             )
 
             # delete and recreate all default tasks. this ensures the default
-            # tasks exposed by model engines are all up-to-date.
+            # tasks are all up-to-date.
             await con.execute("DELETE FROM tasks WHERE is_default = 1")
-            for engine_name in self.ai_engines:
-                engine = self.ai_engines[engine_name]
-                for task in engine.list_default_tasks():
-                    id = engine.name + ":" + task["id"]
-                    await con.execute(
-                        "INSERT INTO tasks (id, name, engine, prompt_template, insertion_mode, is_default) VALUES (?, ?, ?, ?, ?, ?)",
-                        (id, task["name"], engine.name, task["prompt_template"], task["insertion_mode"], 1)
-                    )
+            for task in self.default_tasks:
+                await con.execute(
+                    "INSERT INTO tasks (id, name, prompt_template, modality, insertion_mode, is_default) VALUES (?, ?, ?, ?, ?, ?)",
+                    (task["id"], task["name"], task["prompt_template"], task["modality"], task["insertion_mode"], 1)
+                )
             
             await con.commit()
     
@@ -44,7 +42,7 @@ class TaskManager:
         await self.db_initialized
         async with aiosqlite.connect(self.db_path) as con:
             cursor = await con.execute(
-                "SELECT id, name, engine FROM tasks"
+                "SELECT id, name FROM tasks"
             )
             rows = await cursor.fetchall()
             tasks = []
@@ -55,8 +53,7 @@ class TaskManager:
             for row in rows:
                 tasks.append(ListTasksEntry(
                     id=row[0],
-                    name=row[1],
-                    engine=row[2]
+                    name=row[1]
                 ))
             
             return ListTasksResponse(tasks=tasks)
@@ -65,17 +62,28 @@ class TaskManager:
         await self.db_initialized
         async with aiosqlite.connect(self.db_path) as con:
             cursor = await con.execute(
-                "SELECT name, engine, prompt_template, insertion_mode FROM tasks WHERE id = ?", (id,)
+                "SELECT name, prompt_template, modality, insertion_mode FROM tasks WHERE id = ?", (id,)
             )
             row = await cursor.fetchone()
 
             if row is None:
                 return None
+
+            # determine what engines are available for the task's modality
+            engines: List[ListEnginesEntry] = []
+            modality = row[2]
+            for engine in self.engines.values():
+                if modality in engine.modalities:
+                    engines.append(ListEnginesEntry(id=engine.id, name=engine.name))
+            
+            # sort engines A-Z
+            engines = sorted(engines, key=lambda engine: engine.name)
             
             return DescribeTaskResponse(
                 name=row[0],
-                engine=row[1],
-                prompt_template=row[2],
-                insertion_mode=row[3]
+                prompt_template=row[1],
+                modality=row[2],
+                insertion_mode=row[3],
+                engines=engines
             )
     

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -32,8 +32,11 @@ dependencies = [
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
-[project.entry-points."jupyter_ai.model_engine_class"]
+[project.entry-points."jupyter_ai.model_engine_classes"]
 gpt3 = "jupyter_ai:GPT3ModelEngine"
+
+[project.entry-points."jupyter_ai.default_tasks"]
+core_default_tasks = "jupyter_ai:tasks"
 
 [project.optional-dependencies]
 test = [

--- a/packages/jupyter-ai/src/commands.ts
+++ b/packages/jupyter-ai/src/commands.ts
@@ -172,6 +172,7 @@ export function buildNotebookShortcutCommand(
     // make request, then delete placeholder cell
     const request: AiService.IPromptRequest = {
       task_id,
+      engine_id: 'chatgpt',
       prompt_variables: {
         body: cellContents
       }
@@ -237,8 +238,8 @@ export function buildDefaultInserter(mode: 'above' | 'below' | 'replace') {
 }
 
 /**
- * Utility function that builds command that inserts 
- * prompt output above or below in new notebook cells. 
+ * Utility function that builds command that inserts
+ * prompt output above or below in new notebook cells.
  * Requires the current cell to be the active cell.
  */
 export function buildNotebookInserter(

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -53,6 +53,7 @@ export namespace AiService {
 
   export interface IPromptRequest {
     task_id: string;
+    engine_id: string;
     prompt_variables: {
       body: string;
       [key: string]: string;
@@ -83,7 +84,6 @@ export namespace AiService {
   export type ListTasksEntry = {
     id: string;
     name: string;
-    engine: string;
   };
 
   export type ListTasksResponse = {
@@ -94,11 +94,16 @@ export namespace AiService {
     return requestAPI<ListTasksResponse>('tasks');
   }
 
+  export type ListEnginesEntry = {
+    id: string;
+    name: string;
+  };
+
   export type DescribeTaskResponse = {
     name: string;
-    engine: string;
     insertion_mode: string;
     prompt_template: string;
+    engines: ListEnginesEntry[];
   };
 
   export async function describeTask(

--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -17,8 +17,8 @@ import { psychologyIcon } from './icons';
 import { getTextSelection } from './utils';
 
 export enum NotebookTasks {
-  GenerateCode = 'chatgpt:generate-code-in-cells-below',
-  ExplainCode = 'chatgpt:explain-code-in-cells-above'
+  GenerateCode = 'generate-code-in-cells-below',
+  ExplainCode = 'explain-code-in-cells-above'
 }
 
 export namespace CommandIDs {

--- a/playground/config.example.py
+++ b/playground/config.example.py
@@ -6,4 +6,4 @@
 
 # Specify full path to the notebook dir if running jupyter lab from
 # outside of the jupyter-ai project root directory 
-c["notebook-dir"] = "./playground"
+c.ServerApp.root_dir = "./playground"


### PR DESCRIPTION
# Demo

https://user-images.githubusercontent.com/44106031/224867632-12301cf9-3e94-4208-8dbd-39ec64870493.mov

# Description

- Decouples tasks from model engines by introducing the concept of **modalities**. Defined loosely, they can be thought of as representing the input and output types for a model.
  - This is motivated by the fact that tasks are frequently shared between model engines of a common modality (e.g. txt2txt: GPT-3/ChatGPT, txt2img: DALL-E/Stable Diffusion). It is redundant to have each model engine of a common modality to re-define the default tasks they offer.
  - Each modality is associated with a string representation known as a **modality ID**.
  - Right now, there are only two modality IDs under Jupyter AI:
    1. `txt2txt`: accepts an English text prompt and generates English text that roughly corresponds to the prompt
    2. `txt2img`: accepts an English text prompt and generates an image that roughly corresponds to the prompt

- Model engines now must declare what modalities they support as a class attribute. This is simply a list of modality IDs, for example:

```
class ChatGptModelEngine(BaseModelEngine):
    id = "chatgpt"
    name = "ChatGPT"
    modalities = [
        "txt2txt"
    ]
```

- Model engines may support multiple modalities, but most models available today only can handle one.
- A modality is defined strictly as a pair of two sets: a set of input types and a set of output types.
  - For example, a model that generates both an image and a text caption would have to declare a unique modality, such as `text-to-captioned-image`. This is because this model has two output types, and its modality is not described by `txt2txt` or `txt2img`.
  - For example, an extremely fine-tuned language model that can only answer questions in Chinese would also have to declare a unique modality, as its set of input types consists exclusively of Chinese text, not English text. 
- Tasks must declare one and only one modality.
- Tasks are now declared as entrypoints under `jupyter_ai.default_tasks`.
- The `DescribeTask` API response now includes a list of valid model engines that support the modality of a given task. Very useful 😁 
- The Dialog UI now includes a dropdown to select a model engine for a given task. The only model engines listed are ones that support a task's modality.
- Model engines now declare their ID in a separate attribute `id`. `name` is now reserved for a model engine's human readable name, e.g. "ChatGPT".

## Notes

You need to delete the SQLite DB at `~/.local/share/jupyter/ai_task_manager.db`.

# Other fixes

- Fixes dev setup
- Re-enables check-release workflow for PRs (I know I backtracked on this, but since we don't have any other workflows, this one will have to do for now)