### PR TITLE
Ray based document parsing of more file types

### DIFF
--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "ipython",
     "pydantic",
     "importlib_metadata~=5.2.0",
-    "langchain~=0.0.115"
+    "langchain~=0.0.144"
 ]
 
 [project.optional-dependencies]

--- a/packages/jupyter-ai/jupyter_ai/actors/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/ask.py
@@ -9,8 +9,8 @@ from jupyter_ai.actors.base import ACTOR_TYPE, BaseActor, Logger
 
 
 @ray.remote
-class FileSystemActor(BaseActor):
-    """Processes messages prefixed with /fs. This actor will
+class AskActor(BaseActor):
+    """Processes messages prefixed with /ask. This actor will
     send the message as input to a RetrieverQA chain, that
     follows the Retrieval and Generation (RAG) tehnique to
     query the documents from the index, and sends this context
@@ -19,7 +19,7 @@ class FileSystemActor(BaseActor):
 
     def __init__(self, reply_queue: Queue, log: Logger):
         super().__init__(log=log, reply_queue=reply_queue)
-        index_actor = ray.get_actor(ACTOR_TYPE.INDEX.value)
+        index_actor = ray.get_actor(ACTOR_TYPE.LEARN.value)
         handle = index_actor.get_index.remote()
         vectorstore = ray.get(handle)
         if not vectorstore:
@@ -34,7 +34,7 @@ class FileSystemActor(BaseActor):
     def process_message(self, message: HumanChatMessage):
         query = message.body.split(' ', 1)[-1]
         
-        index_actor = ray.get_actor(ACTOR_TYPE.INDEX.value)
+        index_actor = ray.get_actor(ACTOR_TYPE.LEARN.value)
         handle = index_actor.get_index.remote()
         vectorstore = ray.get(handle)
         # Have to reference the latest index

--- a/packages/jupyter-ai/jupyter_ai/actors/base.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/base.py
@@ -1,8 +1,14 @@
+import argparse
 from enum import Enum
+from uuid import uuid4
+import time
 import logging
 from typing import Union
-from jupyter_ai.models import HumanChatMessage
+import traceback
+
 from ray.util.queue import Queue
+
+from jupyter_ai.models import HumanChatMessage, AgentChatMessage
 
 
 Logger = Union[logging.Logger, logging.LoggerAdapter]
@@ -28,7 +34,36 @@ class BaseActor():
         ):
         self.log = log
         self.reply_queue = reply_queue
+        self.parser = argparse.ArgumentParser()
 
     def process_message(self, message: HumanChatMessage):
         """Processes the message passed by the `Router`"""
+        try:
+            self._process_message(message)
+        except Exception as e:
+            formatted_e = traceback.format_exc()
+            response = f"Sorry, something went wrong and I wasn't able to index that path.\n\n```\n{formatted_e}\n```"
+            self.reply(response, message)
+    
+    def _process_message(self, message: HumanChatMessage):
+        """Processes the message passed by the `Router`"""
         raise NotImplementedError("Should be implemented by subclasses.")
+    
+    def reply(self, response, message: HumanChatMessage):
+        m = AgentChatMessage(
+            id=uuid4().hex,
+            time=time.time(),
+            body=response,
+            reply_to=message.id
+        )
+        self.reply_queue.put(m)
+    
+    def parse_args(self, message):
+        args = message.body.split(' ')
+        try:
+            args = self.parser.parse_args(args[1:])
+        except (argparse.ArgumentError, SystemExit) as e:
+            response = f"{self.parser.format_usage()}"
+            self.reply(response, message)
+            return None
+        return args

--- a/packages/jupyter-ai/jupyter_ai/actors/base.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/base.py
@@ -9,14 +9,13 @@ Logger = Union[logging.Logger, logging.LoggerAdapter]
 
 class ACTOR_TYPE(str, Enum):
     DEFAULT = "default"
-    FILESYSTEM = "filesystem"
-    INDEX = 'index'
+    ASK = "ask"
+    LEARN = 'learn'
     MEMORY = 'memory'
 
 COMMANDS = {
-    '/fs': ACTOR_TYPE.FILESYSTEM,
-    '/filesystem': ACTOR_TYPE.FILESYSTEM,
-    '/index': ACTOR_TYPE.INDEX
+    '/ask': ACTOR_TYPE.ASK,
+    '/learn': ACTOR_TYPE.LEARN
 }
 
 class BaseActor():

