### PR TITLE
Added doc indexing, moved processing to ray actors

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/actors.py
+++ b/packages/jupyter-ai/jupyter_ai/actors.py
@@ -1,9 +1,11 @@
+from enum import Enum
 import os
 import time
 from uuid import uuid4
 from jupyter_ai.models import AgentChatMessage, ChatMessage, HumanChatMessage
 from jupyter_ai_magics.providers import ChatOpenAINewProvider
-from langchain import ConversationChain
+from langchain import ConversationChain, OpenAI
+from langchain.chains import ConversationalRetrievalChain
 import ray
 from ray.util.queue import Queue
 from langchain.memory import ConversationBufferMemory
@@ -13,22 +15,136 @@ from langchain.prompts import (
     SystemMessagePromptTemplate, 
     HumanMessagePromptTemplate
 )
+from langchain.vectorstores import FAISS
+from langchain.embeddings.openai import OpenAIEmbeddings
+from langchain.document_loaders import DirectoryLoader, TextLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from jupyter_core.paths import jupyter_data_dir
 
+class ACTOR_TYPE(str, Enum):
+    DEFAULT = "default"
+    FILESYSTEM = "filesystem"
+    READ = 'read'
+
+COMMANDS = {
+    '/fs': ACTOR_TYPE.FILESYSTEM,
+    '/read': ACTOR_TYPE.READ
+}
 
 @ray.remote
 class Router():
-    def __init__(self, reply_queue: Queue):
-        pass
+    """Routes messages to the correct actor. To register 
+    new actors, add the actor type in the `ACTOR_TYPE` 
+    enum and then add a corresponding command in the 
+    `COMMANDS` dictionary.
+    """
+
+    def __init__(self, log):
+        self.log = log
+
+    def route_message(self, message):
+        
+        # assign default actor
+        actor = ray.get_actor(ACTOR_TYPE.DEFAULT)
+
+        if(message.body.startswith("/")):
+            command = message.body.split(' ', 1)[0]
+            if command in COMMANDS.keys():
+                actor = ray.get_actor(COMMANDS[command].value)
+        
+        actor.process_message.remote(message)
+
+
+@ray.remote
+class DocumentIndexActor():
+    def __init__(self, reply_queue: Queue, root_dir: str, log):
+        self.reply_queue = reply_queue
+        self.root_dir = root_dir
+        self.log = log
+        self.index_save_dir = os.path.join(jupyter_data_dir(), '.jupyter_ai_indexes')
+
+        if ChatOpenAINewProvider.auth_strategy.name not in os.environ:
+            return
+        
+        if not os.path.exists(self.index_save_dir):
+            os.makedirs(self.index_save_dir)
+
+        embeddings = OpenAIEmbeddings()
+        try:
+            self.index = FAISS.load_local(self.index_save_dir, embeddings)
+        except Exception as e:
+            self.index = FAISS.from_texts(["This is just starter text for the index"], embeddings)
+
+    def get_index(self):
+        return self.index
+
+    def process_message(self, message: HumanChatMessage):
+        dir_path = message.body.split(' ', 1)[-1]
+        load_path = os.path.join(self.root_dir, dir_path)
+        loader = DirectoryLoader(
+            load_path, 
+            glob="**/*.txt",
+            loader_cls=TextLoader
+        )
+        documents = loader.load_and_split(
+            text_splitter=RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=20)
+        )
+        self.index.add_documents(documents)
+        self.index.save_local(self.index_save_dir)
+
+        response = f"""🎉 I have read documents at **{dir_path}** and ready to answer questions. 
+        You can ask questions from these docs by prefixing your message with **/fs**."""
+        agent_message = AgentChatMessage(
+                id=uuid4().hex,
+                time=time.time(),
+                body=response,
+                reply_to=message.id
+            )
+        self.reply_queue.put(agent_message)
 
 
 @ray.remote
 class FileSystemActor():
+    """Processes messages prefixed with /fs. This actor will
+    send the message as input to a RetrieverQA chain, that
+    follows the Retrieval and Generation (RAG) tehnique to
+    query the documents from the index, and sends this context
+    to the LLM to generate the final reply.
+    """
+
     def __init__(self, reply_queue: Queue):
         self.reply_queue = reply_queue
+        index_actor = ray.get_actor(ACTOR_TYPE.READ.value)
+        handle = index_actor.get_index.remote()
+        vectorstore = ray.get(handle)
+        if not vectorstore:
+            return
 
