### PR TITLE
Adds code format option

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -128,6 +128,7 @@ By default, Jupyter AI assumes that a model will output markdown, so the output 
 an `%%ai` command will be formatted as markdown by default. You can override this
 using the `-f` or `--format` argument to your magic command. Valid formats include:
 
+- `code`
 - `markdown`
 - `math`
 - `html`
@@ -147,6 +148,22 @@ will look like properly typeset equations.
 ```
 %%ai chatgpt -f math
 Generate the 2D heat equation in LaTeX surrounded by `$$`. Do not include an explanation.
+```
+
+This prompt will produce output as a code cell below the input cell. 
+
+:::{warning}
+:name: run-code
+**Please review any code that a generative AI model produces before you run it
+or distribute it.**
+The code that you get in response to a prompt may have negative side effects and may
+include calls to nonexistent (hallucinated) helper functions.
+:::
+
+```
+%%ai chatgpt -f code
+A function that computes the lowest common multiples of two integers, and
+a function that runs 5 test cases of the lowest common multiple function
 ```
 
 ### Interpolating IPython in prompts

--- a/examples/code.ipynb
+++ b/examples/code.ipynb
@@ -1,0 +1,130 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c7c709c4-0dbe-4f82-8ee6-f4cf2fd55b68",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%reload_ext jupyter_ai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f69abe97-654c-4e4a-8d18-575deca9c935",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%ai chatgpt --format code\n",
+    "A program that asks me for my name and then greets me by my name, in Polish"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a832d3be-7a0b-49bc-aaf6-da8a32a89285",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Jak masz na imię?  foo\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cześć foo!\n"
+     ]
+    }
+   ],
+   "source": [
+    "name = input(\"Jak masz na imię? \")\n",
+    "print(\"Cześć \" + name + \"!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7e187e37-9abd-4ed2-9959-fb3acdb3acfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%ai chatgpt --format code\n",
+    "A function that computes the lowest common multiples of two integers, and a function that runs 5 test cases of the lowest common multiple function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "555662c1-f576-4786-8dda-51ebe48c1d75",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def lcm(x, y):\n",
+    "    if x > y:\n",
+    "        greater = x\n",
+    "    else:\n",
+    "        greater = y\n",
+    "\n",
+    "    while True:\n",
+    "        if (greater % x == 0) and (greater % y == 0):\n",
+    "            lcm = greater\n",
+    "            break\n",
+    "        greater += 1\n",
+    "\n",
+    "    return lcm\n",
+    "\n",
+    "def test_lcm():\n",
+    "    assert lcm(3, 5) == 15\n",
+    "    assert lcm(7, 9) == 63\n",
+    "    assert lcm(18, 24) == 72\n",
+    "    assert lcm(10, 15) == 30\n",
+    "    assert lcm(12, 16) == 48\n",
+    "\n",
+    "test_lcm()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9978c08c-c0da-49dd-9e01-3b9d8c9e1a5e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Fixes #43.

Adds a `--format code` option that produces a new code cell after the input. The `%%ai` command returns no output if `--format code` is used.

![Screen Shot 2023-04-12 at 3 02 50 PM](https://user-images.githubusercontent.com/93281816/231597219-f77c9fa9-0873-42a9-a4b3-ef2fd5a0a685.png)


Adds a new example file. Updates docs.