### PR TITLE
Magic tweaks

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/magics.py
+++ b/packages/jupyter-ai/jupyter_ai/magics.py
@@ -1,5 +1,6 @@
 import os
 import json
+import warnings
 from typing import Optional
 from importlib_metadata import entry_points
 
@@ -40,6 +41,11 @@ class AiMagics(Magics):
     def __init__(self, shell):
         super(AiMagics, self).__init__(shell)
         self.transcript_openai = []
+
+        # suppress warning when using old OpenAIChat provider
+        warnings.filterwarnings("ignore", message="You are trying to use a chat model. This way of initializing it is "
+            "no longer supported. Instead, please use: "
+            "`from langchain.chat_models import ChatOpenAI`")
 
         # load model providers from entry point
         self.providers = {}

--- a/packages/jupyter-ai/jupyter_ai/magics.py
+++ b/packages/jupyter-ai/jupyter_ai/magics.py
@@ -2,13 +2,14 @@ import os
 import json
 import warnings
 from typing import Optional
-from importlib_metadata import entry_points
 
-from jupyter_ai.providers import BaseProvider
+from importlib_metadata import entry_points
 from IPython import get_ipython
 from IPython.core.magic import Magics, magics_class, line_cell_magic
 from IPython.core.magic_arguments import magic_arguments, argument, parse_argstring
-from IPython.display import display, HTML, Markdown, Math, JSON
+from IPython.display import HTML, Markdown, Math, JSON
+
+from jupyter_ai.providers import BaseProvider
 
 
 MODEL_ID_ALIASES = {
@@ -130,7 +131,7 @@ class AiMagics(Magics):
         provider_id, local_model_id = self._decompose_model_id(args.model_id)
         Provider = self._get_provider(provider_id)
         if Provider is None:
-            return display(f"Cannot determine model provider from model ID {args.model_id}.")
+            return f"Cannot determine model provider from model ID {args.model_id}."
 
         # if `--reset` is specified, reset transcript and return early
         if (provider_id == "openai-chat" and args.reset):
@@ -174,4 +175,4 @@ class AiMagics(Magics):
         output_display = DisplayClass(output)
 
         # finally, display output display
-        return display(output_display)
+        return output_display

--- a/packages/jupyter-ai/jupyter_ai/magics.py
+++ b/packages/jupyter-ai/jupyter_ai/magics.py
@@ -25,6 +25,7 @@ DISPLAYS_BY_FORMAT = {
     "math": Math,
     "md": Markdown,
     "json": JSON,
+    "raw": None
 }
 
 class FormatDict(dict):
@@ -104,7 +105,7 @@ class AiMagics(Magics):
                 optionally prefixed with the ID of the model provider, delimited
                 by a colon.""")
     @argument('-f', '--format',
-                choices=["markdown", "html", "json", "math", "md"],
+                choices=["markdown", "html", "json", "math", "md", "raw"],
                 nargs="?",
                 default="markdown",
                 help="""IPython display to use when rendering output. [default="markdown"]""")
@@ -169,6 +170,8 @@ class AiMagics(Magics):
 
         # build output display
         DisplayClass = DISPLAYS_BY_FORMAT[args.format]
+        if DisplayClass is None:
+            return output
         if args.format == 'json':
             # JSON display expects a dict, not a JSON string
             output = json.loads(output)


### PR DESCRIPTION
- Suppress warning when using `openai-chat` models via magics
- do not call `IPython.display.display()` when displaying output
  - Required so you can reference output cells from magics via `Out[*]`
- add `raw` format for debugging