-    def process_message(self, msg):
-        reply = f"FileSystemActor: Processed message {msg}"
-        self.reply_queue.put(reply)
+        self.chat_history = []
+        self.chat_provider = ConversationalRetrievalChain.from_llm(
+            OpenAI(temperature=0, verbose=True),
+            vectorstore.as_retriever()
+        )
+
+    def process_message(self, message: HumanChatMessage):
+        query = message.body.split(' ', 1)[-1]
+        
+        index_actor = ray.get_actor(ACTOR_TYPE.READ.value)
+        handle = index_actor.get_index.remote()
+        vectorstore = ray.get(handle)
+        # Have to reference the latest index
+        self.chat_provider.retriever = vectorstore.as_retriever()
+        
+        result = self.chat_provider({"question": query, "chat_history": self.chat_history})
+        reply = result['answer']
+        self.chat_history.append((query, reply)) 
+        agent_message = AgentChatMessage(
+            id=uuid4().hex,
+            time=time.time(),
+            body=reply,
+            reply_to=message.id
+        )
+        self.reply_queue.put(agent_message)
 
 @ray.remote
 class DefaultActor():

--- a/packages/jupyter-ai/jupyter_ai/actors.py
+++ b/packages/jupyter-ai/jupyter_ai/actors.py
@@ -14,6 +14,13 @@ from langchain.prompts import (
     HumanMessagePromptTemplate
 )
 
+
+@ray.remote
+class Router():
+    def __init__(self, reply_queue: Queue):
+        pass
+
+
 @ray.remote
 class FileSystemActor():
     def __init__(self, reply_queue: Queue):

--- a/packages/jupyter-ai/jupyter_ai/actors.py
+++ b/packages/jupyter-ai/jupyter_ai/actors.py
@@ -1,0 +1,62 @@
+import os
+import time
+from uuid import uuid4
+from jupyter_ai.models import AgentChatMessage, ChatMessage, HumanChatMessage
+from jupyter_ai_magics.providers import ChatOpenAINewProvider
+from langchain import ConversationChain
+import ray
+from ray.util.queue import Queue
+from langchain.memory import ConversationBufferMemory
+from langchain.prompts import (
+    ChatPromptTemplate, 
+    MessagesPlaceholder, 
+    SystemMessagePromptTemplate, 
+    HumanMessagePromptTemplate
+)
+
+@ray.remote
+class FileSystemActor():
+    def __init__(self, reply_queue: Queue):
+        self.reply_queue = reply_queue
+
+    def process_message(self, msg):
+        reply = f"FileSystemActor: Processed message {msg}"
+        self.reply_queue.put(reply)
+
+@ray.remote
+class DefaultActor():
+    def __init__(self, reply_queue: Queue):
+        # TODO: Should take the provider/model id as strings
+        
+        self.reply_queue = reply_queue
+        if ChatOpenAINewProvider.auth_strategy.name in os.environ:
+            provider = ChatOpenAINewProvider(model_id="gpt-3.5-turbo")
+            
+            # Create a conversation memory
+            memory = ConversationBufferMemory(return_messages=True)
+            prompt_template = ChatPromptTemplate.from_messages([
+                SystemMessagePromptTemplate.from_template("The following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know."),
+                MessagesPlaceholder(variable_name="history"),
+                HumanMessagePromptTemplate.from_template("{input}")
+            ])
+            chain = ConversationChain(
+                llm=provider, 
+                prompt=prompt_template,
+                verbose=True, 
+                memory=memory
+            )
+            self.chat_provider = chain
+
+    def process_message(self, message: HumanChatMessage):
+        if self.chat_provider:
+            response = self.chat_provider.predict(input=message.body)
+            agent_message = AgentChatMessage(
+                id=uuid4().hex,
+                time=time.time(),
+                body=response,
+                reply_to=message.id
+            )
+            self.reply_queue.put(agent_message)
+
+
+

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -102,13 +102,19 @@ class AiExtension(ExtensionApp):
         self.settings["reply_queue"] = reply_queue
 
         router = Router.options(name="router").remote(log=self.log)
