### PR TITLE
Removes version from docs config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,6 @@
 project = 'Jupyter AI'
 copyright = '2023, Project Jupyter'
 author = 'Project Jupyter'
-release = '0.4.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
Removes the version number from the docs config, so that we don't have to keep synchronizing it as we release new versions.