### PR TITLE
Add a /clear command to clear the chat history

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/actors.py
+++ b/packages/jupyter-ai/jupyter_ai/actors.py
@@ -4,7 +4,7 @@ import os
 import time
 from typing import Union
 from uuid import uuid4
-from jupyter_ai.models import AgentChatMessage, ChatMessage, HumanChatMessage
+from jupyter_ai.models import AgentChatMessage, ChatMessage, HumanChatMessage, ClearMessage
 from jupyter_ai_magics.providers import ChatOpenAINewProvider
 from langchain import ConversationChain, OpenAI
 from langchain.chains import ConversationalRetrievalChain
@@ -43,21 +43,25 @@ class Router():
     add a corresponding command in the `COMMANDS` dictionary.
     """
 
-    def __init__(self, log: Logger):
+    def __init__(self, log: Logger, reply_queue: Queue):
         self.log = log
+        self.reply_queue = reply_queue
 
     def route_message(self, message):
         
         # assign default actor
-        actor = ray.get_actor(ACTOR_TYPE.DEFAULT)
+        default = ray.get_actor(ACTOR_TYPE.DEFAULT)
 
-        if(message.body.startswith("/")):
+        if message.body.startswith("/"):
             command = message.body.split(' ', 1)[0]
             if command in COMMANDS.keys():
                 actor = ray.get_actor(COMMANDS[command].value)
-                
-        
-        actor.process_message.remote(message)
+                actor.process_message.remote(message)
+            if command == '/clear':
+                reply_message = ClearMessage()
+                self.reply_queue.put(reply_message)
+        else:
+            default.process_message.remote(message)
 
 class BaseActor():
     """Base actor implemented by actors that are called by the `Router`"""

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -101,7 +101,10 @@ class AiExtension(ExtensionApp):
         reply_queue = Queue()
         self.settings["reply_queue"] = reply_queue
 
-        router = Router.options(name="router").remote(log=self.log)
+        router = Router.options(name="router").remote(
+            reply_queue=reply_queue,
+            log=self.log
+        )
         default_actor = DefaultActor.options(name=ACTOR_TYPE.DEFAULT.value).remote(
             reply_queue=reply_queue, 
             log=self.log

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -42,6 +42,9 @@ class ConnectionMessage(BaseModel):
     type: Literal["connection"] = "connection"
     client_id: str
 
+class ClearMessage(BaseModel):
+    type: Literal["clear"] = "clear"
+
 # the type of messages being broadcast to clients
 ChatMessage = Union[
     AgentChatMessage,
@@ -51,7 +54,8 @@ ChatMessage = Union[
 Message = Union[
     AgentChatMessage,
     HumanChatMessage,
-    ConnectionMessage
+    ConnectionMessage,
+    ClearMessage
 ]
 
 class ListEnginesEntry(BaseModel):

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -45,6 +45,9 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
     function handleChatEvents(message: AiService.Message) {
       if (message.type === 'connection') {
         return;
+      } else if (message.type === 'clear') {
+        setMessages([]);
+        return;
       }
 
       setMessages(messageGroups => [...messageGroups, message]);

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -46,7 +46,6 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
       if (message.type === 'connection') {
         return;
       } else if (message.type === 'clear') {
-        console.log('clearing messages');
         setMessages([]);
         return;
       }

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -46,6 +46,7 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
       if (message.type === 'connection') {
         return;
       } else if (message.type === 'clear') {
+        console.log('clearing messages');
         setMessages([]);
         return;
       }

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -98,8 +98,12 @@ export namespace AiService {
     client_id: string;
   };
 
+  export type ClearMessage = {
+    type: 'clear'
+  }
+
   export type ChatMessage = AgentChatMessage | HumanChatMessage;
-  export type Message = AgentChatMessage | HumanChatMessage | ConnectionMessage;
+  export type Message = AgentChatMessage | HumanChatMessage | ConnectionMessage | ClearMessage;
 
   export type ChatHistory = {
     messages: ChatMessage[];


### PR DESCRIPTION
This PR adds a /clear command that clears the chat history, but leaves the memory intact.