### PR TITLE
Documents requirements to use Python 3.10, JupyterLab

### DIFF
--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -13,6 +13,11 @@ If you use `conda`, you can install Python 3.10 in your environment by running:
 conda install python=3.10
 ```
 
+You will also need to have a currently-maintained version of JupyterLab installed. If you use `conda`, you can install JupyterLab in your environment by running:
+
+```
+conda install jupyterlab
+```
 
 ## Development install
 

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -4,7 +4,15 @@ This page is intended for people interested in building new or modified function
 
 ## Prerequisites
 
-You can develop Jupyter AI on any system that can run a supported Python version, including recent Windows, macOS, and Linux versions. If you have not already done so, [download Python](https://www.python.org/downloads/) and install it. The commands below presume that you can run `python` and `pip` from your preferred terminal.
+You can develop Jupyter AI on any system that can run a supported Python version up to and including 3.10, including recent Windows, macOS, and Linux versions. Python 3.11 is **not supported** due
+to incompatibility with the [ray](https://pypi.org/project/ray/) library that we use.
+
+If you use `conda`, you can install Python 3.10 in your environment by running:
+
+```
+conda install python=3.10
+```
+
 
 ## Development install
 

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -13,7 +13,7 @@ If you use `conda`, you can install Python 3.10 in your environment by running:
 conda install python=3.10
 ```
 
-To use the `jupyter_ai` package in JupyterLab, as the development environment below does, you will need a currently-maintained version of JupyterLab. If you use `conda`, you can install JupyterLab in your environment by running:
+To use the `jupyter_ai` package in JupyterLab, as the development environment below does, you will need a currently-maintained version of JupyterLab 3. We do not yet support JupyterLab 4. If you use `conda`, you can install JupyterLab in your environment by running:
 
 ```
 conda install jupyterlab

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -13,7 +13,7 @@ If you use `conda`, you can install Python 3.10 in your environment by running:
 conda install python=3.10
 ```
 
-You will also need to have a currently-maintained version of JupyterLab installed. If you use `conda`, you can install JupyterLab in your environment by running:
+To use the `jupyter_ai` package in JupyterLab, as the development environment below does, you will need a currently-maintained version of JupyterLab. If you use `conda`, you can install JupyterLab in your environment by running:
 
 ```
 conda install jupyterlab

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -5,6 +5,17 @@ Welcome to the user documentation for Jupyter AI.
 If you are interested in contributing to Jupyter AI, 
 please see our {doc}`contributor's guide </contributors/index>`.
 
+## Prerequisites
+
+You will need a supported version of Python up to and including 3.10. Python 3.11 is **not supported** due
+to incompatibility with the [ray](https://pypi.org/project/ray/) library that we use.
+
+If you use `conda`, you can install Python 3.10 in your environment by running:
+
+```
+conda install python=3.10
+```
+
 ## Model providers
 
 Jupyter AI supports a wide range of model providers and models. To use Jupyter AI, you will need to 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -16,6 +16,12 @@ If you use `conda`, you can install Python 3.10 in your environment by running:
 conda install python=3.10
 ```
 
+You will also need to have a currently-maintained version of JupyterLab installed. If you use `conda`, you can install JupyterLab in your environment by running:
+
+```
+conda install jupyterlab
+```
+
 ## Model providers
 
 Jupyter AI supports a wide range of model providers and models. To use Jupyter AI, you will need to 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -16,11 +16,13 @@ If you use `conda`, you can install Python 3.10 in your environment by running:
 conda install python=3.10
 ```
 
-You will also need to have a currently-maintained version of JupyterLab installed. If you use `conda`, you can install JupyterLab in your environment by running:
+To use the `jupyter_ai` package, you will also need to have a currently-maintained version of JupyterLab installed. If you use `conda`, you can install JupyterLab in your environment by running:
 
 ```
 conda install jupyterlab
 ```
+
+You can use the `jupyter_ai_magics` package without JupyterLab, but you will need a compatible interface, such as [IPython](https://ipython.org/).
 
 ## Model providers
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -16,7 +16,7 @@ If you use `conda`, you can install Python 3.10 in your environment by running:
 conda install python=3.10
 ```
 
-To use the `jupyter_ai` package, you will also need to have a currently-maintained version of JupyterLab installed. If you use `conda`, you can install JupyterLab in your environment by running:
+To use the `jupyter_ai` package, you will also need to have a currently-maintained version of JupyterLab 3 installed. We do not yet support JupyterLab 4. If you use `conda`, you can install JupyterLab in your environment by running:
 
 ```
 conda install jupyterlab

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyter_ai"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.7,<=3.10"
+requires-python = ">=3.7,<3.11"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyter_ai"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.7,<=3.10"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
@@ -20,10 +20,10 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "jupyter_server>=1.6,<3",
+    "jupyterlab>=3.5,<4",
     "pydantic",
     "openai~=0.26",
     "aiosqlite~=0.18",


### PR DESCRIPTION
Fixes #73 by updating the `pyproject.toml` and documentation to instruct users to use Python 3.10, not 3.11, which may be installed by default. `ray` does not support Python 3.11, per its `pip` page.

Also explicitly mentions that JupyterLab is a prereq and a dependency of `jupyter_ai` (but not of `jupyter_ai_magics`).