### PR TITLE
Various magic enhancements and fixes

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -11,14 +11,15 @@ in environment variables, and you will have to install relevant Python packages 
 You can find the environment variables you need to set, and the Python packages you need, in
 [`packages/jupyter-ai/jupyter_ai/providers.py`](https://github.com/jupyterlab/jupyter-ai/blob/main/packages/jupyter-ai/jupyter_ai/providers.py).
 
-| Provider    | Environment variable       | Python package(s) |
-| ------------| -------------------------- | -------------- |
-| AI21        | `AI21_API_KEY`             | `ai21`         |
-| Anthropic   | `ANTHROPIC_API_KEY`        | `anthropic`    |
-| Cohere      | `COHERE_API_KEY`           | `cohere`       |
-| HuggingFace | `HUGGINGFACEHUB_API_TOKEN` | `huggingface_hub`, `ipywidgets` |
-| OpenAI      | `OPENAI_API_KEY`           | `openai`       |
-| SageMaker   | N/A                        | `boto3`        |
+| Provider            | Provider ID          | Environment variable       | Python package(s)               |
+|---------------------|----------------------|----------------------------|---------------------------------|
+| AI21                | `ai21`               | `AI21_API_KEY`             | `ai21`                          |
+| Anthropic           | `anthropic`          | `ANTHROPIC_API_KEY`        | `anthropic`                     |
+| Cohere              | `cohere`             | `COHERE_API_KEY`           | `cohere`                        |
+| HuggingFace Hub     | `huggingface_hub`    | `HUGGINGFACEHUB_API_TOKEN` | `huggingface_hub`, `ipywidgets` |
+| OpenAI              | `openai`             | `OPENAI_API_KEY`           | `openai`                        |
+| OpenAI (chat)       | `openai-chat`        | `OPENAI_API_KEY`           | `openai`                        |
+| SageMaker Endpoints | `sagemaker-endpoint` | N/A                        | `boto3`                         |
 
 To use SageMaker's models, you will need to authenticate via
 [boto3](https://github.com/boto/boto3).

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -58,6 +58,16 @@ test = [
     "pytest-tornasync"
 ]
 
+all = [
+    "ai21",
+    "anthropic",
+    "cohere",
+    "huggingface_hub",
+    "ipywidgets",
+    "openai",
+    "boto3"
+]
+
 [tool.hatch.version]
 source = "nodejs"
 


### PR DESCRIPTION
- Fix HF Hub provider not respecting the `model_id` kwarg
  - This is because weirdly enough, the `repo_id` attribute used by the upstream provider implementation is not resolved dynamically (i.e. self.repo_id is not accessed on model invocation); it is set statically in the constructor like so:

```py
@root_validator()
    def validate_environment(cls, values: Dict) -> Dict:
        """Validate that api key and python package exists in environment."""
        huggingfacehub_api_token = get_from_dict_or_env(
            values, "huggingfacehub_api_token", "HUGGINGFACEHUB_API_TOKEN"
        )
        try:
            from huggingface_hub.inference_api import InferenceApi

            repo_id = values["repo_id"]
            client = InferenceApi(
                repo_id=repo_id,
                token=huggingfacehub_api_token,
                task=values.get("task"),
            )
        ...
```

- Improve magics documentation
- Add `[all]` optional dependency group to easily install all model provider dependencies