--- a/packages/jupyter-ai/jupyter_ai/actors/default.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/default.py
@@ -1,13 +1,11 @@
 import time
 from uuid import uuid4
-from jupyter_ai.actors.base import BaseActor, Logger, ACTOR_TYPE
-from jupyter_ai.actors.memory import RemoteMemory
-from jupyter_ai.models import AgentChatMessage, HumanChatMessage
-from jupyter_ai_magics.providers import ChatOpenAINewProvider
-from langchain import ConversationChain
+
+
 import ray
 from ray.util.queue import Queue
-from langchain.memory import ConversationBufferMemory
+
+from langchain import ConversationChain
 from langchain.prompts import (
     ChatPromptTemplate, 
     MessagesPlaceholder, 
@@ -15,8 +13,12 @@ from langchain.prompts import (
     HumanMessagePromptTemplate
 )
 
-SYSTEM_PROMPT = "The following is a friendly conversation between a human and an AI, whose name is Jupyter AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know."
+from jupyter_ai.actors.base import BaseActor, Logger, ACTOR_TYPE
+from jupyter_ai.actors.memory import RemoteMemory
+from jupyter_ai.models import AgentChatMessage, HumanChatMessage
+from jupyter_ai_magics.providers import ChatOpenAINewProvider
 
+SYSTEM_PROMPT = "The following is a friendly conversation between a human and an AI, whose name is Jupyter AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know."
 
 @ray.remote
 class DefaultActor(BaseActor):

--- a/packages/jupyter-ai/jupyter_ai/actors/default.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/default.py
@@ -1,7 +1,3 @@
-import time
-from uuid import uuid4
-
-
 import ray
 from ray.util.queue import Queue
 
@@ -15,7 +11,7 @@ from langchain.prompts import (
 
 from jupyter_ai.actors.base import BaseActor, Logger, ACTOR_TYPE
 from jupyter_ai.actors.memory import RemoteMemory
-from jupyter_ai.models import AgentChatMessage, HumanChatMessage
+from jupyter_ai.models import HumanChatMessage
 from jupyter_ai_magics.providers import ChatOpenAINewProvider
 
 SYSTEM_PROMPT = "The following is a friendly conversation between a human and an AI, whose name is Jupyter AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know."
@@ -23,8 +19,7 @@ SYSTEM_PROMPT = "The following is a friendly conversation between a human and an
 @ray.remote
 class DefaultActor(BaseActor):
     def __init__(self, reply_queue: Queue, log: Logger):
-        super().__init__(log=log, reply_queue=reply_queue)
-        # TODO: Should take the provider/model id as strings
+        super().__init__(reply_queue=reply_queue, log=log)
         provider = ChatOpenAINewProvider(model_id="gpt-3.5-turbo")
         
         # Create a conversation memory
@@ -42,12 +37,6 @@ class DefaultActor(BaseActor):
         )
         self.chat_provider = chain
 
-    def process_message(self, message: HumanChatMessage):
+    def _process_message(self, message: HumanChatMessage):
         response = self.chat_provider.predict(input=message.body)
-        agent_message = AgentChatMessage(
-            id=uuid4().hex,
-            time=time.time(),
-            body=response,
-            reply_to=message.id
-        )
-        self.reply_queue.put(agent_message)
+        self.reply(response, message)

--- a/packages/jupyter-ai/jupyter_ai/actors/index.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/index.py
@@ -1,27 +1,50 @@
 import time
 from uuid import uuid4
-from jupyter_ai.models import AgentChatMessage, HumanChatMessage
-from langchain import FAISS
-import ray
 import os
+import traceback
+from collections import Counter
+import argparse
 
+import ray
+from ray.util.queue import Queue
+
+from jupyter_core.paths import jupyter_data_dir
+
+from langchain import FAISS
+from langchain.embeddings.openai import OpenAIEmbeddings
+from langchain.text_splitter import (
+    RecursiveCharacterTextSplitter, PythonCodeTextSplitter,
+    MarkdownTextSplitter, LatexTextSplitter
+)
+
+from jupyter_ai.models import AgentChatMessage, HumanChatMessage
 from jupyter_ai.actors.base import BaseActor, Logger
 from jupyter_ai_magics.providers import ChatOpenAINewProvider
+from jupyter_ai.document_loaders.directory import RayRecursiveDirectoryLoader
+from jupyter_ai.document_loaders.splitter import ExtensionSplitter, NotebookSplitter
 
-from ray.util.queue import Queue
-from jupyter_core.paths import jupyter_data_dir
-from langchain.embeddings.openai import OpenAIEmbeddings
-from langchain.document_loaders import TextLoader
-from langchain.text_splitter import RecursiveCharacterTextSplitter
-from jupyter_ai.document_loaders.directory import DirectoryLoader
 
+def create_message(response, id):
+    m = AgentChatMessage(
+        id=uuid4().hex,
+        time=time.time(),
+        body=response,
+        reply_to=id
+    )
+    return m
 
 @ray.remote
 class DocumentIndexActor(BaseActor):
+
     def __init__(self, reply_queue: Queue, root_dir: str, log: Logger):
         super().__init__(log=log, reply_queue=reply_queue)
         self.root_dir = root_dir
         self.index_save_dir = os.path.join(jupyter_data_dir(), '.jupyter_ai_indexes')
+        self.chunk_size = 2000
+        self.chunk_overlap = 100
+        self.parser = argparse.ArgumentParser(prog='/index')
+        self.parser.add_argument('path')
+        self.parser.add_argument('-v', '--verbose', action='store_true')
 
         if ChatOpenAINewProvider.auth_strategy.name not in os.environ:
             return
@@ -33,31 +56,68 @@ class DocumentIndexActor(BaseActor):
         try:
             self.index = FAISS.load_local(self.index_save_dir, embeddings)
         except Exception as e:
-            self.index = FAISS.from_texts(["This is just starter text for the index"], embeddings)
+            self.index = FAISS.from_texts(["Jupyter AI knows about your filesystem, to ask questions first use the /index command."], embeddings)
 
     def get_index(self):
         return self.index
-
+        
     def process_message(self, message: HumanChatMessage):
-        dir_path = message.body.split(' ', 1)[-1]
-        load_path = os.path.join(self.root_dir, dir_path)
-        loader = DirectoryLoader(
-            load_path, 
-            glob=['*.txt', '*.text', '*.md', '*.py', '*.ipynb', '*.R'],
-            loader_cls=TextLoader
-        )
-        documents = loader.load_and_split(
-            text_splitter=RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=20)
-        )
-        self.index.add_documents(documents)
-        self.index.save_local(self.index_save_dir)
 
