### PR TITLE
Removed sleep that was slowing replies down

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/reply_processor.py
+++ b/packages/jupyter-ai/jupyter_ai/reply_processor.py
@@ -23,7 +23,4 @@ class ReplyProcessor():
 
     async def start(self):
         while True:
-            if not self.queue.empty():
-                self.process(await self.queue.get_async())
-            
-            await asyncio.sleep(5)
+            self.process(await self.queue.get_async())


### PR DESCRIPTION
I have tested this and found that we don't need the extra sleep in the async loop for processing the reply_queue. This speeds up all replies by ~5s.