### PR TITLE
Error handling and messaging when the chat service doesn't work

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -81,16 +81,8 @@ class TaskAPIHandler(APIHandler):
 class ChatHistoryHandler(BaseAPIHandler):
     """Handler to return message history"""
 
-    _chat_provider = None  
     _messages = []
     
-    @property
-    def chat_provider(self):
-        actor = ray.get_actor("default")
-        self._chat_provider = actor.chat_provider
-            
-        return self._chat_provider
-
     @property
     def chat_history(self):
         return self.settings["chat_history"]
@@ -104,13 +96,6 @@ class ChatHistoryHandler(BaseAPIHandler):
         history = ChatHistory(messages=self.chat_history)
         self.finish(history.json())
 
-    @tornado.web.authenticated
-    async def delete(self):
-        self.chat_provider.memory.chat_memory.clear()
-        self.chat_history = []
-        self.set_status(204)
-        self.finish()
-
 
 class ChatHandler(
     JupyterHandler,
@@ -122,7 +107,6 @@ class ChatHandler(
 
     _chat_provider = None  
     _chat_message_queue = None 
-    _reply_queue = None
     
     @property
     def chat_message_queue(self):
@@ -150,13 +134,6 @@ class ChatHandler(
     @property
     def chat_history(self) -> List[ChatMessage]:
         return self.settings["chat_history"]
-    
-    @property
-    def reply_queue(self):
-        if not self._reply_queue:
-            self._reply_queue = self.settings["reply_queue"]
-
-        return self._reply_queue
 
     def initialize(self):
         self.log.debug("Initializing websocket connection %s", self.request.path)

--- a/packages/jupyter-ai/src/chat_handler.ts
+++ b/packages/jupyter-ai/src/chat_handler.ts
@@ -40,6 +40,7 @@ export class ChatHandler implements IDisposable {
         (token ? `?token=${encodeURIComponent(token)}` : '');
 
       const socket = (this._socket = new WebSocket(url));
+      socket.onerror = (e) => reject(e);
       socket.onmessage = msg =>
         msg.data && this._onMessage(JSON.parse(msg.data));
 

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -31,8 +31,13 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
    */
   useEffect(() => {
     async function fetchHistory() {
-      const history = await chatHandler.getHistory();
-      setMessages(history.messages);
+      try {
+        const history = await chatHandler.getHistory();
+        setMessages(history.messages);
+      } catch (e) {
+        
+      }
+      
     }
 
     fetchHistory();

--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -4,13 +4,14 @@ import {
   ILayoutRestorer
 } from '@jupyterlab/application';
 
-import { IWidgetTracker } from '@jupyterlab/apputils';
+import { IWidgetTracker, ReactWidget } from '@jupyterlab/apputils';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { IGlobalAwareness } from '@jupyterlab/collaboration';
 import type { Awareness } from 'y-protocols/awareness';
 import { buildChatSidebar } from './widgets/chat-sidebar';
 import { SelectionWatcher } from './selection-watcher';
 import { ChatHandler } from './chat_handler';
+import { buildErrorWidget } from './widgets/chat-error';
 
 export type DocumentTracker = IWidgetTracker<IDocumentWidget>;
 
@@ -35,10 +36,15 @@ const plugin: JupyterFrontEndPlugin<void> = {
      * Initialize chat handler, open WS connection
      */
     const chatHandler = new ChatHandler();
-    await chatHandler.initialize();
-
-    const chatWidget = buildChatSidebar(selectionWatcher, chatHandler, globalAwareness);
-
+    
+    let chatWidget: ReactWidget | null = null;
+    try {
+      await chatHandler.initialize();
+      chatWidget = buildChatSidebar(selectionWatcher, chatHandler, globalAwareness);
+    } catch (e) {
+      chatWidget = buildErrorWidget()
+    }
+   
     /**
      * Add Chat widget to right sidebar
      */

--- a/packages/jupyter-ai/src/widgets/chat-error.tsx
+++ b/packages/jupyter-ai/src/widgets/chat-error.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ReactWidget } from '@jupyterlab/apputils';
+
+import { chatIcon } from '../icons';
+import { Alert, Box } from '@mui/material';
+import { JlThemeProvider } from '../components/jl-theme-provider';
+
+export function buildErrorWidget() {
+    const ErrorWidget = ReactWidget.create(
+        <JlThemeProvider>
+            <Box
+                sx={{
+                    width: '100%',
+                    height: '100%',
+                    boxSizing: 'border-box',
+                    background: 'var(--jp-layout-color0)',
+                    display: 'flex',
+                    flexDirection: 'column'
+                }}
+            >
+                <Box sx={{ padding: 4 }}>
+                    <Alert severity="error">
+                        There seems to be a problem with the Chat backend, please look at the
+                        JupyterLab server logs or contact your administrator to correct this
+                        problem.
+                    </Alert>
+                </Box>
+            </Box>
+        </JlThemeProvider>
+    );
+    ErrorWidget.id = 'jupyter-ai::chat';
+    ErrorWidget.title.icon = chatIcon;
+    ErrorWidget.title.caption = 'Jupyter AI Chat'; // TODO: i18n
+    
+    return ErrorWidget
+}
+


### PR DESCRIPTION
Fixes #83 

- UI shows an error message in the chat widget if there is a network error, this is a side-effect of missing env value for chat provider.
- The users can keep using the magics in the notebook if chat doesn't work.
- Removed some redundant code from handlers.

<img width="1037" alt="Screen Shot 2023-04-17 at 6 13 06 PM" src="https://user-images.githubusercontent.com/289369/232645007-d5f8c614-4f15-477d-89f4-bc66e0b284f5.png">