-        response = f"""🎉 I have indexed documents at **{dir_path}** and ready to answer questions. 
-        You can ask questions from these docs by prefixing your message with **/fs**."""
-        agent_message = AgentChatMessage(
-                id=uuid4().hex,
-                time=time.time(),
-                body=response,
-                reply_to=message.id
+        def reply(response):
+            m = create_message(response, message.id)
+            self.reply_queue.put(m)
+
+        try:
+            args = message.body.split(' ')
+
+            if len(args) <= 1:
+                response = f"Usage: `/index [-v] path`."
+                reply(response)
+                return
+            
+            try:
+                args = self.parser.parse_args(args[1:])
+            except (argparse.ArgumentError, SystemExit) as e:
+                response = f"Usage: `/index [-v] path`."
+                reply(response)
+                return
+
+            load_path = os.path.join(self.root_dir, args.path)
+
+            # Make sure the path exists.
+            if not os.path.exists(load_path):
+                response = f"Sorry, that path doesn't exist: {load_path}"
+                reply(response)
+                return
+
+            if args.verbose:
+                reply(f"Loading and splitting files for {load_path}")
+            
+            splitters={
+                '.py': PythonCodeTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
+                '.md': MarkdownTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
+                '.tex': LatexTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
+                '.ipynb': NotebookSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap)
+            }
+            splitter = ExtensionSplitter(
+                splitters=splitters,
+                default_splitter=RecursiveCharacterTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap)
             )
