### PR TITLE
Implement chat UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "setup:dev": "lerna run setup:dev --stream",
     "build": "lerna run build --stream",
+    "build:core": "lerna run build --stream --scope \"@jupyter-ai/core\"",
     "build:prod": "lerna run build:prod --stream",
     "clean": "lerna run clean",
     "clean:all": "lerna run clean:all",

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -5,7 +5,7 @@ from .handlers import ChatHandler, ChatHistoryHandler, PromptAPIHandler, TaskAPI
 from importlib_metadata import entry_points
 import inspect
 from .engine import BaseModelEngine
-from .providers import ChatOpenAIProvider
+from .providers import ChatOpenAIProvider, ChatOpenAINewProvider
 import os
 
 from langchain.memory import ConversationBufferMemory
@@ -85,9 +85,12 @@ class AiExtension(ExtensionApp):
         self.settings["ai_default_tasks"] = default_tasks
         self.log.info("Registered all default tasks.")
 
-        ## load OpenAI chat provider
-        if ChatOpenAIProvider.auth_strategy.name in os.environ:
-            self.settings["openai_chat"] = ChatOpenAIProvider(model_id="gpt-3.5-turbo")
+        ## load OpenAI provider
+        self.settings["openai_chat"] = ChatOpenAIProvider(model_id="gpt-3.5-turbo")
+
+        ## load OpenAI new provider
+        if ChatOpenAINewProvider.auth_strategy.name in os.environ:
+            provider = ChatOpenAINewProvider(model_id="gpt-3.5-turbo")
             # Create a conversation memory
             memory = ConversationBufferMemory(return_messages=True)
             prompt_template = ChatPromptTemplate.from_messages([
@@ -96,7 +99,7 @@ class AiExtension(ExtensionApp):
                 HumanMessagePromptTemplate.from_template("{input}")
             ])
             chain = ConversationChain(
-                llm=self.settings["openai_chat"], 
+                llm=provider, 
                 prompt=prompt_template,
                 verbose=True, 
                 memory=memory

--- a/packages/jupyter-ai/jupyter_ai/providers.py
+++ b/packages/jupyter-ai/jupyter_ai/providers.py
@@ -7,6 +7,7 @@ from langchain.llms import (
     Cohere,
     HuggingFaceHub,
     OpenAI,
+    OpenAIChat,
     SagemakerEndpoint
 )
 
@@ -155,7 +156,7 @@ class OpenAIProvider(BaseProvider, OpenAI):
     pypi_package_deps = ["openai"]
     auth_strategy = EnvAuthStrategy(name="OPENAI_API_KEY")
 
-class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
+class ChatOpenAIProvider(BaseProvider, OpenAIChat):
     id = "openai-chat"
     name = "OpenAI"
     models = [
@@ -181,6 +182,23 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
             "role": "assistant",
             "content": output
         })
+
+# uses the new OpenAIChat provider. temporarily living as a separate class until
+# conflicts can be resolved
+class ChatOpenAINewProvider(BaseProvider, ChatOpenAI):
+    id = "openai-chat-new"
+    name = "OpenAI"
+    models = [
+        "gpt-4",
+        "gpt-4-0314",
+        "gpt-4-32k",
+        "gpt-4-32k-0314",
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-0301",
+    ]
+    model_id_key = "model_name"
+    pypi_package_deps = ["openai"]
+    auth_strategy = EnvAuthStrategy(name="OPENAI_API_KEY")
 
 class SmEndpointProvider(BaseProvider, SagemakerEndpoint):
     id = "sagemaker-endpoint"

--- a/packages/jupyter-ai/jupyter_ai/providers.py
+++ b/packages/jupyter-ai/jupyter_ai/providers.py
@@ -170,9 +170,6 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
     pypi_package_deps = ["openai"]
     auth_strategy = EnvAuthStrategy(name="OPENAI_API_KEY")
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def append_exchange(self, prompt: str, output: str):
         """Appends a conversational exchange between user and an OpenAI Chat
         model to a transcript that will be included in future exchanges."""

--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -71,7 +71,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.6",
-    "react-syntax-highlighter": "^15.5.0"
+    "react-syntax-highlighter": "^15.5.0",
+    "rehype-katex": "^6.0.2",
+    "remark-math": "^5.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -70,7 +70,8 @@
     "@mui/material": "^5.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-markdown": "^8.0.6"
+    "react-markdown": "^8.0.6",
+    "react-syntax-highlighter": "^15.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -78,6 +79,7 @@
     "@jupyterlab/builder": "^3.5.1",
     "@jupyterlab/testutils": "^3.0.0",
     "@types/jest": "^26.0.0",
+    "@types/react-syntax-highlighter": "^15.5.6",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
     "eslint": "^7.14.0",

--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -69,7 +69,8 @@
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-markdown": "^8.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/jupyter-ai/schema/plugin.json
+++ b/packages/jupyter-ai/schema/plugin.json
@@ -2,6 +2,8 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Generative AI",
   "description": "JupyterLab generative artificial intelligence integration.",