-        default_actor = DefaultActor.options(name=ACTOR_TYPE.DEFAULT.value).remote(reply_queue)
-        index_actor = DocumentIndexActor.options(name=ACTOR_TYPE.READ.value).remote(
+        default_actor = DefaultActor.options(name=ACTOR_TYPE.DEFAULT.value).remote(
+            reply_queue=reply_queue, 
+            log=self.log
+        )
+        index_actor = DocumentIndexActor.options(name=ACTOR_TYPE.INDEX.value).remote(
             reply_queue=reply_queue,
             root_dir=self.serverapp.root_dir,
             log=self.log 
         )
-        fs_actor = FileSystemActor.options(name=ACTOR_TYPE.FILESYSTEM.value).remote(reply_queue)
+        fs_actor = FileSystemActor.options(name=ACTOR_TYPE.FILESYSTEM.value).remote(
+            reply_queue=reply_queue, 
+            log=self.log
+        )
         self.settings['router'] = router
         self.settings["default_actor"] = default_actor
         self.settings["index_actor"] = index_actor

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -247,9 +247,9 @@ class ChatHandler(
         # broadcast the message to other clients
         self.broadcast_message(message=chat_message)
 
-        # process through actors
-        actor = ray.get_actor("default")
-        actor.process_message.remote(chat_message)             
+        # process through the router
+        router = ray.get_actor("router")
+        router.route_message.remote(chat_message)
 
     def on_close(self):
         self.log.debug("Disconnecting client with user %s", self.client_id)

--- a/packages/jupyter-ai/jupyter_ai/reply_processor.py
+++ b/packages/jupyter-ai/jupyter_ai/reply_processor.py
@@ -7,9 +7,9 @@ from ray.util.queue import Queue
 class ReplyProcessor():
     """A single processor to distribute replies"""
 
-    def __init__(self, handlers: Dict[str, ChatHandler], reply_queue: Queue, log):
+    def __init__(self, handlers: Dict[str, ChatHandler], queue: Queue, log):
         self.handlers = handlers
-        self.reply_queue = reply_queue
+        self.queue = queue
         self.log = log
 
     def process(self, message):
@@ -23,7 +23,7 @@ class ReplyProcessor():
 
     async def start(self):
         while True:
-            if not self.reply_queue.empty():
-                self.process(self.reply_queue.get())
+            if not self.queue.empty():
+                self.process(self.queue.get())
             
             await asyncio.sleep(5)

--- a/packages/jupyter-ai/jupyter_ai/reply_processor.py
+++ b/packages/jupyter-ai/jupyter_ai/reply_processor.py
@@ -24,6 +24,6 @@ class ReplyProcessor():
     async def start(self):
         while True:
             if not self.queue.empty():
-                self.process(self.queue.get())
+                self.process(await self.queue.get_async())
             
             await asyncio.sleep(5)

--- a/packages/jupyter-ai/jupyter_ai/reply_processor.py
+++ b/packages/jupyter-ai/jupyter_ai/reply_processor.py
@@ -1,0 +1,29 @@
+import asyncio
+from typing import Dict
+from jupyter_ai.handlers import ChatHandler
+from ray.util.queue import Queue
+
+
+class ReplyProcessor():
+    """A single processor to distribute replies"""
+
+    def __init__(self, handlers: Dict[str, ChatHandler], reply_queue: Queue, log):
+        self.handlers = handlers
+        self.reply_queue = reply_queue
+        self.log = log
+
+    def process(self, message):
+        self.log.debug('Processing message %s in ReplyProcessor', message)
+        for handler in self.handlers.values():
+            if not handler:
+                continue
+            
+            handler.broadcast_message(message)
+            break
+
+    async def start(self):
+        while True:
+            if not self.reply_queue.empty():
+                self.process(self.reply_queue.get())
+            
+            await asyncio.sleep(5)

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "importlib_metadata~=5.2.0",
     "langchain~=0.0.115",
     "jupyter_ai_magics",
-    "ray==2.2.0" # latest ray version 2.3.0 requires grpcio installation from conda
+    "ray==2.2.0", # latest ray version 2.3.0 requires grpcio installation from conda
+    "faiss-cpu", # Not distributed by official repo
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "aiosqlite~=0.18",
     "importlib_metadata~=5.2.0",
     "langchain~=0.0.115",
-    "jupyter_ai_magics"
+    "jupyter_ai_magics",
+    "ray==2.2.0" # latest ray version 2.3.0 requires grpcio installation from conda
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]


### PR DESCRIPTION
## Summary
This PR moves the chat prediction code to distributed tasks using ray actors, this will allow non-blocking processing of chat requests. To process the replies, a `ReplyProcessor` has been added that that will distribute the replies from the chat provider. This PR also includes the ability to load the specified directories into a FAISS index, which can be used to ask questions pertaining to the loaded documents. Users can type `/index <dir-name>` in the chat to start loading the directories. They can then use the `/fs <question>` or `/filesystem <question>` to ask a question, which will switch to a RAG chain to get relevant context from the indexed documents.

### Demo
![chat-index-docs-1](https://user-images.githubusercontent.com/289369/232246153-5c04a414-1749-458a-a81c-2ac533b60d8c.gif)


### Tasks
- [x] Moved chat provider prediction to ray actors, allows non-blocking distributed tasks
- [x] Added a reply processor, single processor to distribute replies from actors, this was originally in the web socket 
- [x] Ability to index directories, users can index directories from chat by sending `/read <dir-name>`
- [x] Ability to chat with indexed directories, users can chat with indexed directories by sending `/fs <query>`
- [x] Save index to file, so users can ask questions about directories indexed in previous sessions
- [ ]  Add a menu item for indexing directories from the file browser
- [ ]  Add a data loader for faster directory indexing, explore dask or ray for this
- [ ]  Add loading for python, markdown and R files
- [ ]  Add sources in the reply
- [ ]  Some visual indication of what directories are indexed
- [ ]  Mechanism to reply to user if directory is already indexed, and take input from user if they want to update the index
 