-        self.reply_queue.put(agent_message)
+
+            loader = RayRecursiveDirectoryLoader(load_path)
+            texts = loader.load_and_split(text_splitter=splitter)
+
+            counts = Counter([text.metadata['extension'] for text in texts])
+            if args.verbose:
+                reply(f"I have read the files from {load_path} and processed them into {sum(counts.values())} total chunks.")
+            
+            self.index.add_documents(texts)
+            self.index.save_local(self.index_save_dir)
+
+            response = f"""🎉 I have indexed documents at **{args.path}** and ready to answer questions. 
+            You can ask questions from these docs by prefixing your message with **/fs**."""
+            reply(response)
+        except Exception as e:
+            formatted_e = traceback.format_exc()
+            response = f"Sorry, something went wrong and I wasn't able to index that path.\n\n```\n{formatted_e}\n```"
+            reply(response)

--- a/packages/jupyter-ai/jupyter_ai/actors/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/learn.py
@@ -53,7 +53,7 @@ class LearnActor(BaseActor):
 
         if args.delete:
             self.delete()
-            self.reply(f"👍 I have deleted everthing I previously learned", message)
+            self.reply(f"👍 I have deleted everything I previously learned.", message)
             return
 
         # Make sure the path exists.

--- a/packages/jupyter-ai/jupyter_ai/actors/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/learn.py
@@ -87,7 +87,7 @@ class LearnActor(BaseActor):
         self.save()
 
         response = f"""🎉 I have indexed documents at **{load_path}** and I am ready to answer questions about them. 
-        You can ask questions from these docs by prefixing your message with **/ask**."""
+        You can ask questions about these docs by prefixing your message with **/ask**."""
         self.reply(response, message)
 
     def get_index(self):

--- a/packages/jupyter-ai/jupyter_ai/actors/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/learn.py
@@ -1,5 +1,3 @@
-import time
-from uuid import uuid4
 import os
 import traceback
 from collections import Counter
@@ -17,34 +15,28 @@ from langchain.text_splitter import (
     MarkdownTextSplitter, LatexTextSplitter
 )
 
-from jupyter_ai.models import AgentChatMessage, HumanChatMessage
+from jupyter_ai.models import HumanChatMessage
 from jupyter_ai.actors.base import BaseActor, Logger
 from jupyter_ai_magics.providers import ChatOpenAINewProvider
 from jupyter_ai.document_loaders.directory import RayRecursiveDirectoryLoader
 from jupyter_ai.document_loaders.splitter import ExtensionSplitter, NotebookSplitter
 
 
-def create_message(response, id):
-    m = AgentChatMessage(
-        id=uuid4().hex,
-        time=time.time(),
-        body=response,
-        reply_to=id
-    )
-    return m
-
 @ray.remote
 class LearnActor(BaseActor):
 
-    def __init__(self, reply_queue: Queue, root_dir: str, log: Logger):
-        super().__init__(log=log, reply_queue=reply_queue)
+    def __init__(self, reply_queue: Queue, log: Logger, root_dir: str):
+        super().__init__(reply_queue=reply_queue, log=log)
         self.root_dir = root_dir
-        self.index_save_dir = os.path.join(jupyter_data_dir(), 'jupyter_ai')
+        self.index_save_dir = os.path.join(jupyter_data_dir(), 'jupyter_ai', 'indices')
         self.chunk_size = 2000
         self.chunk_overlap = 100
-        self.parser = argparse.ArgumentParser(prog='/learn')
-        self.parser.add_argument('path')
+        self.parser.prog = '/learn'
         self.parser.add_argument('-v', '--verbose', action='store_true')
+        self.parser.add_argument('-d', '--delete', action='store_true')
+        self.parser.add_argument('path', nargs=argparse.REMAINDER)
+        self.index_name = 'default'
+        self.index = None
 
         if ChatOpenAINewProvider.auth_strategy.name not in os.environ:
             return
@@ -52,72 +44,76 @@ class LearnActor(BaseActor):
         if not os.path.exists(self.index_save_dir):
             os.makedirs(self.index_save_dir)
 
-        embeddings = OpenAIEmbeddings()
-        try:
-            self.index = FAISS.load_local(self.index_save_dir, embeddings)
-        except Exception as e:
-            self.index = FAISS.from_texts(["Jupyter AI knows about your filesystem, to ask questions first use the /learn command."], embeddings)
+        self.load_or_create()
+        
+    def _process_message(self, message: HumanChatMessage):
+        args = self.parse_args(message)
+        if args is None:
+            return
+
+        if args.delete:
+            self.delete()
+            self.reply(f"👍 I have deleted everthing I previously learned", message)
+            return
+
+        # Make sure the path exists.
+        if not len(args.path) == 1:
+            self.reply(f"{self.parser.format_usage()}", message)
+            return
+        short_path = args.path[0]
+        load_path = os.path.join(self.root_dir, short_path)
+        if not os.path.exists(load_path):
+            response = f"Sorry, that path doesn't exist: {load_path}"
+            self.reply(response, message)
+            return
+
+        if args.verbose:
+            self.reply(f"Loading and splitting files for {load_path}", message)
+        
+        splitters={
+            '.py': PythonCodeTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
+            '.md': MarkdownTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
+            '.tex': LatexTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
+            '.ipynb': NotebookSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap)
+        }
+        splitter = ExtensionSplitter(
+            splitters=splitters,
+            default_splitter=RecursiveCharacterTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap)
+        )
+
+        loader = RayRecursiveDirectoryLoader(load_path)
+        texts = loader.load_and_split(text_splitter=splitter)        
+        self.index.add_documents(texts)
+        self.save()
+
+        response = f"""🎉 I have indexed documents at **{load_path}** and ready to answer questions. 
+        You can ask questions from these docs by prefixing your message with **/ask**."""
+        self.reply(response, message)
 
     def get_index(self):
         return self.index
-        
-    def process_message(self, message: HumanChatMessage):
 
-        def reply(response):
-            m = create_message(response, message.id)
-            self.reply_queue.put(m)
+    def delete(self):
+        self.index = None
+        paths = [os.path.join(self.index_save_dir, self.index_name+ext) for ext in ['.pkl', '.faiss']]
+        for path in paths:
+            if os.path.isfile(path):
+                os.remove(path)
+        self.create()
+    
+    def create(self):
+        embeddings = OpenAIEmbeddings()
+        self.index = FAISS.from_texts(["Jupyter AI knows about your filesystem, to ask questions first use the /learn command."], embeddings)
+        self.save()
 
-        try:
-            args = message.body.split(' ')
+    def save(self):
+        if self.index is not None:
+            self.index.save_local(self.index_save_dir, index_name=self.index_name)
 
-            if len(args) <= 1:
-                response = f"Usage: `/learn [-v] path`."
-                reply(response)
-                return
-            
+    def load_or_create(self):
+        embeddings = OpenAIEmbeddings()
+        if self.index is None:
             try:
-                args = self.parser.parse_args(args[1:])
-            except (argparse.ArgumentError, SystemExit) as e:
-                response = f"Usage: `/learn [-v] path`."
-                reply(response)
-                return
-
-            load_path = os.path.join(self.root_dir, args.path)
-
-            # Make sure the path exists.
-            if not os.path.exists(load_path):
-                response = f"Sorry, that path doesn't exist: {load_path}"
-                reply(response)
-                return
-
-            if args.verbose:
-                reply(f"Loading and splitting files for {load_path}")
-            
-            splitters={
-                '.py': PythonCodeTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
-                '.md': MarkdownTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
-                '.tex': LatexTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
-                '.ipynb': NotebookSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap)
-            }
-            splitter = ExtensionSplitter(
-                splitters=splitters,
-                default_splitter=RecursiveCharacterTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap)
-            )
-
-            loader = RayRecursiveDirectoryLoader(load_path)
-            texts = loader.load_and_split(text_splitter=splitter)
-
-            counts = Counter([text.metadata['extension'] for text in texts])
-            if args.verbose:
-                reply(f"I have read the files from {load_path} and processed them into {sum(counts.values())} total chunks.")
-            
-            self.index.add_documents(texts)
-            self.index.save_local(self.index_save_dir)
-
-            response = f"""🎉 I have indexed documents at **{args.path}** and ready to answer questions. 
-            You can ask questions from these docs by prefixing your message with **/ask**."""
-            reply(response)
-        except Exception as e:
-            formatted_e = traceback.format_exc()
-            response = f"Sorry, something went wrong and I wasn't able to index that path.\n\n```\n{formatted_e}\n```"
-            reply(response)
+                self.index = FAISS.load_local(self.index_save_dir, embeddings, index_name=self.index_name)
+            except Exception as e:
+                self.create()

--- a/packages/jupyter-ai/jupyter_ai/actors/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/learn.py
@@ -86,7 +86,7 @@ class LearnActor(BaseActor):
         self.index.add_documents(texts)
         self.save()
 
-        response = f"""🎉 I have indexed documents at **{load_path}** and ready to answer questions. 
+        response = f"""🎉 I have indexed documents at **{load_path}** and I am ready to answer questions about them. 
         You can ask questions from these docs by prefixing your message with **/ask**."""
         self.reply(response, message)
 