+  "jupyter.lab.setting-icon": "jupyter-ai::psychology",
+  "jupyter.lab.setting-icon-label": "Jupyter AI Chat",
   "jupyter.lab.toolbars": {
     "Cell": [
       {

--- a/packages/jupyter-ai/src/components/chat-code-view.tsx
+++ b/packages/jupyter-ai/src/components/chat-code-view.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useMemo } from 'react';
+
+import type { CodeProps } from 'react-markdown/lib/ast-to-react';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { duotoneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { Box, Button } from '@mui/material';
+
+type ChatCodeViewProps = CodeProps;
+
+type ChatCodeInlineProps = ChatCodeViewProps;
+
+type ChatCodeBlockProps = ChatCodeViewProps & {
+  language?: string;
+};
+
+function ChatCodeInline({
+  className,
+  children,
+  ...props
+}: ChatCodeInlineProps) {
+  return (
+    <code {...props} className={className}>
+      {children}
+    </code>
+  );
+}
+
+enum CopyStatus {
+  None,
+  Copying,
+  Copied
+}
+
+const COPYBTN_TEXT_BY_STATUS: Record<CopyStatus, string> = {
+  [CopyStatus.None]: 'Copy to clipboard',
+  [CopyStatus.Copying]: 'Copying...',
+  [CopyStatus.Copied]: 'Copied!'
+};
+
+function ChatCodeBlock({ language, children, ...props }: ChatCodeBlockProps) {
+  const value = useMemo(() => String(children).replace(/\n$/, ''), [children]);
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>(CopyStatus.None);
+
+  const copy = async () => {
+    setCopyStatus(CopyStatus.Copying);
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch (e) {
+      console.error(e);
+      setCopyStatus(CopyStatus.None);
+      return;
+    }
+
+    setCopyStatus(CopyStatus.Copied);
+    setTimeout(() => setCopyStatus(CopyStatus.None), 1000);
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      <SyntaxHighlighter
+        {...props}
+        children={value}
+        style={duotoneLight}
+        language={language}
+        PreTag="div"
+      />
+      <Button
+        onClick={copy}
+        disabled={copyStatus !== CopyStatus.None}
+        sx={{ alignSelf: 'flex-end' }}
+      >
+        {COPYBTN_TEXT_BY_STATUS[copyStatus]}
+      </Button>
+    </Box>
+  );
+}
+
+export function ChatCodeView({
+  inline,
+  className,
+  ...props
+}: ChatCodeViewProps) {
+  const match = /language-(\w+)/.exec(className || '');
+  return inline ? (
+    <ChatCodeInline {...props} />
+  ) : (
+    <ChatCodeBlock {...props} language={match ? match[1] : undefined} />
+  );
+}

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -4,6 +4,7 @@ import { Box, IconButton, Input } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 
 type ChatInputProps = {
+  loading: boolean;
   value: string;
   onChange: (newValue: string) => unknown;
   onSend: () => unknown;
@@ -18,7 +19,12 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
         multiline
         sx={{ flexGrow: 1 }}
       />
-      <IconButton size="large" color="primary" onClick={props.onSend}>
+      <IconButton
+        size="large"
+        color="primary"
+        onClick={props.onSend}
+        disabled={props.loading || !props.value.trim().length}
+      >
         <SendIcon />
       </IconButton>
     </Box>

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, IconButton, Input } from '@mui/material';
+import { Box, IconButton, Input, SxProps, Theme } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 
 type ChatInputProps = {
@@ -8,11 +8,12 @@ type ChatInputProps = {
   value: string;
   onChange: (newValue: string) => unknown;
   onSend: () => unknown;
+  sx?: SxProps<Theme>;
 };
 
 export function ChatInput(props: ChatInputProps): JSX.Element {
   return (
-    <Box sx={{ display: 'flex' }}>
+    <Box sx={{ display: 'flex', ...props.sx }}>
       <Input
         value={props.value}
         onChange={e => props.onChange(e.target.value)}

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 
-import { Box, IconButton, Input, SxProps, Theme } from '@mui/material';
+import {
+  Box,
+  IconButton,
+  Input,
+  SxProps,
+  Theme,
+  FormGroup,
+  FormControlLabel,
+  Checkbox
+} from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 
 type ChatInputProps = {
@@ -8,26 +17,55 @@ type ChatInputProps = {
   value: string;
   onChange: (newValue: string) => unknown;
   onSend: () => unknown;
+  hasSelection: boolean;
+  includeSelection: boolean;
+  toggleIncludeSelection: () => unknown;
+  replaceSelection: boolean;
+  toggleReplaceSelection: () => unknown;
   sx?: SxProps<Theme>;
 };
 
 export function ChatInput(props: ChatInputProps): JSX.Element {
   return (
-    <Box sx={{ display: 'flex', ...props.sx }}>
-      <Input
-        value={props.value}
-        onChange={e => props.onChange(e.target.value)}
-        multiline
-        sx={{ flexGrow: 1 }}
-      />
-      <IconButton
-        size="large"
-        color="primary"
-        onClick={props.onSend}
-        disabled={props.loading || !props.value.trim().length}
-      >
-        <SendIcon />
-      </IconButton>
+    <Box sx={props.sx}>
+      <Box sx={{ display: 'flex' }}>
+        <Input
+          value={props.value}
+          onChange={e => props.onChange(e.target.value)}
+          multiline
+          sx={{ flexGrow: 1 }}
+        />
+        <IconButton
+          size="large"
+          color="primary"
+          onClick={props.onSend}
+          disabled={props.loading || !props.value.trim().length}
+        >
+          <SendIcon />
+        </IconButton>
+      </Box>
+      {props.hasSelection && (
+        <FormGroup sx={{ display: 'flex', flexDirection: 'row' }}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={props.includeSelection}
+                onChange={props.toggleIncludeSelection}
+              />
+            }
+            label="Include selection"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={props.replaceSelection}
+                onChange={props.toggleReplaceSelection}
+              />
+            }
+            label="Replace selection"
+          />
+        </FormGroup>
+      )}
     </Box>
   );
 }

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { Box, IconButton, Input } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+
+type ChatInputProps = {
+  value: string;
+  onChange: (newValue: string) => unknown;
+  onSend: () => unknown;
+};
+
+export function ChatInput(props: ChatInputProps): JSX.Element {
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <Input
+        value={props.value}
+        onChange={e => props.onChange(e.target.value)}
+        multiline
+        sx={{ flexGrow: 1 }}
+      />
+      <IconButton size="large" color="primary" onClick={props.onSend}>
+        <SendIcon />
+      </IconButton>
+    </Box>
+  );
+}

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -1,84 +1,76 @@
 import React from 'react';
 
-import { Avatar, Box, Grid, useTheme } from '@mui/material';
+import { Avatar, Box, useTheme } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material';
+import PsychologyIcon from '@mui/icons-material/Psychology';
 import ReactMarkdown from 'react-markdown';
 
 import { ChatCodeView } from './chat-code-view';
 
 type ChatMessagesProps = {
-  side: 'left' | 'right';
+  sender: 'self' | 'ai' | string;
   messages: string[];
 };
+
+function getAvatar(sender: 'self' | 'ai' | string) {
+  const sharedStyles: SxProps<Theme> = {
+    height: '2em',
+    width: '2em'
+  };
+
+  switch (sender) {
+    case 'self':
+      return <Avatar src="" sx={{ ...sharedStyles }} />;
+    case 'ai':
+      return (
+        <Avatar sx={{ ...sharedStyles }}>
+          <PsychologyIcon />
+        </Avatar>
+      );
+    default:
+      return <Avatar src="?" sx={{ ...sharedStyles }} />;
+  }
+}
 
 export function ChatMessages(props: ChatMessagesProps) {
   const theme = useTheme();
   const radius = theme.spacing(2);
 
   return (
-    <Grid
-      container
-      spacing={2}
-      justifyContent={props.side === 'right' ? 'flex-end' : 'flex-start'}
-    >
-      {props.side === 'left' && (
-        <Grid item>
-          <Avatar src={''} />
-        </Grid>
-      )}
-      <Grid item xs={8} sx={{ textAlign: props.side }}>
+    <Box sx={{ display: 'flex', ' > :not(:last-child)': { marginRight: 2 } }}>
+      {getAvatar(props.sender)}
+      <Box sx={{ flexGrow: 1 }}>
         {props.messages.map((message, i) => (
-          <Box key={i}>
-            <Box
-              sx={{
-                display: 'inline-block',
-                padding: theme.spacing(1, 2),
-                borderRadius: radius,
-                marginBottom: 1,
-                wordBreak: 'break-word',
-                textAlign: 'left',
-                maxWidth: '100%',
-                boxSizing: 'border-box',
-                ...(props.side === 'left'
-                  ? {
-                      borderTopRightRadius: radius,
-                      borderBottomRightRadius: radius,
-                      backgroundColor: theme.palette.grey[100]
-                    }
-                  : {
-                      borderTopLeftRadius: radius,
-                      borderBottomLeftRadius: radius,
-                      backgroundColor: theme.palette.primary.main,
-                      color: theme.palette.common.white
-                    }),
-                ...(props.side === 'left' &&
-                  i === 0 && {
-                    borderTopLeftRadius: radius
-                  }),
-                ...(props.side === 'left' &&
-                  i === props.messages.length - 1 && {
-                    borderBottomLeftRadius: radius
-                  }),
-                ...(props.side === 'right' &&
-                  i === 0 && {
-                    borderTopRightRadius: radius
-                  }),
-                ...(props.side === 'right' &&
-                  i === props.messages.length - 1 && {
-                    borderBottomRightRadius: radius
+          <Box
+            sx={{
+              display: 'inline-block',
+              padding: theme.spacing(1, 2),
+              borderRadius: radius,
+              marginBottom: 1,
+              wordBreak: 'break-word',
+              textAlign: 'left',
+              maxWidth: '100%',
+              boxSizing: 'border-box',
+              ...(props.sender === 'self'
+                ? {
+                    backgroundColor: theme.palette.primary.main,
+                    color: theme.palette.common.white
+                  }
+                : {
+                    backgroundColor: theme.palette.grey[100]
                   })
+            }}
+          >
+            <ReactMarkdown
+              components={{
+                code: ChatCodeView
               }}
             >
-              <ReactMarkdown
-                components={{
-                  code: ChatCodeView
-                }}
-              >
-                {message}
-              </ReactMarkdown>
-            </Box>
+              {message}
+            </ReactMarkdown>
           </Box>
         ))}
-      </Grid>
-    </Grid>
+      </Box>
+    </Box>
   );
 }

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -41,33 +41,36 @@ export function ChatMessages(props: ChatMessagesProps) {
       {getAvatar(props.sender)}
       <Box sx={{ flexGrow: 1, minWidth: 0 }}>
         {props.messages.map((message, i) => (
-          <Box
-            sx={{
-              display: 'inline-block',
-              padding: theme.spacing(1, 2),
-              borderRadius: radius,
-              marginBottom: 1,
-              wordBreak: 'break-word',
-              textAlign: 'left',
-              maxWidth: '100%',
-              boxSizing: 'border-box',
-              ...(props.sender === 'self'
-                ? {
-                    backgroundColor: theme.palette.primary.main,
-                    color: theme.palette.common.white
-                  }
-                : {
-                    backgroundColor: theme.palette.grey[100]
-                  })
-            }}
-          >
-            <ReactMarkdown
-              components={{
-                code: ChatCodeView
+          // extra div needed to ensure each bubble is on a new line
+          <Box key={i}>
+            <Box
+              sx={{
+                display: 'inline-block',
+                padding: theme.spacing(1, 2),
+                borderRadius: radius,
+                marginBottom: 1,
+                wordBreak: 'break-word',
+                textAlign: 'left',
+                maxWidth: '100%',
+                boxSizing: 'border-box',
+                ...(props.sender === 'self'
+                  ? {
+                      backgroundColor: theme.palette.primary.main,
+                      color: theme.palette.common.white
+                    }
+                  : {
+                      backgroundColor: theme.palette.grey[100]
+                    })
               }}
             >
-              {message}
-            </ReactMarkdown>
+              <ReactMarkdown
+                components={{
+                  code: ChatCodeView
+                }}
+              >
+                {message}
+              </ReactMarkdown>
+            </Box>
           </Box>
         ))}
       </Box>

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -4,6 +4,9 @@ import { Avatar, Box, useTheme } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material';
 import PsychologyIcon from '@mui/icons-material/Psychology';
 import ReactMarkdown from 'react-markdown';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
+import 'katex/dist/katex.min.css';
 
 import { ChatCodeView } from './chat-code-view';
 
@@ -67,6 +70,8 @@ export function ChatMessages(props: ChatMessagesProps) {
                 components={{
                   code: ChatCodeView
                 }}
+                remarkPlugins={[remarkMath]}
+                rehypePlugins={[rehypeKatex]}
               >
                 {message}
               </ReactMarkdown>

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { Avatar, Box, Grid, useTheme } from '@mui/material';
+// import MuiMarkdown from 'mui-markdown';
+import ReactMarkdown from 'react-markdown';
+
+type ChatMessagesProps = {
+  side: 'left' | 'right';
+  messages: string[];
+};
+
+export function ChatMessages(props: ChatMessagesProps) {
+  const theme = useTheme();
+  const radius = theme.spacing(2);
+
+  return (
+    <Grid
+      container
+      spacing={2}
+      justifyContent={props.side === 'right' ? 'flex-end' : 'flex-start'}
+    >
+      {props.side === 'left' && (
+        <Grid item>
+          <Avatar src={''} />
+        </Grid>
+      )}
+      <Grid item xs={8} sx={{ textAlign: props.side }}>
+        {props.messages.map((message, i) => (
+          <Box key={i}>
+            <Box
+              sx={{
+                display: 'inline-block',
+                padding: theme.spacing(1, 2),
+                borderRadius: radius,
+                marginBottom: 1,
+                wordBreak: 'break-word',
+                textAlign: 'left',
+                ...(props.side === 'left'
+                  ? {
+                      borderTopRightRadius: radius,
+                      borderBottomRightRadius: radius,
+                      backgroundColor: theme.palette.grey[100]
+                    }
+                  : {
+                      borderTopLeftRadius: radius,
+                      borderBottomLeftRadius: radius,
+                      backgroundColor: theme.palette.primary.main,
+                      color: theme.palette.common.white
+                    }),
+                ...(props.side === 'left' &&
+                  i === 0 && {
+                    borderTopLeftRadius: radius
+                  }),
+                ...(props.side === 'left' &&
+                  i === props.messages.length - 1 && {
+                    borderBottomLeftRadius: radius
+                  }),
+                ...(props.side === 'right' &&
+                  i === 0 && {
+                    borderTopRightRadius: radius
+                  }),
+                ...(props.side === 'right' &&
+                  i === props.messages.length - 1 && {
+                    borderBottomRightRadius: radius
+                  })
+              }}
+            >
+              <ReactMarkdown>{message}</ReactMarkdown>
+            </Box>
+          </Box>
+        ))}
+      </Grid>
+    </Grid>
+  );
+}

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -39,7 +39,7 @@ export function ChatMessages(props: ChatMessagesProps) {
   return (
     <Box sx={{ display: 'flex', ' > :not(:last-child)': { marginRight: 2 } }}>
       {getAvatar(props.sender)}
-      <Box sx={{ flexGrow: 1 }}>
+      <Box sx={{ flexGrow: 1, minWidth: 0 }}>
         {props.messages.map((message, i) => (
           <Box
             sx={{

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { Avatar, Box, Grid, useTheme } from '@mui/material';
-// import MuiMarkdown from 'mui-markdown';
 import ReactMarkdown from 'react-markdown';
+
+import { ChatCodeView } from './chat-code-view';
 
 type ChatMessagesProps = {
   side: 'left' | 'right';
@@ -35,6 +36,8 @@ export function ChatMessages(props: ChatMessagesProps) {
                 marginBottom: 1,
                 wordBreak: 'break-word',
                 textAlign: 'left',
+                maxWidth: '100%',
+                boxSizing: 'border-box',
                 ...(props.side === 'left'
                   ? {
                       borderTopRightRadius: radius,
@@ -65,7 +68,13 @@ export function ChatMessages(props: ChatMessagesProps) {
                   })
               }}
             >
-              <ReactMarkdown>{message}</ReactMarkdown>
+              <ReactMarkdown
+                components={{
+                  code: ChatCodeView
+                }}
+              >
+                {message}
+              </ReactMarkdown>
             </Box>
           </Box>
         ))}

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+
+import { Box } from '@mui/system';
+
+import { JlThemeProvider } from './jl-theme-provider';
+import { ChatMessages } from './chat-messages';
+import { ChatInput } from './chat-input';
+import { AiService } from '../handler';
+
+type ChatMessageGroup = {
+  side: 'left' | 'right';
+  messages: string[];
+};
+
+export function Chat(): JSX.Element {
+  const [messageGroups, setMessageGroups] = useState<ChatMessageGroup[]>([]);
+  const [input, setInput] = useState('');
+
+  const onSend = async () => {
+    setInput('');
+    setMessageGroups(messageGroups => [
+      ...messageGroups,
+      { side: 'right', messages: [input] }
+    ]);
+    const response = await AiService.sendChat({ prompt: input });
+    setMessageGroups(messageGroups => [
+      ...messageGroups,
+      { side: 'left', messages: [response.output] }
+    ]);
+  };
+
+  return (
+    <JlThemeProvider>
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          boxSizing: 'border-box',
+          background: 'white',
+          padding: 4,
+          display: 'flex',
+          flexDirection: 'column'
+        }}
+      >
+        <Box sx={{ flexGrow: 1 }}>
+          <ChatMessages side="right" messages={['Hello. Who are you?']} />
+          <ChatMessages
+            side="left"
+            messages={[
+              'My name is Jupyter AI, and I am a helpful assistant for Jupyter users.',
+              'For example, I can write `python3` code like so:',
+              '```py\nfor i in range(5):\n  print(i)\n```',
+              'Would you like help with something?'
+            ]}
+          />
+          {messageGroups.map((group, idx) => (
+            <ChatMessages side={group.side} messages={group.messages} />
+          ))}
+        </Box>
+        <ChatInput value={input} onChange={setInput} onSend={onSend} />
+      </Box>
+    </JlThemeProvider>
+  );
+}

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -14,15 +14,25 @@ type ChatMessageGroup = {
 
 export function Chat(): JSX.Element {
   const [messageGroups, setMessageGroups] = useState<ChatMessageGroup[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
   const [input, setInput] = useState('');
 
   const onSend = async () => {
+    setLoading(true);
     setInput('');
     setMessageGroups(messageGroups => [
       ...messageGroups,
       { side: 'right', messages: [input] }
     ]);
-    const response = await AiService.sendChat({ prompt: input });
+
+    let response: AiService.ChatResponse;
+
+    try {
+      response = await AiService.sendChat({ prompt: input });
+    } finally {
+      setLoading(false);
+    }
+
     setMessageGroups(messageGroups => [
       ...messageGroups,
       { side: 'left', messages: [response.output] }
@@ -69,7 +79,12 @@ export function Chat(): JSX.Element {
             <ChatMessages side={group.side} messages={group.messages} />
           ))}
         </Box>
-        <ChatInput value={input} onChange={setInput} onSend={onSend} />
+        <ChatInput
+          loading={loading}
+          value={input}
+          onChange={setInput}
+          onSend={onSend}
+        />
       </Box>
     </JlThemeProvider>
   );

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -20,7 +20,7 @@ type ChatMessageGroup = {
 function ChatBody(): JSX.Element {
   const [messageGroups, setMessageGroups] = useState<ChatMessageGroup[]>([]);
   const [loading, setLoading] = useState(false);
-  const [includeSelection, setIncludeSelection] = useState(false);
+  const [includeSelection, setIncludeSelection] = useState(true);
   const [replaceSelection, setReplaceSelection] = useState(false);
   const [input, setInput] = useState('');
   const [selection, replaceSelectionFn] = useSelectionContext();

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -1,4 +1,8 @@
-import React, { useState } from 'react';
+import React, {
+  useState
+  // useMemo,
+  // useEffect
+} from 'react';
 
 import { Box } from '@mui/system';
 
@@ -11,6 +15,7 @@ import {
   useSelectionContext
 } from '../contexts/selection-context';
 import { SelectionWatcher } from '../selection-watcher';
+// import { ChatHandler } from '../chat_handler';
 
 type ChatMessageGroup = {
   sender: 'self' | 'ai' | string;
@@ -24,6 +29,53 @@ function ChatBody(): JSX.Element {
   const [replaceSelection, setReplaceSelection] = useState(false);
   const [input, setInput] = useState('');
   const [selection, replaceSelectionFn] = useSelectionContext();
+
+  // TODO: connect to websockets.
+  // const chatHandler = useMemo(() => new ChatHandler(), []);
+  //
+  // /**
+  //  * Effect: fetch history on initial render
+  //  */
+  // useEffect(() => {
+  //   async function fetchHistory() {
+  //     const history = await chatHandler.getHistory();
+  //     const messages = history.messages;
+  //     if (!messages.length) {
+  //       return;
+  //     }
+
+  //     const newMessageGroups = messages.map(
+  //       (message: AiService.ChatMessage): ChatMessageGroup => ({
+  //         sender: message.type === 'ai' ? 'ai' : 'self',
+  //         messages: [message.data.content]
+  //       })
+  //     );
+  //     setMessageGroups(newMessageGroups);
+  //   }
+
+  //   fetchHistory();
+  // }, [chatHandler]);
+
+  // /**
+  //  * Effect: listen to chat messages
+  //  */
+  // useEffect(() => {
+  //   function handleChatEvents(message: AiService.ChatMessage) {
+  //     setMessageGroups(messageGroups => [
+  //       ...messageGroups,
+  //       {
+  //         sender: message.type === 'ai' ? 'ai' : 'self',
+  //         messages: [message.data.content]
+  //       }
+  //     ]);
+  //   }
+
+  //   chatHandler.addListener(handleChatEvents);
+
+  //   return function cleanup() {
+  //     chatHandler.removeListener(handleChatEvents);
+  //   };
+  // }, [chatHandler]);
 
   const onSend = async () => {
     setLoading(true);

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -42,17 +42,27 @@ export function Chat(): JSX.Element {
   return (
     <JlThemeProvider>
       <Box
+        // root box should not include padding as it offsets the vertical
+        // scrollbar to the left
         sx={{
           width: '100%',
           height: '100%',
           boxSizing: 'border-box',
           background: 'white',
-          padding: 2,
           display: 'flex',
           flexDirection: 'column'
         }}
       >
-        <Box sx={{ flexGrow: 1, overflowY: 'scroll' }}>
+        <Box
+          sx={{
+            flexGrow: 1,
+            padding: 2,
+            overflowY: 'scroll',
+            '> :not(:last-child)': {
+              marginBottom: 1
+            }
+          }}
+        >
           <ChatMessages sender="self" messages={['Hello. Who are you?']} />
           <ChatMessages
             sender="ai"
@@ -84,6 +94,9 @@ export function Chat(): JSX.Element {
           value={input}
           onChange={setInput}
           onSend={onSend}
+          sx={{
+            padding: 2
+          }}
         />
       </Box>
     </JlThemeProvider>

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -8,7 +8,7 @@ import { ChatInput } from './chat-input';
 import { AiService } from '../handler';
 
 type ChatMessageGroup = {
-  side: 'left' | 'right';
+  sender: 'self' | 'ai' | string;
   messages: string[];
 };
 
@@ -22,7 +22,7 @@ export function Chat(): JSX.Element {
     setInput('');
     setMessageGroups(messageGroups => [
       ...messageGroups,
-      { side: 'right', messages: [input] }
+      { sender: 'self', messages: [input] }
     ]);
 
     let response: AiService.ChatResponse;
@@ -35,7 +35,7 @@ export function Chat(): JSX.Element {
 
     setMessageGroups(messageGroups => [
       ...messageGroups,
-      { side: 'left', messages: [response.output] }
+      { sender: 'ai', messages: [response.output] }
     ]);
   };
 
@@ -47,15 +47,15 @@ export function Chat(): JSX.Element {
           height: '100%',
           boxSizing: 'border-box',
           background: 'white',
-          padding: 4,
+          padding: 2,
           display: 'flex',
           flexDirection: 'column'
         }}
       >
         <Box sx={{ flexGrow: 1, overflowY: 'scroll' }}>
-          <ChatMessages side="right" messages={['Hello. Who are you?']} />
+          <ChatMessages sender="self" messages={['Hello. Who are you?']} />
           <ChatMessages
-            side="left"
+            sender="ai"
             messages={[
               'My name is Jupyter AI, and I am a helpful assistant for Jupyter users.',
               'For example, I can write `python3` code like so:',
@@ -64,19 +64,19 @@ export function Chat(): JSX.Element {
             ]}
           />
           <ChatMessages
-            side="right"
+            sender="self"
             messages={[
               'Could you show me an example implementation of a mutex lock in C++?'
             ]}
           />
           <ChatMessages
-            side="left"
+            sender="ai"
             messages={[
               'Certainly! Here\'s an example implementation of a mutex lock using C++ `pthread_mutex_t`:\n\n```cpp\n#include <iostream>\n#include <thread>\n#include <pthread.h>\n\n// Declare a mutex object\npthread_mutex_t myMutex;\n\nvoid printWithLock(const std::string& message) {\n    // Lock mutex before accessing shared resource\n    pthread_mutex_lock(&myMutex);\n\n    // Critical section (shared resource access)\n    std::cout << message << std::endl;\n\n    // Mutex is released upon calling pthread_mutex_unlock()\n    pthread_mutex_unlock(&myMutex);\n}\n\nvoid workerThread() {\n    for (int i = 0; i < 5; i++) {\n        printWithLock("Hello, World!");\n    }\n}\n\nint main() {\n    // Initialize the mutex object\n    pthread_mutex_init(&myMutex, NULL);\n\n    // Start worker thread\n    std::thread t(workerThread);\n\n    // Main thread\n    for (int i = 0; i < 5; i++) {\n        printWithLock("Hello, Mutex!");\n    }\n\n    // Wait for worker thread to finish\n    t.join();\n\n    // Destroy the mutex object\n    pthread_mutex_destroy(&myMutex);\n\n    return 0;\n}\n```\n\nIn this example implementation, we use the `pthread_mutex_t` data type to declare a mutex object called `myMutex`. In the `printWithLock` function, we call `pthread_mutex_lock()` to acquire the mutex lock before accessing the shared resource (`std::cout`). We then release the mutex lock by calling `pthread_mutex_unlock()` before exiting the function.\n\nWe also define a worker thread function `workerThread` that simply calls `printWithLock` five times with the message "Hello, World!". In the `main` function, we call `printWithLock` five times with the message "Hello, Mutex!" from the main thread and wait for the worker thread to finish by calling `t.join()`.\n\nWe initialize the mutex object using `pthread_mutex_init()` at the beginning of the `main` function and destroy it using `pthread_mutex_destroy()` before the end of the function.\n\nThis implementation ensures that only one thread at a time can access the shared resource, preventing race conditions and data corruption.'
             ]}
           />
           {messageGroups.map((group, idx) => (
-            <ChatMessages side={group.side} messages={group.messages} />
+            <ChatMessages sender={group.sender} messages={group.messages} />
           ))}
         </Box>
         <ChatInput

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -134,28 +134,6 @@ function ChatBody(): JSX.Element {
           }
         }}
       >
-        <ChatMessages sender="self" messages={['Hello. Who are you?']} />
-        <ChatMessages
-          sender="ai"
-          messages={[
-            'My name is Jupyter AI, and I am a helpful assistant for Jupyter users.',
-            'For example, I can write `python3` code like so:',
-            '```py\nfor i in range(5):\n  print(i)\n```',
-            'Would you like help with something?'
-          ]}
-        />
-        <ChatMessages
-          sender="self"
-          messages={[
-            'Could you show me an example implementation of a mutex lock in C++?'
-          ]}
-        />
-        <ChatMessages
-          sender="ai"
-          messages={[
-            'Certainly! Here\'s an example implementation of a mutex lock using C++ `pthread_mutex_t`:\n\n```cpp\n#include <iostream>\n#include <thread>\n#include <pthread.h>\n\n// Declare a mutex object\npthread_mutex_t myMutex;\n\nvoid printWithLock(const std::string& message) {\n    // Lock mutex before accessing shared resource\n    pthread_mutex_lock(&myMutex);\n\n    // Critical section (shared resource access)\n    std::cout << message << std::endl;\n\n    // Mutex is released upon calling pthread_mutex_unlock()\n    pthread_mutex_unlock(&myMutex);\n}\n\nvoid workerThread() {\n    for (int i = 0; i < 5; i++) {\n        printWithLock("Hello, World!");\n    }\n}\n\nint main() {\n    // Initialize the mutex object\n    pthread_mutex_init(&myMutex, NULL);\n\n    // Start worker thread\n    std::thread t(workerThread);\n\n    // Main thread\n    for (int i = 0; i < 5; i++) {\n        printWithLock("Hello, Mutex!");\n    }\n\n    // Wait for worker thread to finish\n    t.join();\n\n    // Destroy the mutex object\n    pthread_mutex_destroy(&myMutex);\n\n    return 0;\n}\n```\n\nIn this example implementation, we use the `pthread_mutex_t` data type to declare a mutex object called `myMutex`. In the `printWithLock` function, we call `pthread_mutex_lock()` to acquire the mutex lock before accessing the shared resource (`std::cout`). We then release the mutex lock by calling `pthread_mutex_unlock()` before exiting the function.\n\nWe also define a worker thread function `workerThread` that simply calls `printWithLock` five times with the message "Hello, World!". In the `main` function, we call `printWithLock` five times with the message "Hello, Mutex!" from the main thread and wait for the worker thread to finish by calling `t.join()`.\n\nWe initialize the mutex object using `pthread_mutex_init()` at the beginning of the `main` function and destroy it using `pthread_mutex_destroy()` before the end of the function.\n\nThis implementation ensures that only one thread at a time can access the shared resource, preventing race conditions and data corruption.'
-          ]}
-        />
         {messageGroups.map((group, idx) => (
           <ChatMessages
             key={idx}

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -42,7 +42,7 @@ export function Chat(): JSX.Element {
           flexDirection: 'column'
         }}
       >
-        <Box sx={{ flexGrow: 1 }}>
+        <Box sx={{ flexGrow: 1, overflowY: 'scroll' }}>
           <ChatMessages side="right" messages={['Hello. Who are you?']} />
           <ChatMessages
             side="left"
@@ -51,6 +51,18 @@ export function Chat(): JSX.Element {
               'For example, I can write `python3` code like so:',
               '```py\nfor i in range(5):\n  print(i)\n```',
               'Would you like help with something?'
+            ]}
+          />
+          <ChatMessages
+            side="right"
+            messages={[
+              'Could you show me an example implementation of a mutex lock in C++?'
+            ]}
+          />
+          <ChatMessages
+            side="left"
+            messages={[
+              'Certainly! Here\'s an example implementation of a mutex lock using C++ `pthread_mutex_t`:\n\n```cpp\n#include <iostream>\n#include <thread>\n#include <pthread.h>\n\n// Declare a mutex object\npthread_mutex_t myMutex;\n\nvoid printWithLock(const std::string& message) {\n    // Lock mutex before accessing shared resource\n    pthread_mutex_lock(&myMutex);\n\n    // Critical section (shared resource access)\n    std::cout << message << std::endl;\n\n    // Mutex is released upon calling pthread_mutex_unlock()\n    pthread_mutex_unlock(&myMutex);\n}\n\nvoid workerThread() {\n    for (int i = 0; i < 5; i++) {\n        printWithLock("Hello, World!");\n    }\n}\n\nint main() {\n    // Initialize the mutex object\n    pthread_mutex_init(&myMutex, NULL);\n\n    // Start worker thread\n    std::thread t(workerThread);\n\n    // Main thread\n    for (int i = 0; i < 5; i++) {\n        printWithLock("Hello, Mutex!");\n    }\n\n    // Wait for worker thread to finish\n    t.join();\n\n    // Destroy the mutex object\n    pthread_mutex_destroy(&myMutex);\n\n    return 0;\n}\n```\n\nIn this example implementation, we use the `pthread_mutex_t` data type to declare a mutex object called `myMutex`. In the `printWithLock` function, we call `pthread_mutex_lock()` to acquire the mutex lock before accessing the shared resource (`std::cout`). We then release the mutex lock by calling `pthread_mutex_unlock()` before exiting the function.\n\nWe also define a worker thread function `workerThread` that simply calls `printWithLock` five times with the message "Hello, World!". In the `main` function, we call `printWithLock` five times with the message "Hello, Mutex!" from the main thread and wait for the worker thread to finish by calling `t.join()`.\n\nWe initialize the mutex object using `pthread_mutex_init()` at the beginning of the `main` function and destroy it using `pthread_mutex_destroy()` before the end of the function.\n\nThis implementation ensures that only one thread at a time can access the shared resource, preventing race conditions and data corruption.'
             ]}
           />
           {messageGroups.map((group, idx) => (

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -6,33 +6,53 @@ import { JlThemeProvider } from './jl-theme-provider';
 import { ChatMessages } from './chat-messages';
 import { ChatInput } from './chat-input';
 import { AiService } from '../handler';
+import {
+  SelectionContextProvider,
+  useSelectionContext
+} from '../contexts/selection-context';
+import { SelectionWatcher } from '../selection-watcher';
 
 type ChatMessageGroup = {
   sender: 'self' | 'ai' | string;
   messages: string[];
 };
 
-export function Chat(): JSX.Element {
+function ChatBody(): JSX.Element {
   const [messageGroups, setMessageGroups] = useState<ChatMessageGroup[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState(false);
+  const [includeSelection, setIncludeSelection] = useState(false);
+  const [replaceSelection, setReplaceSelection] = useState(false);
   const [input, setInput] = useState('');
+  const [selection, replaceSelectionFn] = useSelectionContext();
 
   const onSend = async () => {
     setLoading(true);
     setInput('');
+    console.log({
+      includeSelection,
+      replaceSelection
+    });
+    const newMessages = [input];
+    if (includeSelection && selection) {
+      newMessages.push('```\n' + selection + '\n```');
+    }
     setMessageGroups(messageGroups => [
       ...messageGroups,
-      { sender: 'self', messages: [input] }
+      { sender: 'self', messages: newMessages }
     ]);
 
     let response: AiService.ChatResponse;
 
+    const prompt = input + (selection ? '\n--\n' + selection : '');
     try {
-      response = await AiService.sendChat({ prompt: input });
+      response = await AiService.sendChat({ prompt });
     } finally {
       setLoading(false);
     }
 
+    if (replaceSelection) {
+      replaceSelectionFn(response.output);
+    }
     setMessageGroups(messageGroups => [
       ...messageGroups,
       { sender: 'ai', messages: [response.output] }
@@ -40,65 +60,90 @@ export function Chat(): JSX.Element {
   };
 
   return (
-    <JlThemeProvider>
+    <Box
+      // root box should not include padding as it offsets the vertical
+      // scrollbar to the left
+      sx={{
+        width: '100%',
+        height: '100%',
+        boxSizing: 'border-box',
+        background: 'white',
+        display: 'flex',
+        flexDirection: 'column'
+      }}
+    >
       <Box
-        // root box should not include padding as it offsets the vertical
-        // scrollbar to the left
         sx={{
-          width: '100%',
-          height: '100%',
-          boxSizing: 'border-box',
-          background: 'white',
-          display: 'flex',
-          flexDirection: 'column'
+          flexGrow: 1,
+          padding: 2,
+          overflowY: 'scroll',
+          '> :not(:last-child)': {
+            marginBottom: 1
+          }
         }}
       >
-        <Box
-          sx={{
-            flexGrow: 1,
-            padding: 2,
-            overflowY: 'scroll',
-            '> :not(:last-child)': {
-              marginBottom: 1
-            }
-          }}
-        >
-          <ChatMessages sender="self" messages={['Hello. Who are you?']} />
-          <ChatMessages
-            sender="ai"
-            messages={[
-              'My name is Jupyter AI, and I am a helpful assistant for Jupyter users.',
-              'For example, I can write `python3` code like so:',
-              '```py\nfor i in range(5):\n  print(i)\n```',
-              'Would you like help with something?'
-            ]}
-          />
-          <ChatMessages
-            sender="self"
-            messages={[
-              'Could you show me an example implementation of a mutex lock in C++?'
-            ]}
-          />
-          <ChatMessages
-            sender="ai"
-            messages={[
-              'Certainly! Here\'s an example implementation of a mutex lock using C++ `pthread_mutex_t`:\n\n```cpp\n#include <iostream>\n#include <thread>\n#include <pthread.h>\n\n// Declare a mutex object\npthread_mutex_t myMutex;\n\nvoid printWithLock(const std::string& message) {\n    // Lock mutex before accessing shared resource\n    pthread_mutex_lock(&myMutex);\n\n    // Critical section (shared resource access)\n    std::cout << message << std::endl;\n\n    // Mutex is released upon calling pthread_mutex_unlock()\n    pthread_mutex_unlock(&myMutex);\n}\n\nvoid workerThread() {\n    for (int i = 0; i < 5; i++) {\n        printWithLock("Hello, World!");\n    }\n}\n\nint main() {\n    // Initialize the mutex object\n    pthread_mutex_init(&myMutex, NULL);\n\n    // Start worker thread\n    std::thread t(workerThread);\n\n    // Main thread\n    for (int i = 0; i < 5; i++) {\n        printWithLock("Hello, Mutex!");\n    }\n\n    // Wait for worker thread to finish\n    t.join();\n\n    // Destroy the mutex object\n    pthread_mutex_destroy(&myMutex);\n\n    return 0;\n}\n```\n\nIn this example implementation, we use the `pthread_mutex_t` data type to declare a mutex object called `myMutex`. In the `printWithLock` function, we call `pthread_mutex_lock()` to acquire the mutex lock before accessing the shared resource (`std::cout`). We then release the mutex lock by calling `pthread_mutex_unlock()` before exiting the function.\n\nWe also define a worker thread function `workerThread` that simply calls `printWithLock` five times with the message "Hello, World!". In the `main` function, we call `printWithLock` five times with the message "Hello, Mutex!" from the main thread and wait for the worker thread to finish by calling `t.join()`.\n\nWe initialize the mutex object using `pthread_mutex_init()` at the beginning of the `main` function and destroy it using `pthread_mutex_destroy()` before the end of the function.\n\nThis implementation ensures that only one thread at a time can access the shared resource, preventing race conditions and data corruption.'
-            ]}
-          />
-          {messageGroups.map((group, idx) => (
-            <ChatMessages sender={group.sender} messages={group.messages} />
-          ))}
-        </Box>
-        <ChatInput
-          loading={loading}
-          value={input}
-          onChange={setInput}
-          onSend={onSend}
-          sx={{
-            padding: 2
-          }}
+        <ChatMessages sender="self" messages={['Hello. Who are you?']} />
+        <ChatMessages
+          sender="ai"
+          messages={[
+            'My name is Jupyter AI, and I am a helpful assistant for Jupyter users.',
+            'For example, I can write `python3` code like so:',
+            '```py\nfor i in range(5):\n  print(i)\n```',
+            'Would you like help with something?'
+          ]}
         />
+        <ChatMessages
+          sender="self"
+          messages={[
+            'Could you show me an example implementation of a mutex lock in C++?'
+          ]}
+        />
+        <ChatMessages
+          sender="ai"
+          messages={[
+            'Certainly! Here\'s an example implementation of a mutex lock using C++ `pthread_mutex_t`:\n\n```cpp\n#include <iostream>\n#include <thread>\n#include <pthread.h>\n\n// Declare a mutex object\npthread_mutex_t myMutex;\n\nvoid printWithLock(const std::string& message) {\n    // Lock mutex before accessing shared resource\n    pthread_mutex_lock(&myMutex);\n\n    // Critical section (shared resource access)\n    std::cout << message << std::endl;\n\n    // Mutex is released upon calling pthread_mutex_unlock()\n    pthread_mutex_unlock(&myMutex);\n}\n\nvoid workerThread() {\n    for (int i = 0; i < 5; i++) {\n        printWithLock("Hello, World!");\n    }\n}\n\nint main() {\n    // Initialize the mutex object\n    pthread_mutex_init(&myMutex, NULL);\n\n    // Start worker thread\n    std::thread t(workerThread);\n\n    // Main thread\n    for (int i = 0; i < 5; i++) {\n        printWithLock("Hello, Mutex!");\n    }\n\n    // Wait for worker thread to finish\n    t.join();\n\n    // Destroy the mutex object\n    pthread_mutex_destroy(&myMutex);\n\n    return 0;\n}\n```\n\nIn this example implementation, we use the `pthread_mutex_t` data type to declare a mutex object called `myMutex`. In the `printWithLock` function, we call `pthread_mutex_lock()` to acquire the mutex lock before accessing the shared resource (`std::cout`). We then release the mutex lock by calling `pthread_mutex_unlock()` before exiting the function.\n\nWe also define a worker thread function `workerThread` that simply calls `printWithLock` five times with the message "Hello, World!". In the `main` function, we call `printWithLock` five times with the message "Hello, Mutex!" from the main thread and wait for the worker thread to finish by calling `t.join()`.\n\nWe initialize the mutex object using `pthread_mutex_init()` at the beginning of the `main` function and destroy it using `pthread_mutex_destroy()` before the end of the function.\n\nThis implementation ensures that only one thread at a time can access the shared resource, preventing race conditions and data corruption.'
+          ]}
+        />
+        {messageGroups.map((group, idx) => (
+          <ChatMessages
+            key={idx}
+            sender={group.sender}
+            messages={group.messages}
+          />
+        ))}
       </Box>
+      <ChatInput
+        loading={loading}
+        value={input}
+        onChange={setInput}
+        onSend={onSend}
+        hasSelection={!!selection}
+        includeSelection={includeSelection}
+        toggleIncludeSelection={() =>
+          setIncludeSelection(includeSelection => !includeSelection)
+        }
+        replaceSelection={replaceSelection}
+        toggleReplaceSelection={() =>
+          setReplaceSelection(replaceSelection => !replaceSelection)
+        }
+        sx={{
+          padding: 2
+        }}
+      />
+    </Box>
+  );
+}
+
+export type ChatProps = {
+  selectionWatcher: SelectionWatcher;
+};
+
+export function Chat(props: ChatProps) {
+  return (
+    <JlThemeProvider>
+      <SelectionContextProvider selectionWatcher={props.selectionWatcher}>
+        <ChatBody />
+      </SelectionContextProvider>
     </JlThemeProvider>
   );
 }

--- a/packages/jupyter-ai/src/components/jl-theme-provider.tsx
+++ b/packages/jupyter-ai/src/components/jl-theme-provider.tsx
@@ -1,0 +1,17 @@
+import React, { useState, useEffect } from 'react';
+
+import { Theme, ThemeProvider, createTheme } from '@mui/material/styles';
+import { getJupyterLabTheme } from '../theme-provider';
+
+export function JlThemeProvider(props: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(createTheme());
+
+  useEffect(() => {
+    async function setJlTheme() {
+      setTheme(await getJupyterLabTheme());
+    }
+    setJlTheme();
+  }, []);
+
+  return <ThemeProvider theme={theme}>{props.children}</ThemeProvider>;
+}

--- a/packages/jupyter-ai/src/components/open-task-dialog.tsx
+++ b/packages/jupyter-ai/src/components/open-task-dialog.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { Widget } from '@lumino/widgets';
 
-import { ThemeProvider } from '@mui/material/styles';
 import {
   Box,
   InputLabel,
@@ -17,7 +16,7 @@ import { ExpandableTextField } from './expandable-text-field';
 
 import { insertOutput } from '../inserter';
 import { AiService } from '../handler';
-import { getJupyterLabTheme } from '../theme-provider';
+import { JlThemeProvider } from './jl-theme-provider';
 
 /**
  * Map of human-readable descriptions per insertion mode.
@@ -122,7 +121,7 @@ export function OpenTaskDialog(props: IOpenTaskDialogProps): JSX.Element {
       : '';
 
   return (
-    <ThemeProvider theme={getJupyterLabTheme()}>
+    <JlThemeProvider>
       <Box padding={1} width={'40em'}>
         <Stack spacing={4}>
           <FormControl fullWidth>
@@ -191,6 +190,6 @@ export function OpenTaskDialog(props: IOpenTaskDialogProps): JSX.Element {
           </Stack>
         </Stack>
       </Box>
-    </ThemeProvider>
+    </JlThemeProvider>
   );
 }

--- a/packages/jupyter-ai/src/contexts/selection-context.tsx
+++ b/packages/jupyter-ai/src/contexts/selection-context.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback, useContext, useEffect, useState } from 'react';
+import { SelectionWatcher } from '../selection-watcher';
+
+const SelectionContext = React.createContext<
+  [string, (value: string) => unknown]
+>([
+  '',
+  () => {
+    /* noop */
+  }
+]);
+
+export function useSelectionContext() {
+  return useContext(SelectionContext);
+}
+
+type SelectionContextProviderProps = {
+  selectionWatcher: SelectionWatcher;
+  children: React.ReactNode;
+};
+
+export function SelectionContextProvider({
+  selectionWatcher,
+  children
+}: SelectionContextProviderProps) {
+  const [selection, setSelection] = useState('');
+
+  /**
+   * Effect: subscribe to SelectionWatcher
+   */
+  useEffect(() => {
+    selectionWatcher.selectionChanged.connect((sender, newSelection) => {
+      setSelection(newSelection);
+    });
+  }, []);
+
+  const replaceSelection = useCallback(
+    (value: string) => {
+      selectionWatcher.replaceSelection(value);
+    },
+    [selectionWatcher]
+  );
+
+  return (
+    <SelectionContext.Provider value={[selection, replaceSelection]}>
+      {children}
+    </SelectionContext.Provider>
+  );
+}

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -69,18 +69,18 @@ export namespace AiService {
   };
 
   export type ChatMessageData = {
-    content: string
-    additional_kwargs: {[key: string]: any}
-  }
+    content: string;
+    additional_kwargs: { [key: string]: any };
+  };
 
   export type ChatMessage = {
-    type: string
-    data: ChatMessageData
-  }
+    type: string;
+    data: ChatMessageData;
+  };
 
   export type ChatHistory = {
-    messages: ChatMessage[]
-  }
+    messages: ChatMessage[];
+  };
 
   export interface IPromptResponse {
     output: string;

--- a/packages/jupyter-ai/src/icons.ts
+++ b/packages/jupyter-ai/src/icons.ts
@@ -5,6 +5,6 @@ import { LabIcon } from '@jupyterlab/ui-components';
 import psychologySvgStr from '../style/icons/psychology.svg';
 
 export const psychologyIcon = new LabIcon({
-  name: 'jupyterlab-ai:psychology',
+  name: 'jupyter-ai::psychology',
   svgstr: psychologySvgStr
 });

--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from './commands';
 import { psychologyIcon } from './icons';
 import { getTextSelection } from './utils';
+import { buildChatSidebar } from './widgets/chat-sidebar';
 
 export enum NotebookTasks {
   GenerateCode = 'generate-code-in-cells-below',
@@ -50,7 +51,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     notebookTracker: INotebookTracker,
     editorTracker: IEditorTracker
   ) => {
-    const { commands } = app;
+    const { commands, shell } = app;
 
     /**
      * Register core commands
@@ -73,6 +74,11 @@ const plugin: JupyterFrontEndPlugin<void> = {
         return !!(editorWidget && getTextSelection(editorWidget));
       }
     });
+
+    /**
+     * Add Chat widget to right sidebar
+     */
+    shell.add(buildChatSidebar(), 'right');
 
     /**
      * Register inserters

--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -16,6 +16,7 @@ import {
 import { psychologyIcon } from './icons';
 import { getTextSelection } from './utils';
 import { buildChatSidebar } from './widgets/chat-sidebar';
+import { SelectionWatcher } from './selection-watcher';
 
 export enum NotebookTasks {
   GenerateCode = 'generate-code-in-cells-below',
@@ -76,9 +77,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
     });
 
     /**
+     * Initialize selection watcher singleton
+     */
+    const selectionWatcher = new SelectionWatcher(shell);
+
+    /**
      * Add Chat widget to right sidebar
      */
-    shell.add(buildChatSidebar(), 'right');
+    shell.add(buildChatSidebar(selectionWatcher), 'right');
 
     /**
      * Register inserters

--- a/packages/jupyter-ai/src/selection-watcher.ts
+++ b/packages/jupyter-ai/src/selection-watcher.ts
@@ -1,0 +1,52 @@
+import { JupyterFrontEnd, LabShell } from '@jupyterlab/application';
+import { DocumentWidget } from '@jupyterlab/docregistry';
+import { Widget } from '@lumino/widgets';
+import { Signal } from '@lumino/signaling';
+
+import { getEditor, getTextSelection } from './utils';
+
+export class SelectionWatcher {
+  constructor(shell: JupyterFrontEnd.IShell) {
+    if (!(shell instanceof LabShell)) {
+      throw 'Shell is not an instance of LabShell. Jupyter AI does not currently support custom shells.';
+    }
+
+    shell.currentChanged.connect((sender, args) => {
+      this._mainAreaWidget = args.newValue;
+    });
+    setInterval(this._poll.bind(this), 200);
+  }
+
+  get selectionChanged() {
+    return this._selectionChanged;
+  }
+
+  replaceSelection(value: string) {
+    if (!(this._mainAreaWidget instanceof DocumentWidget)) {
+      return;
+    }
+
+    const editor = getEditor(this._mainAreaWidget.content);
+    editor?.replaceSelection?.(value);
+  }
+
+  protected _poll() {
+    if (!(this._mainAreaWidget instanceof DocumentWidget)) {
+      return;
+    }
+
+    const prevSelection = this._selection;
+    const currSelection = getTextSelection(this._mainAreaWidget.content);
+
+    if (prevSelection === currSelection) {
+      return;
+    }
+
+    this._selection = currSelection;
+    this._selectionChanged.emit(currSelection);
+  }
+
+  protected _mainAreaWidget: Widget | null = null;
+  protected _selection = '';
+  protected _selectionChanged = new Signal<this, string>(this);
+}

--- a/packages/jupyter-ai/src/theme-provider.ts
+++ b/packages/jupyter-ai/src/theme-provider.ts
@@ -4,7 +4,14 @@ function getCSSVariable(name: string): string {
   return getComputedStyle(document.body).getPropertyValue(name).trim();
 }
 
-export function getJupyterLabTheme(): Theme {
+export async function pollUntilReady(): Promise<void> {
+  while (!document.body.hasAttribute('data-jp-theme-light')) {
+    await new Promise(resolve => setTimeout(resolve, 100)); // Wait 100ms
+  }
+}
+
+export async function getJupyterLabTheme(): Promise<Theme> {
+  await pollUntilReady();
   const light = document.body.getAttribute('data-jp-theme-light');
   return createTheme({
     spacing: 4,

--- a/packages/jupyter-ai/src/utils.ts
+++ b/packages/jupyter-ai/src/utils.ts
@@ -7,7 +7,7 @@ import { CodeEditor } from '@jupyterlab/codeeditor';
 import { Widget } from '@lumino/widgets';
 
 /**
- * Get text selection from the widget.
+ * Get text selection from an editor widget (DocumentWidget#content).
  */
 export function getTextSelection(widget: Widget): string {
   const editor = getEditor(widget);

--- a/packages/jupyter-ai/src/widgets/chat-sidebar.tsx
+++ b/packages/jupyter-ai/src/widgets/chat-sidebar.tsx
@@ -3,9 +3,12 @@ import { ReactWidget } from '@jupyterlab/apputils';
 
 import { Chat } from '../components/chat';
 import { psychologyIcon } from '../icons';
+import { SelectionWatcher } from '../selection-watcher';
 
-export function buildChatSidebar() {
-  const ChatWidget = ReactWidget.create(<Chat />);
+export function buildChatSidebar(selectionWatcher: SelectionWatcher) {
+  const ChatWidget = ReactWidget.create(
+    <Chat selectionWatcher={selectionWatcher} />
+  );
   ChatWidget.id = 'jupyter-ai::chat';
   ChatWidget.title.icon = psychologyIcon;
   ChatWidget.title.caption = 'Jupyter AI Chat'; // TODO: i18n

--- a/packages/jupyter-ai/src/widgets/chat-sidebar.tsx
+++ b/packages/jupyter-ai/src/widgets/chat-sidebar.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { ReactWidget } from '@jupyterlab/apputils';
+
+import { Chat } from '../components/chat';
+import { psychologyIcon } from '../icons';
+
+export function buildChatSidebar() {
+  const ChatWidget = ReactWidget.create(<Chat />);
+  ChatWidget.id = 'jupyter-ai::chat';
+  ChatWidget.title.icon = psychologyIcon;
+  ChatWidget.title.caption = 'Jupyter AI Chat'; // TODO: i18n
+  return ChatWidget;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,6 +2696,16 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/katex@^0.11.0":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@types/katex/-/katex-0.11.1.tgz#34de04477dcf79e2ef6c8d23b41a3d81f9ebeaf5"
+  integrity sha512-DUlIj2nk0YnJdlWgsFuVKcX27MLW0KbKmGVoUHmFr+74FYYNUDAaj9ZqTADvsbE8rfxuVmSFc7KczYn5Y09ozg==
+
+"@types/katex@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@types/katex/-/katex-0.16.0.tgz#0e640df3647fe237212be863e1f5111eb9754f93"
+  integrity sha512-hz+S3nV6Mym5xPbT9fnO8dDhBFQguMYpY0Ipxv06JMi1ORgnEM4M1ymWDUhUNer3ElLmT583opRo4RzxKmh9jw==
+
 "@types/mdast@^3.0.0":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.11.tgz#dc130f7e7d9306124286f6d6cee40cf4d14a3dc0"
@@ -4022,6 +4032,11 @@ commander@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+commander@^8.0.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 commander@~2.19.0:
   version "2.19.0"
@@ -5768,10 +5783,48 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hast-util-from-parse5@^7.0.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz#aecfef73e3ceafdfa4550716443e4eb7b02e22b0"
+  integrity sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/unist" "^2.0.0"
+    hastscript "^7.0.0"
+    property-information "^6.0.0"
+    vfile "^5.0.0"
+    vfile-location "^4.0.0"
+    web-namespaces "^2.0.0"
+
+hast-util-is-element@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-2.1.3.tgz#cd3279cfefb70da6d45496068f020742256fc471"
+  integrity sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/unist" "^2.0.0"
+
 hast-util-parse-selector@^2.0.0:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
   integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
+
+hast-util-parse-selector@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz#25ab00ae9e75cbc62cf7a901f68a247eade659e2"
+  integrity sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==
+  dependencies:
+    "@types/hast" "^2.0.0"
+
+hast-util-to-text@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/hast-util-to-text/-/hast-util-to-text-3.1.2.tgz#ecf30c47141f41e91a5d32d0b1e1859fd2ac04f2"
+  integrity sha512-tcllLfp23dJJ+ju5wCCZHVpzsQQ43+moJbqVX3jNWPB7z/KFC4FyZD6R7y94cHL6MQ33YtMZL8Z0aIXXI4XFTw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/unist" "^2.0.0"
+    hast-util-is-element "^2.0.0"
+    unist-util-find-after "^4.0.0"
 
 hast-util-whitespace@^2.0.0:
   version "2.0.1"
@@ -5788,6 +5841,17 @@ hastscript@^6.0.0:
     hast-util-parse-selector "^2.0.0"
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
+
+hastscript@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-7.2.0.tgz#0eafb7afb153d047077fa2a833dc9b7ec604d10b"
+  integrity sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^3.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
 
 he@1.2.x:
   version "1.2.0"
@@ -7099,6 +7163,20 @@ just-diff@^5.0.1:
   resolved "https://registry.yarnpkg.com/just-diff/-/just-diff-5.2.0.tgz#60dca55891cf24cd4a094e33504660692348a241"
   integrity sha512-6ufhP9SHjb7jibNFrNxyFZ6od3g+An6Ai9mhGRvcYe8UJlH0prseN64M+6ZBBUoKYHZsitDP42gAJ8+eVWr3lw==
 
+katex@^0.15.0:
+  version "0.15.6"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.15.6.tgz#c4e2f6ced2ac4de1ef6f737fe7c67d3026baa0e5"
+  integrity sha512-UpzJy4yrnqnhXvRPhjEuLA4lcPn6eRngixW7Q3TJErjg3Aw2PuLFBzTkdUb89UtumxjhHTqL3a5GDGETMSwgJA==
+  dependencies:
+    commander "^8.0.0"
+
+katex@^0.16.0:
+  version "0.16.4"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.4.tgz#87021bc3bbd80586ef715aeb476794cba6a49ad4"
+  integrity sha512-WudRKUj8yyBeVDI4aYMNxhx5Vhh2PjpzQw1GRu/LVGqL4m1AxwD1GcUp0IMbdJaf5zsjtj8ghP0DOQRYhroNkw==
+  dependencies:
+    commander "^8.0.0"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -7464,6 +7542,11 @@ log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
+longest-streak@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
+  integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -7637,6 +7720,23 @@ mdast-util-from-markdown@^1.0.0:
     unist-util-stringify-position "^3.0.0"
     uvu "^0.5.0"
 
+mdast-util-math@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-math/-/mdast-util-math-2.0.2.tgz#19a06a81f31643f48cc805e7c31edb7ce739242c"
+  integrity sha512-8gmkKVp9v6+Tgjtq6SYx9kGPpTf6FVYRa53/DLh479aldR9AyP48qeVOgNZ5X7QUK7nOy4yw7vg6mbiGcs9jWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    longest-streak "^3.0.0"
+    mdast-util-to-markdown "^1.3.0"
+
+mdast-util-phrasing@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz#c7c21d0d435d7fb90956038f02e8702781f95463"
+  integrity sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    unist-util-is "^5.0.0"
+
 mdast-util-to-hast@^12.1.0:
   version "12.3.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz#045d2825fb04374e59970f5b3f279b5700f6fb49"
@@ -7651,7 +7751,21 @@ mdast-util-to-hast@^12.1.0:
     unist-util-position "^4.0.0"
     unist-util-visit "^4.0.0"
 
-mdast-util-to-string@^3.1.0:
+mdast-util-to-markdown@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz#c13343cb3fc98621911d33b5cd42e7d0731171c6"
+  integrity sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    longest-streak "^3.0.0"
+    mdast-util-phrasing "^3.0.0"
+    mdast-util-to-string "^3.0.0"
+    micromark-util-decode-string "^1.0.0"
+    unist-util-visit "^4.0.0"
+    zwitch "^2.0.0"
+
+mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz#66f7bb6324756741c5f47a53557f0cbf16b6f789"
   integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
@@ -7728,6 +7842,19 @@ micromark-core-commonmark@^1.0.1:
     micromark-util-subtokenize "^1.0.0"
     micromark-util-symbol "^1.0.0"
     micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
+
+micromark-extension-math@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-math/-/micromark-extension-math-2.1.0.tgz#15ec67f8a3d6de64428d6eb456b0b00a77402f3b"
+  integrity sha512-WH+fJkveMvM3ZN+deb/jT3UW623x8xO9ycfJNDC+UQXX+V72RO6hT9KqxA7c8XFwozAFJ7tufOeG+x/CVSXHUw==
+  dependencies:
+    "@types/katex" "^0.16.0"
+    katex "^0.16.0"
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
     uvu "^0.5.0"
 
 micromark-factory-destination@^1.0.0:
@@ -8852,7 +8979,7 @@ parse-url@^8.1.0:
   dependencies:
     parse-path "^7.0.0"
 
-parse5@6.0.1:
+parse5@6.0.1, parse5@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
@@ -9569,10 +9696,44 @@ regjsparser@^0.9.1:
   dependencies:
     jsesc "~0.5.0"
 
+rehype-katex@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/rehype-katex/-/rehype-katex-6.0.2.tgz#20197bbc10bdf79f6b999bffa6689d7f17226c35"
+  integrity sha512-C4gDAlS1+l0hJqctyiU64f9CvT00S03qV1T6HiMzbSuLBgWUtcqydWHY9OpKrm0SpkK16FNd62CDKyWLwV2ppg==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/katex" "^0.11.0"
+    hast-util-to-text "^3.1.0"
+    katex "^0.15.0"
+    rehype-parse "^8.0.0"
+    unified "^10.0.0"
+    unist-util-remove-position "^4.0.0"
+    unist-util-visit "^4.0.0"
+
+rehype-parse@^8.0.0:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-8.0.4.tgz#3d17c9ff16ddfef6bbcc8e6a25a99467b482d688"
+  integrity sha512-MJJKONunHjoTh4kc3dsM1v3C9kGrrxvA3U8PxZlP2SjH8RNUSrb+lF7Y0KVaUDnGH2QZ5vAn7ulkiajM9ifuqg==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    hast-util-from-parse5 "^7.0.0"
+    parse5 "^6.0.0"
+    unified "^10.0.0"
+
 relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
+
+remark-math@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/remark-math/-/remark-math-5.1.1.tgz#459e798d978d4ca032e745af0bac81ddcdf94964"
+  integrity sha512-cE5T2R/xLVtfFI4cCePtiRn+e6jKMtFDR3P8V3qpv8wpKjwvHoBA4eJzvX+nVrnlNy0911bdGmuspCSwetfYHw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-math "^2.0.0"
+    micromark-extension-math "^2.0.0"
+    unified "^10.0.0"
 
 remark-parse@^10.0.0:
   version "10.0.1"
@@ -10911,6 +11072,14 @@ unique-slug@^3.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+unist-util-find-after@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-find-after/-/unist-util-find-after-4.0.1.tgz#80c69c92b0504033638ce11973f4135f2c822e2d"
+  integrity sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
 unist-util-generated@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-2.0.1.tgz#e37c50af35d3ed185ac6ceacb6ca0afb28a85cae"
@@ -10929,6 +11098,14 @@ unist-util-position@^4.0.0:
   integrity sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==
   dependencies:
     "@types/unist" "^2.0.0"
+
+unist-util-remove-position@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-4.0.2.tgz#a89be6ea72e23b1a402350832b02a91f6a9afe51"
+  integrity sha512-TkBb0HABNmxzAcfLf4qsIbFbaPDvMO6wa3b3j4VcEzFVaw1LBKwnW4/sRJ/atSLSzoIg41JWEdnE7N6DIhGDGQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-visit "^4.0.0"
 
 unist-util-stringify-position@^3.0.0:
   version "3.0.3"
@@ -11128,6 +11305,14 @@ validate.io-number@^1.0.3:
   resolved "https://registry.yarnpkg.com/validate.io-number/-/validate.io-number-1.0.3.tgz#f63ffeda248bf28a67a8d48e0e3b461a1665baf8"
   integrity sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==
 
+vfile-location@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-4.1.0.tgz#69df82fb9ef0a38d0d02b90dd84620e120050dd0"
+  integrity sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    vfile "^5.0.0"
+
 vfile-message@^3.0.0:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.1.4.tgz#15a50816ae7d7c2d1fa87090a7f9f96612b59dea"
@@ -11193,6 +11378,11 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+web-namespaces@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
@@ -11626,3 +11816,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zwitch@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
+  integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2605,6 +2605,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/debug@^4.0.0":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/dom4@^2.0.1":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.2.tgz#6495303f049689ce936ed328a3e5ede9c51408ee"
@@ -2643,6 +2650,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hast@^2.0.0":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"
+  integrity sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -2675,6 +2689,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/mdast@^3.0.0":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.11.tgz#dc130f7e7d9306124286f6d6cee40cf4d14a3dc0"
+  integrity sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -2684,6 +2705,11 @@
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*":
   version "18.13.0"
@@ -2705,7 +2731,7 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
   integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
 
-"@types/prop-types@*", "@types/prop-types@^15.7.5":
+"@types/prop-types@*", "@types/prop-types@^15.0.0", "@types/prop-types@^15.7.5":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
@@ -2756,6 +2782,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/unist@*", "@types/unist@^2.0.0":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
+  integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
 "@types/webpack-sources@^0.1.5":
   version "0.1.9"
@@ -3418,6 +3449,11 @@ babel-preset-jest@^26.6.2:
     babel-plugin-jest-hoist "^26.6.2"
     babel-preset-current-node-syntax "^1.0.0"
 
+bail@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -3719,6 +3755,11 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
+character-entities@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -3927,6 +3968,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
+  integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
 commander@2.17.x:
   version "2.17.1"
@@ -4251,7 +4297,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.3, debug@^4.3.4:
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -4287,6 +4333,13 @@ decimal.js@^10.2.1:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
+
+decode-named-character-reference@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz#daabac9690874c394c81e4162a0304b35d824f0e"
+  integrity sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==
+  dependencies:
+    character-entities "^2.0.0"
 
 decode-uri-component@^0.2.0:
   version "0.2.2"
@@ -4390,6 +4443,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+dequal@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
@@ -4412,6 +4470,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -4977,6 +5040,11 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   dependencies:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
+
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 external-editor@^3.0.3:
   version "3.1.0"
@@ -5654,6 +5722,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hast-util-whitespace@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz#0ec64e257e6fc216c7d14c8a1b74d27d650b4557"
+  integrity sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==
+
 he@1.2.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -5911,6 +5984,11 @@ init-package-json@3.0.2, init-package-json@^3.0.2:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^4.0.0"
 
+inline-style-parser@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
+
 inquirer@^8.2.4:
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
@@ -6006,6 +6084,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
@@ -6147,6 +6230,11 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
+
+is-plain-obj@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -6950,6 +7038,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+kleur@^4.0.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
+  integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
+
 known-css-properties@^0.26.0:
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.26.0.tgz#008295115abddc045a9f4ed7e2a84dc8b3a77649"
@@ -7419,6 +7512,54 @@ mathml-tag-names@^2.1.3:
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
   integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
 
+mdast-util-definitions@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz#9910abb60ac5d7115d6819b57ae0bcef07a3f7a7"
+  integrity sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    unist-util-visit "^4.0.0"
+
+mdast-util-from-markdown@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.0.tgz#0214124154f26154a2b3f9d401155509be45e894"
+  integrity sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    mdast-util-to-string "^3.1.0"
+    micromark "^3.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-decode-string "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    unist-util-stringify-position "^3.0.0"
+    uvu "^0.5.0"
+
+mdast-util-to-hast@^12.1.0:
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz#045d2825fb04374e59970f5b3f279b5700f6fb49"
+  integrity sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    mdast-util-definitions "^5.0.0"
+    micromark-util-sanitize-uri "^1.1.0"
+    trim-lines "^3.0.0"
+    unist-util-generated "^2.0.0"
+    unist-util-position "^4.0.0"
+    unist-util-visit "^4.0.0"
+
+mdast-util-to-string@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz#66f7bb6324756741c5f47a53557f0cbf16b6f789"
+  integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+
 memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
@@ -7468,6 +7609,201 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromark-core-commonmark@^1.0.1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz#edff4c72e5993d93724a3c206970f5a15b0585ad"
+  integrity sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-factory-destination "^1.0.0"
+    micromark-factory-label "^1.0.0"
+    micromark-factory-space "^1.0.0"
+    micromark-factory-title "^1.0.0"
+    micromark-factory-whitespace "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-classify-character "^1.0.0"
+    micromark-util-html-tag-name "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
+
+micromark-factory-destination@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz#fef1cb59ad4997c496f887b6977aa3034a5a277e"
+  integrity sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-label@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz#6be2551fa8d13542fcbbac478258fb7a20047137"
+  integrity sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-factory-space@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz#cebff49968f2b9616c0fcb239e96685cb9497633"
+  integrity sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-title@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz#7e09287c3748ff1693930f176e1c4a328382494f"
+  integrity sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-factory-whitespace@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz#e991e043ad376c1ba52f4e49858ce0794678621c"
+  integrity sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-character@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-1.1.0.tgz#d97c54d5742a0d9611a68ca0cd4124331f264d86"
+  integrity sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-chunked@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz#5b40d83f3d53b84c4c6bce30ed4257e9a4c79d06"
+  integrity sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-classify-character@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz#cbd7b447cb79ee6997dd274a46fc4eb806460a20"
+  integrity sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-combine-extensions@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz#91418e1e74fb893e3628b8d496085639124ff3d5"
+  integrity sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-decode-numeric-character-reference@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz#dcc85f13b5bd93ff8d2868c3dba28039d490b946"
+  integrity sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-decode-string@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz#942252ab7a76dec2dbf089cc32505ee2bc3acf02"
+  integrity sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-encode@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz#2c1c22d3800870ad770ece5686ebca5920353383"
+  integrity sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==
+
+micromark-util-html-tag-name@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz#eb227118befd51f48858e879b7a419fc0df20497"
+  integrity sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==
+
+micromark-util-normalize-identifier@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz#4a3539cb8db954bbec5203952bfe8cedadae7828"
+  integrity sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-resolve-all@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz#a7c363f49a0162e931960c44f3127ab58f031d88"
+  integrity sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==
+  dependencies:
+    micromark-util-types "^1.0.0"
+
+micromark-util-sanitize-uri@^1.0.0, micromark-util-sanitize-uri@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz#f12e07a85106b902645e0364feb07cf253a85aee"
+  integrity sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-subtokenize@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz#ff6f1af6ac836f8bfdbf9b02f40431760ad89105"
+  integrity sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-util-symbol@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz#b90344db62042ce454f351cf0bebcc0a6da4920e"
+  integrity sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==
+
+micromark-util-types@^1.0.0, micromark-util-types@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-1.0.2.tgz#f4220fdb319205812f99c40f8c87a9be83eded20"
+  integrity sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==
+
+micromark@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.1.0.tgz#eeba0fe0ac1c9aaef675157b52c166f125e89f62"
+  integrity sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    micromark-core-commonmark "^1.0.1"
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-combine-extensions "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
 
 micromatch@^3.1.4:
   version "3.1.10"
@@ -7660,6 +7996,11 @@ moment@^2.24.0:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
+mri@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
 ms@2.0.0:
   version "2.0.0"
@@ -8675,7 +9016,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8683,6 +9024,11 @@ prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+property-information@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.2.0.tgz#b74f522c31c097b5149e3c3cb8d7f3defd986a1d"
+  integrity sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -8794,7 +9140,7 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^18.2.0:
+react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
@@ -8803,6 +9149,27 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-markdown@^8.0.6:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-8.0.6.tgz#3e939018f8bfce800ffdf22cf50aba3cdded7ad1"
+  integrity sha512-KgPWsYgHuftdx510wwIzpwf+5js/iHqBR+fzxefv8Khk3mFbnioF1bmL2idHN3ler0LMQmICKeDrWnZrX9mtbQ==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/prop-types" "^15.0.0"
+    "@types/unist" "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^2.0.0"
+    prop-types "^15.0.0"
+    property-information "^6.0.0"
+    react-is "^18.0.0"
+    remark-parse "^10.0.0"
+    remark-rehype "^10.0.0"
+    space-separated-tokens "^2.0.0"
+    style-to-object "^0.4.0"
+    unified "^10.0.0"
+    unist-util-visit "^4.0.0"
+    vfile "^5.0.0"
 
 react-popper@^1.3.7:
   version "1.3.11"
@@ -9060,6 +9427,25 @@ relateurl@0.2.x:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
 
+remark-parse@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.1.tgz#6f60ae53edbf0cf38ea223fe643db64d112e0775"
+  integrity sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-from-markdown "^1.0.0"
+    unified "^10.0.0"
+
+remark-rehype@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-10.1.0.tgz#32dc99d2034c27ecaf2e0150d22a6dcccd9a6279"
+  integrity sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-hast "^12.1.0"
+    unified "^10.0.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -9184,6 +9570,13 @@ rxjs@^7.5.5:
   integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
   dependencies:
     tslib "^2.1.0"
+
+sade@^1.7.3:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
+  integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
+  dependencies:
+    mri "^1.1.0"
 
 safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -9536,6 +9929,11 @@ source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
+space-separated-tokens@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
+  integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
+
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -9742,6 +10140,13 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
+
+style-to-object@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.4.1.tgz#53cf856f7cf7f172d72939d9679556469ba5de37"
+  integrity sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==
+  dependencies:
+    inline-style-parser "0.1.1"
 
 stylelint-config-prettier@^9.0.4:
   version "9.0.5"
@@ -10102,10 +10507,20 @@ treeverse@^2.0.0:
   resolved "https://registry.yarnpkg.com/treeverse/-/treeverse-2.0.0.tgz#036dcef04bc3fd79a9b79a68d4da03e882d8a9ca"
   integrity sha512-N5gJCkLu1aXccpOTtqV6ddSEi6ZmGkh3hjmbu1IjcavJK4qyOVQmi0myQKM7z5jVGmD68SJoliaVrMmVObhj6A==
 
+trim-lines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
+
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+
+trough@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
+  integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
 
 ts-jest@^26.0.0, ts-jest@^26.3.0:
   version "26.5.6"
@@ -10293,6 +10708,19 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
+unified@^10.0.0:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.2.tgz#b1d64e55dafe1f0b98bb6c719881103ecf6c86df"
+  integrity sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    bail "^2.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^5.0.0"
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -10330,6 +10758,49 @@ unique-slug@^3.0.0:
   integrity sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==
   dependencies:
     imurmurhash "^0.1.4"
+
+unist-util-generated@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-2.0.1.tgz#e37c50af35d3ed185ac6ceacb6ca0afb28a85cae"
+  integrity sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==
+
+unist-util-is@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.2.1.tgz#b74960e145c18dcb6226bc57933597f5486deae9"
+  integrity sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-position@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-4.0.4.tgz#93f6d8c7d6b373d9b825844645877c127455f037"
+  integrity sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-stringify-position@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz#03ad3348210c2d930772d64b489580c13a7db39d"
+  integrity sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-visit-parents@^5.1.1:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz#b4520811b0ca34285633785045df7a8d6776cfeb"
+  integrity sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
+unist-util-visit@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.2.tgz#125a42d1eb876283715a3cb5cceaa531828c72e2"
+  integrity sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.1.1"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"
@@ -10429,6 +10900,16 @@ uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uvu@^0.5.0:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.6.tgz#2754ca20bcb0bb59b64e9985e84d2e81058502df"
+  integrity sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==
+  dependencies:
+    dequal "^2.0.0"
+    diff "^5.0.0"
+    kleur "^4.0.3"
+    sade "^1.7.3"
+
 v8-compile-cache@2.3.0, v8-compile-cache@^2.0.3, v8-compile-cache@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
@@ -10494,6 +10975,24 @@ validate.io-number@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/validate.io-number/-/validate.io-number-1.0.3.tgz#f63ffeda248bf28a67a8d48e0e3b461a1665baf8"
   integrity sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==
+
+vfile-message@^3.0.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.1.4.tgz#15a50816ae7d7c2d1fa87090a7f9f96612b59dea"
+  integrity sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+
+vfile@^5.0.0:
+  version "5.3.7"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.3.7.tgz#de0677e6683e3380fafc46544cfe603118826ab7"
+  integrity sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+    vfile-message "^3.0.0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,6 +903,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.3.1":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.3.3":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -2743,6 +2750,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-syntax-highlighter@^15.5.6":
+  version "15.5.6"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.6.tgz#77c95e6b74d2be23208fcdcf187b93b47025f1b1"
+  integrity sha512-i7wFuLbIAFlabTeD2I1cLjEOrG/xdMa/rpx2zwzAoGHuXJDhSqp9BSfDlMHSh9JSuNfxHk9eEmMX6D55GiyjGg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.5":
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
@@ -3755,10 +3769,25 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
 character-entities@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
   integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -3968,6 +3997,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
+  integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
 comma-separated-tokens@^2.0.0:
   version "2.0.3"
@@ -5128,6 +5162,13 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fault@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
+  integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
+  dependencies:
+    format "^0.2.0"
+
 fb-watchman@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.2.tgz#e9524ee6b5c77e9e5001af0f85f3adbb8623255c"
@@ -5262,6 +5303,11 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -5722,15 +5768,36 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hast-util-parse-selector@^2.0.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
+  integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
+
 hast-util-whitespace@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz#0ec64e257e6fc216c7d14c8a1b74d27d650b4557"
   integrity sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==
 
+hastscript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-6.0.0.tgz#e8768d7eac56c3fdeac8a92830d58e811e5bf640"
+  integrity sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+
 he@1.2.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+highlight.js@^10.4.1, highlight.js@~10.7.0:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
@@ -6043,6 +6110,19 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arguments@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
@@ -6130,6 +6210,11 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
+
 is-descriptor@^0.1.0:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
@@ -6186,6 +6271,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
 is-interactive@^1.0.0:
   version "1.0.0"
@@ -7385,6 +7475,14 @@ lower-case@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==
+
+lowlight@^1.17.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.20.0.tgz#ddb197d33462ad0d93bf19d17b6c301aa3941888"
+  integrity sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==
+  dependencies:
+    fault "^1.0.0"
+    highlight.js "~10.7.0"
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -8705,6 +8803,18 @@ parse-conflict-json@^2.0.1:
     just-diff "^5.0.1"
     just-diff-apply "^5.2.0"
 
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -8953,6 +9063,16 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
+prismjs@^1.27.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
+  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
+prismjs@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
+
 private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -9024,6 +9144,13 @@ prop-types@^15.0.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, 
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+property-information@^5.0.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
+  integrity sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==
+  dependencies:
+    xtend "^4.0.0"
 
 property-information@^6.0.0:
   version "6.2.0"
@@ -9183,6 +9310,17 @@ react-popper@^1.3.7:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-syntax-highlighter@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz#4b3eccc2325fa2ec8eff1e2d6c18fa4a9e07ab20"
+  integrity sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "^10.4.1"
+    lowlight "^1.17.0"
+    prismjs "^1.27.0"
+    refractor "^3.6.0"
 
 react-transition-group@^2.9.0:
   version "2.9.0"
@@ -9356,6 +9494,15 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+refractor@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
+  integrity sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==
+  dependencies:
+    hastscript "^6.0.0"
+    parse-entities "^2.0.0"
+    prismjs "~1.27.0"
 
 regenerate-unicode-properties@^10.1.0:
   version "10.1.0"
@@ -9928,6 +10075,11 @@ source-map@^0.7.3:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
+
+space-separated-tokens@^1.0.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
+  integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
 
 space-separated-tokens@^2.0.0:
   version "2.0.2"
@@ -11333,7 +11485,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
# Description

Implements a basic Chat UI on the right sidebar to interact with chat models (currently just ChatGPT). This does **not** use the WebSockets handler implemented in #40, and instead calls a temporary REST API endpoint for now. Integration with #40 requires further work, as switching chat providers from `langchain.llms.openai` to `langchain.chat_models.openai` causes the magics to break. The implementation details of how to handle selection replacement in a multi-user scenario are still too ambiguous at this moment.

Features include:

- Chat UI in the right sidebar
- Selection inclusion & replacement
- Math rendering
- Code rendering

# Demo

https://user-images.githubusercontent.com/44106031/230704575-496d3fcc-08d4-4d15-8220-bc0771d245af.mov

# Next steps

- Shift-Enter to send, helper text on send button to inform users
- Migrate to use WebSockets handlers