--- a/packages/jupyter-ai/jupyter_ai/actors/memory.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/memory.py
@@ -1,9 +1,10 @@
-from jupyter_ai.actors.base import Logger
 from typing import Dict, Any, List
-from langchain.schema import BaseMemory
+
 import ray
+from langchain.schema import BaseMemory
 from pydantic import PrivateAttr
 
+from jupyter_ai.actors.base import Logger
 
 @ray.remote
 class MemoryActor(object):
@@ -13,7 +14,7 @@ class MemoryActor(object):
     running in different actors by using RemoteMemory (below).
     """
     
-    def __init__(self, memory: BaseMemory, log: Logger):
+    def __init__(self, log: Logger, memory: BaseMemory):
         self.memory = memory
         self.log = log
     

--- a/packages/jupyter-ai/jupyter_ai/actors/router.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/router.py
@@ -1,9 +1,8 @@
-from jupyter_ai.actors.base import ACTOR_TYPE, COMMANDS, Logger, BaseActor
-from jupyter_ai.models import ClearMessage
-
 import ray
 from ray.util.queue import Queue
 
+from jupyter_ai.actors.base import ACTOR_TYPE, COMMANDS, Logger, BaseActor
+from jupyter_ai.models import ClearMessage
 
 @ray.remote
 class Router(BaseActor):
@@ -13,9 +12,9 @@ class Router(BaseActor):
         To register new actors, add the actor type in the `ACTOR_TYPE` enum and 
         add a corresponding command in the `COMMANDS` dictionary.
         """
-        super().__init__(log=log, reply_queue=reply_queue)
+        super().__init__(reply_queue=reply_queue, log=log)
 
-    def route_message(self, message):
+    def _process_message(self, message):
         
         # assign default actor
         default = ray.get_actor(ACTOR_TYPE.DEFAULT)
@@ -30,4 +29,3 @@ class Router(BaseActor):
                 self.reply_queue.put(reply_message)
         else:
             default.process_message.remote(message)
-

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -44,8 +44,8 @@ class RayRecursiveDirectoryLoader(BaseLoader):
     def __init__(
         self,
         path,
-        extensions={'.py', '.md', '.R', '.Rmd', '.jl', '.sh', '.ipynb', '.js', '.ts'},
-        exclude={'.ipynb_checkpoints', 'node_modules', 'lib', 'build'}
+        extensions={'.py', '.md', '.R', '.Rmd', '.jl', '.sh', '.ipynb', '.js', '.ts', '.jsx', '.tsx', '.txt'},
+        exclude={'.ipynb_checkpoints', 'node_modules', 'lib', 'build', '.git', '.DS_Store'}
     ):
         self.path = path
         self.extensions = extensions

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/splitter.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/splitter.py
@@ -1,0 +1,44 @@
+from typing import List, Optional
+
+from langchain.schema import Document
+from langchain.text_splitter import TextSplitter, RecursiveCharacterTextSplitter, MarkdownTextSplitter
+import copy
+
+class ExtensionSplitter(TextSplitter):
+    
+    def __init__(self, splitters, default_splitter=None):
+        self.splitters = splitters
+        if default_splitter is None:
+            self.default_splitter = RecursiveCharacterTextSplitter()
+        else:
+            self.default_splitter = default_splitter
+    
+    def split_text(self, text: str, metadata=None):
+        splitter = self.splitters.get(metadata['extension'], self.default_splitter)
+        return splitter.split_text(text)
+
+    def create_documents(self, texts: List[str], metadatas: Optional[List[dict]] = None) -> List[Document]:
+        _metadatas = metadatas or [{}] * len(texts)
+        documents = []
+        for i, text in enumerate(texts):
+            metadata = copy.deepcopy(_metadatas[i])
+            for chunk in self.split_text(text, metadata):
+                new_doc = Document(
+                    page_content=chunk, metadata=metadata
+                )
+                documents.append(new_doc)
+        return documents
+
+import nbformat
+
+class NotebookSplitter(TextSplitter):
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.markdown_splitter = MarkdownTextSplitter(chunk_size=self._chunk_size, chunk_overlap=self._chunk_overlap)
+        
+    def split_text(self, text: str):
+        nb = nbformat.reads(text, as_version=4)
+        md = '\n\n'.join([cell.source for cell in nb.cells])
+        return self.markdown_splitter.split_text(md)
+

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -3,8 +3,8 @@ import os
 import queue
 from langchain.memory import ConversationBufferWindowMemory
 from jupyter_ai.actors.default import DefaultActor 
-from jupyter_ai.actors.filesystem import FileSystemActor 
-from jupyter_ai.actors.index import DocumentIndexActor
+from jupyter_ai.actors.ask import AskActor 
+from jupyter_ai.actors.learn import LearnActor
 from jupyter_ai.actors.router import Router
 from jupyter_ai.actors.memory import MemoryActor
 from jupyter_ai.actors.base import ACTOR_TYPE
@@ -120,12 +120,12 @@ class AiExtension(ExtensionApp):
             reply_queue=reply_queue, 
             log=self.log
         )
-        index_actor = DocumentIndexActor.options(name=ACTOR_TYPE.INDEX.value).remote(
+        learn_actor = LearnActor.options(name=ACTOR_TYPE.LEARN.value).remote(
             reply_queue=reply_queue,
             root_dir=self.serverapp.root_dir,
             log=self.log 
         )
-        fs_actor = FileSystemActor.options(name=ACTOR_TYPE.FILESYSTEM.value).remote(
+        ask_actor = AskActor.options(name=ACTOR_TYPE.ASK.value).remote(
             reply_queue=reply_queue, 
             log=self.log
         )
@@ -135,8 +135,8 @@ class AiExtension(ExtensionApp):
         )
         self.settings['router'] = router
         self.settings["default_actor"] = default_actor
-        self.settings["index_actor"] = index_actor
-        self.settings["fs_actor"] = fs_actor
+        self.settings["learn_actor"] = learn_actor
+        self.settings["ask_actor"] = ask_actor
         self.settings["memory_actor"] = memory_actor
 
         reply_processor = ReplyProcessor(self.settings['chat_handlers'], reply_queue, log=self.log)        

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -122,16 +122,16 @@ class AiExtension(ExtensionApp):
         )
         learn_actor = LearnActor.options(name=ACTOR_TYPE.LEARN.value).remote(
             reply_queue=reply_queue,
+            log=self.log,
             root_dir=self.serverapp.root_dir,
-            log=self.log 
         )
         ask_actor = AskActor.options(name=ACTOR_TYPE.ASK.value).remote(
             reply_queue=reply_queue, 
             log=self.log
         )
         memory_actor = MemoryActor.options(name=ACTOR_TYPE.MEMORY.value).remote(
-            memory=ConversationBufferWindowMemory(return_messages=True, k=2),
-            log=self.log
+            log=self.log,
+            memory=ConversationBufferWindowMemory(return_messages=True, k=2)
         )
         self.settings['router'] = router
         self.settings["default_actor"] = default_actor

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -228,7 +228,7 @@ class ChatHandler(
 
         # process through the router
         router = ray.get_actor("router")
-        router.route_message.remote(chat_message)
+        router.process_message.remote(chat_message)
 
     def on_close(self):
         self.log.debug("Disconnecting client with user %s", self.client_id)

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "openai~=0.26",
     "aiosqlite~=0.18",
     "importlib_metadata~=5.2.0",
-    "langchain~=0.0.115",
+    "langchain~=0.0.144",
     "tiktoken", # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "ray==2.2.0", # latest ray version 2.3.0 requires grpcio installation from conda


### PR DESCRIPTION
This is a general improvement to the file indexing capabilities:

* Use ray to parallelize the loading and splitting of documents. This can now read the entire JupyterLab source tree in 800ms.
* Better error handling logic in the indexer.
* More file types supported.
* Added exclude patterns of files/directories to not read (.ipynb_checkpoints, node_modules, build, lib).
* File-extension specific text splitting, including notebooks.
