### PR TITLE
APIs for fetching and setting model and embedding providers

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
@@ -10,6 +10,7 @@ from .providers import (
     HfHubProvider,
     OpenAIProvider,
     ChatOpenAIProvider,
+    ChatOpenAINewProvider,
     SmEndpointProvider
 )
 # expose embedding model providers on the package root

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
@@ -12,6 +12,12 @@ from .providers import (
     ChatOpenAIProvider,
     SmEndpointProvider
 )
+# expose embedding model providers on the package root
+from .embedding_providers import (
+    OpenAIEmbeddingsProvider,
+    CohereEmbeddingsProvider,
+    HfHubEmbeddingsProvider
+)
 from .providers import BaseProvider
 
 def load_ipython_extension(ipython):

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/aliases.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/aliases.py
@@ -1,0 +1,6 @@
+MODEL_ID_ALIASES = {
+    "gpt2": "huggingface_hub:gpt2",
+    "gpt3": "openai:text-davinci-003",
+    "chatgpt": "openai-chat:gpt-3.5-turbo",
+    "gpt4": "openai-chat:gpt-4",
+}

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -5,7 +5,7 @@ from langchain.embeddings import OpenAIEmbeddings, CohereEmbeddings, HuggingFace
 from langchain.embeddings.base import Embeddings
 
 
-class BaseEmbeddingsProvider(Embeddings):
+class BaseEmbeddingsProvider(BaseModel):
     """Base class for embedding providers"""
 
     class Config:
@@ -33,21 +33,10 @@ class BaseEmbeddingsProvider(Embeddings):
 
     model_id: str
 
-    
-    def __init__(self, *args, **kwargs):
-        try:
-            assert kwargs["model_id"]
-        except:
-            raise AssertionError("model_id was not specified. Please specify it as a keyword argument.")
-
-        model_kwargs = {}
-        model_kwargs[self.__class__.model_id_key] = kwargs["model_id"]
-
-        super().__init__(*args, **kwargs, **model_kwargs)
-    
+    provider_klass: ClassVar[Type[Embeddings]]    
 
     
-class OpenAIEmbeddingsProvider(BaseEmbeddingsProvider, OpenAIEmbeddings):
+class OpenAIEmbeddingsProvider(BaseEmbeddingsProvider):
     id = "openai"
     name = "OpenAI"
     models = [
@@ -56,9 +45,10 @@ class OpenAIEmbeddingsProvider(BaseEmbeddingsProvider, OpenAIEmbeddings):
     model_id_key = "model"
     pypi_package_deps = ["openai"]
     auth_strategy = EnvAuthStrategy(name="OPENAI_API_KEY")
+    provider_klass: OpenAIEmbeddings
 
 
-class CohereEmbeddingsProvider(BaseEmbeddingsProvider, CohereEmbeddings):
+class CohereEmbeddingsProvider(BaseEmbeddingsProvider):
     id = "cohere"
     name = "Cohere"
     models = [
@@ -69,9 +59,10 @@ class CohereEmbeddingsProvider(BaseEmbeddingsProvider, CohereEmbeddings):
     model_id_key = "model"
     pypi_package_deps = ["cohere"]
     auth_strategy = EnvAuthStrategy(name="COHERE_API_KEY")
+    provider_klass: CohereEmbeddings
 
 
-class HfHubEmbeddingsProvider(BaseEmbeddingsProvider, HuggingFaceHubEmbeddings):
+class HfHubEmbeddingsProvider(BaseEmbeddingsProvider):
     id = "huggingface_hub"
     name = "HuggingFace Hub"
     models = ["*"]
@@ -81,3 +72,4 @@ class HfHubEmbeddingsProvider(BaseEmbeddingsProvider, HuggingFaceHubEmbeddings):
     # tqdm is a dependency of huggingface_hub
     pypi_package_deps = ["huggingface_hub", "ipywidgets"]
     auth_strategy = EnvAuthStrategy(name="HUGGINGFACEHUB_API_TOKEN")
+    provider_klass: HuggingFaceHubEmbeddings

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -45,7 +45,7 @@ class OpenAIEmbeddingsProvider(BaseEmbeddingsProvider):
     model_id_key = "model"
     pypi_package_deps = ["openai"]
     auth_strategy = EnvAuthStrategy(name="OPENAI_API_KEY")
-    provider_klass: OpenAIEmbeddings
+    provider_klass = OpenAIEmbeddings
 
 
 class CohereEmbeddingsProvider(BaseEmbeddingsProvider):
@@ -59,7 +59,7 @@ class CohereEmbeddingsProvider(BaseEmbeddingsProvider):
     model_id_key = "model"
     pypi_package_deps = ["cohere"]
     auth_strategy = EnvAuthStrategy(name="COHERE_API_KEY")
-    provider_klass: CohereEmbeddings
+    provider_klass = CohereEmbeddings
 
 
 class HfHubEmbeddingsProvider(BaseEmbeddingsProvider):
@@ -72,4 +72,4 @@ class HfHubEmbeddingsProvider(BaseEmbeddingsProvider):
     # tqdm is a dependency of huggingface_hub
     pypi_package_deps = ["huggingface_hub", "ipywidgets"]
     auth_strategy = EnvAuthStrategy(name="HUGGINGFACEHUB_API_TOKEN")
-    provider_klass: HuggingFaceHubEmbeddings
+    provider_klass = HuggingFaceHubEmbeddings

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -1,0 +1,83 @@
+from typing import ClassVar, List, Type
+from jupyter_ai_magics.providers import AuthStrategy, EnvAuthStrategy
+from pydantic import BaseModel, Extra
+from langchain.embeddings import OpenAIEmbeddings, CohereEmbeddings, HuggingFaceHubEmbeddings
+from langchain.embeddings.base import Embeddings
+
+
+class BaseEmbeddingsProvider(Embeddings):
+    """Base class for embedding providers"""
+
+    class Config:
+        extra = Extra.allow
+
+    id: ClassVar[str] = ...
+    """ID for this provider class."""
+
+    name: ClassVar[str] = ...
+    """User-facing name of this provider."""
+
+    models: ClassVar[List[str]] = ...
+    """List of supported models by their IDs. For registry providers, this will
+    be just ["*"]."""
+
+    model_id_key: ClassVar[str] = ...
+    """Kwarg expected by the upstream LangChain provider."""
+
+    pypi_package_deps: ClassVar[List[str]] = []
+    """List of PyPi package dependencies."""
+
+    auth_strategy: ClassVar[AuthStrategy] = None
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
+
+    model_id: str
+
+    
+    def __init__(self, *args, **kwargs):
+        try:
+            assert kwargs["model_id"]
+        except:
+            raise AssertionError("model_id was not specified. Please specify it as a keyword argument.")
+
+        model_kwargs = {}
+        model_kwargs[self.__class__.model_id_key] = kwargs["model_id"]
+
+        super().__init__(*args, **kwargs, **model_kwargs)
+    
+
+    
+class OpenAIEmbeddingsProvider(BaseEmbeddingsProvider, OpenAIEmbeddings):
+    id = "openai"
+    name = "OpenAI"
+    models = [
+        "text-embedding-ada-002"
+    ]
+    model_id_key = "model"
+    pypi_package_deps = ["openai"]
+    auth_strategy = EnvAuthStrategy(name="OPENAI_API_KEY")
+
+
+class CohereEmbeddingsProvider(BaseEmbeddingsProvider, CohereEmbeddings):
+    id = "cohere"
+    name = "Cohere"
+    models = [
+        'large',
+        'multilingual-22-12',
+        'small'
+    ]
+    model_id_key = "model"
+    pypi_package_deps = ["cohere"]
+    auth_strategy = EnvAuthStrategy(name="COHERE_API_KEY")
+
+
+class HfHubEmbeddingsProvider(BaseEmbeddingsProvider, HuggingFaceHubEmbeddings):
+    id = "huggingface_hub"
+    name = "HuggingFace Hub"
+    models = ["*"]
+    model_id_key = "repo_id"
+    # ipywidgets needed to suppress tqdm warning
+    # https://stackoverflow.com/questions/67998191
+    # tqdm is a dependency of huggingface_hub
+    pypi_package_deps = ["huggingface_hub", "ipywidgets"]
+    auth_strategy = EnvAuthStrategy(name="HUGGINGFACEHUB_API_TOKEN")

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -4,11 +4,11 @@ import re
 import warnings
 from typing import Optional
 
-from importlib_metadata import entry_points
 from IPython import get_ipython
 from IPython.core.magic import Magics, magics_class, line_cell_magic
 from IPython.core.magic_arguments import magic_arguments, argument, parse_argstring
 from IPython.display import HTML, Markdown, Math, JSON
+from jupyter_ai_magics.utils import decompose_model_id, load_providers
 
 from .providers import BaseProvider
 
@@ -33,6 +33,7 @@ class TextOrMarkdown(object):
                 'text/markdown': self.markdown
             }
         )
+
 
 class TextWithMetadata(object):
 
@@ -93,16 +94,7 @@ class AiMagics(Magics):
             "no longer supported. Instead, please use: "
             "`from langchain.chat_models import ChatOpenAI`")
 
-        # load model providers from entry point
-        self.providers = {}
-        eps = entry_points()
-        model_provider_eps = eps.select(group="jupyter_ai.model_providers")
-        for model_provider_ep in model_provider_eps:
-            try:
-                Provider = model_provider_ep.load()
-            except:
-                continue
-            self.providers[Provider.id] = Provider
+        self.providers = load_providers()
     
     def _ai_help_command_markdown(self):
         table = ("| Command | Description |\n"
@@ -254,24 +246,7 @@ class AiMagics(Magics):
         })
 
     def _decompose_model_id(self, model_id: str):
-        """Breaks down a model ID into a two-tuple (provider_id, local_model_id). Returns (None, None) if indeterminate."""
-        if model_id in MODEL_ID_ALIASES:
-            model_id = MODEL_ID_ALIASES[model_id]
-
-        if ":" not in model_id:
-            # case: model ID was not provided with a prefix indicating the provider
-            # ID. try to infer the provider ID before returning (None, None).
-
-            # naively search through the dictionary and return the first provider
-            # that provides a model of the same ID.
-            for provider_id, Provider in self.providers.items():
-                if model_id in Provider.models:
-                    return (provider_id, model_id)
-            
-            return (None, None)
-
-        provider_id, local_model_id = model_id.split(":", 1)
-        return (provider_id, local_model_id)
+        return decompose_model_id(model_id, self.providers)
 
     def _get_provider(self, provider_id: Optional[str]) -> BaseProvider:
         """Returns the model provider ID and class for a model ID. Returns None if indeterminate."""

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -206,3 +206,5 @@ class SmEndpointProvider(BaseProvider, SagemakerEndpoint):
     model_id_key = "endpoint_name"
     pypi_package_deps = ["boto3"]
     auth_strategy = AwsAuthStrategy()
+
+    

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict, Optional, Tuple, Union
 from importlib_metadata import entry_points
 from jupyter_ai_magics.aliases import MODEL_ID_ALIASES
+from jupyter_ai_magics.embedding_providers import BaseEmbeddingsProvider
 
 from jupyter_ai_magics.providers import BaseProvider
 
@@ -26,6 +27,27 @@ def load_providers(log: Optional[Logger] = None) -> Dict[str, BaseProvider]:
         log.info(f"Registered model provider `{provider.id}`.")
     
     return providers
+
+
+def load_embedding_providers(log: Optional[Logger] = None) -> Dict[str, BaseEmbeddingsProvider]:
+    if not log:
+        log = logging.getLogger()
+        log.addHandler(logging.NullHandler())
+    providers = {}
+    eps = entry_points()
+    model_provider_eps = eps.select(group="jupyter_ai.embeddings_model_providers")
+    for model_provider_ep in model_provider_eps:
+        try:
+            provider = model_provider_ep.load()
+        except:
+            log.error(f"Unable to load embeddings model provider class from entry point `{model_provider_ep.name}`.")
+            continue
+        providers[provider.id] = provider
+        log.info(f"Registered embeddings model provider `{provider.id}`.")
+    
+    return providers
+
+
 
 def decompose_model_id(model_id: str, providers: Dict[str, BaseProvider]) -> Tuple[str, str]:
         """Breaks down a model ID into a two-tuple (provider_id, local_model_id). Returns (None, None) if indeterminate."""

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
@@ -10,6 +10,9 @@ Logger = Union[logging.Logger, logging.LoggerAdapter]
 
 
 def load_providers(log: Optional[Logger] = None) -> Dict[str, BaseProvider]:
+    if not log:
+        log = logging.getLogger()
+        log.addHandler(logging.NullHandler())
     providers = {}
     eps = entry_points()
     model_provider_eps = eps.select(group="jupyter_ai.model_providers")
@@ -17,12 +20,10 @@ def load_providers(log: Optional[Logger] = None) -> Dict[str, BaseProvider]:
         try:
             provider = model_provider_ep.load()
         except:
-            if log:
-                log.error(f"Unable to load model provider class from entry point `{model_provider_ep.name}`.")
+            log.error(f"Unable to load model provider class from entry point `{model_provider_ep.name}`.")
             continue
         providers[provider.id] = provider
-        if log:
-            log.info(f"Registered model provider `{provider.id}`.")
+        log.info(f"Registered model provider `{provider.id}`.")
     
     return providers
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
@@ -1,0 +1,47 @@
+import logging
+from typing import Dict, Optional, Tuple, Union
+from importlib_metadata import entry_points
+from jupyter_ai_magics.aliases import MODEL_ID_ALIASES
+
+from jupyter_ai_magics.providers import BaseProvider
+
+
+Logger = Union[logging.Logger, logging.LoggerAdapter]
+
+
+def load_providers(log: Optional[Logger] = None) -> Dict[str, BaseProvider]:
+    providers = {}
+    eps = entry_points()
+    model_provider_eps = eps.select(group="jupyter_ai.model_providers")
+    for model_provider_ep in model_provider_eps:
+        try:
+            provider = model_provider_ep.load()
+        except:
+            if log:
+                log.error(f"Unable to load model provider class from entry point `{model_provider_ep.name}`.")
+            continue
+        providers[provider.id] = provider
+        if log:
+            log.info(f"Registered model provider `{provider.id}`.")
+    
+    return providers
+
+def decompose_model_id(model_id: str, providers: Dict[str, BaseProvider]) -> Tuple[str, str]:
+        """Breaks down a model ID into a two-tuple (provider_id, local_model_id). Returns (None, None) if indeterminate."""
+        if model_id in MODEL_ID_ALIASES:
+            model_id = MODEL_ID_ALIASES[model_id]
+
+        if ":" not in model_id:
+            # case: model ID was not provided with a prefix indicating the provider
+            # ID. try to infer the provider ID before returning (None, None).
+
+            # naively search through the dictionary and return the first provider
+            # that provides a model of the same ID.
+            for provider_id, provider in providers.items():
+                if model_id in provider.models:
+                    return (provider_id, model_id)
+            
+            return (None, None)
+
+        provider_id, local_model_id = model_id.split(":", 1)
+        return (provider_id, local_model_id)

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -55,6 +55,11 @@ openai = "jupyter_ai_magics:OpenAIProvider"
 openai-chat = "jupyter_ai_magics:ChatOpenAIProvider"
 sagemaker-endpoint = "jupyter_ai_magics:SmEndpointProvider"
 
+[project.entry-points."jupyter_ai.embeddings_model_providers"]
+cohere = "jupyter_ai_magics:CohereEmbeddingsProvider"
+huggingface_hub = "jupyter_ai_magics:HfHubEmbeddingsProvider"
+openai = "jupyter_ai_magics:OpenAIEmbeddingsProvider"
+
 [tool.hatch.version]
 source = "nodejs"
 

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -53,6 +53,7 @@ cohere = "jupyter_ai_magics:CohereProvider"
 huggingface_hub = "jupyter_ai_magics:HfHubProvider"
 openai = "jupyter_ai_magics:OpenAIProvider"
 openai-chat = "jupyter_ai_magics:ChatOpenAIProvider"
+openai-chat-new = "jupyter_ai_magics:ChatOpenAINewProvider"
 sagemaker-endpoint = "jupyter_ai_magics:SmEndpointProvider"
 
 [project.entry-points."jupyter_ai.embeddings_model_providers"]

--- a/packages/jupyter-ai/.gitignore
+++ b/packages/jupyter-ai/.gitignore
@@ -119,9 +119,6 @@ dmypy.json
 # OSX files
 .DS_Store
 
-# local config storing authn credentials
-config.py
-
 # vscode
 .vscode
 

--- a/packages/jupyter-ai/jupyter_ai/actors/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/ask.py
@@ -1,11 +1,12 @@
 import argparse
-from typing import Dict, Type
+from typing import Dict, List, Type
 from jupyter_ai_magics.providers import BaseProvider
 
 import ray
 from ray.util.queue import Queue
 
 from langchain.chains import ConversationalRetrievalChain
+from langchain.schema import BaseRetriever, Document
 
 from jupyter_ai.models import HumanChatMessage
 from jupyter_ai.actors.base import ACTOR_TYPE, BaseActor, Logger
@@ -27,16 +28,12 @@ class AskActor(BaseActor):
         self.parser.add_argument('query', nargs=argparse.REMAINDER)
 
     def create_llm_chain(self, provider: Type[BaseProvider], provider_params: Dict[str, str]):
-        index_actor = ray.get_actor(ACTOR_TYPE.LEARN.value)
-        vectorstore = ray.get(index_actor.get_index.remote())
-        if not vectorstore:
-            return None
-        
+        retriever = Retriever()
         self.llm = provider(**provider_params)
         self.chat_history = []
         self.llm_chain = ConversationalRetrievalChain.from_llm(
             self.llm,
-            vectorstore.as_retriever()
+            retriever
         )
 
     def _process_message(self, message: HumanChatMessage):
@@ -48,15 +45,25 @@ class AskActor(BaseActor):
             self.reply(f"{self.parser.format_usage()}", message)
             return
         
-        index_actor = ray.get_actor(ACTOR_TYPE.LEARN.value)
-        vectorstore = ray.get(index_actor.get_index.remote())
-        
         self.get_llm_chain()
-        
-        # Have to reference the latest index
-        self.llm_chain.retriever = vectorstore.as_retriever()
-        
+
         result = self.llm_chain({"question": query, "chat_history": self.chat_history})
         response = result['answer']
         self.chat_history.append((query, response))
         self.reply(response, message)
+
+
+class Retriever(BaseRetriever):
+    """Wrapper retriever class to get relevant docs
+    from the vector store, this is important because
+    of inconsistent de-serialization of index when it's
+    accessed directly from the ask actor.
+    """
+    
+    def get_relevant_documents(self, question: str):
+        index_actor = ray.get_actor(ACTOR_TYPE.LEARN.value)
+        docs = ray.get(index_actor.get_relevant_documents.remote(question))
+        return docs
+    
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        return await super().aget_relevant_documents(query)

--- a/packages/jupyter-ai/jupyter_ai/actors/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/ask.py
@@ -47,10 +47,19 @@ class AskActor(BaseActor):
         
         self.get_llm_chain()
 
-        result = self.llm_chain({"question": query, "chat_history": self.chat_history})
-        response = result['answer']
-        self.chat_history.append((query, response))
-        self.reply(response, message)
+        try:
+            result = self.llm_chain({"question": query, "chat_history": self.chat_history})
+            response = result['answer']
+            self.chat_history.append((query, response))
+            self.reply(response, message)
+        except AssertionError as e:
+            self.log.error(e)
+            response = """Sorry, an error occurred while reading the from the learned documents. 
+            If you have changed the embedding provider, try deleting the existing index by running 
+            `/learn -d` command and then re-submitting the `learn <directory>` to learn the documents,
+            and then asking the question again.
+            """
+            self.reply(response, message)
 
 
 class Retriever(BaseRetriever):

--- a/packages/jupyter-ai/jupyter_ai/actors/base.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/base.py
@@ -21,6 +21,8 @@ class ACTOR_TYPE(str, Enum):
     GENERATE = 'generate'
     PROVIDERS = 'providers'
     CONFIG = 'config'
+    CHAT_PROVIDER = 'chat_provider'
+    EMBEDDINGS_PROVIDER = 'embeddings_provider'
 
 COMMANDS = {
     '/ask': ACTOR_TYPE.ASK,

--- a/packages/jupyter-ai/jupyter_ai/actors/base.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/base.py
@@ -93,6 +93,7 @@ class BaseActor():
         
         if provider.__class__.__name__ != self.embeddings.__class__.__name__:
             self.embeddings = provider(**embedding_params)
+
         return self.embeddings
     
     def create_llm_chain(self, provider: Type[BaseProvider], provider_params: Dict[str, str]):

--- a/packages/jupyter-ai/jupyter_ai/actors/base.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/base.py
@@ -19,6 +19,8 @@ class ACTOR_TYPE(str, Enum):
     LEARN = 'learn'
     MEMORY = 'memory'
     GENERATE = 'generate'
+    PROVIDERS = 'providers'
+    CONFIG = 'config'
 
 COMMANDS = {
     '/ask': ACTOR_TYPE.ASK,

--- a/packages/jupyter-ai/jupyter_ai/actors/base.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/base.py
@@ -3,13 +3,15 @@ from enum import Enum
 from uuid import uuid4
 import time
 import logging
-from typing import Union
+from typing import Dict, Union
 import traceback
+
+from jupyter_ai_magics.providers import BaseProvider
+import ray
 
 from ray.util.queue import Queue
 
 from jupyter_ai.models import HumanChatMessage, AgentChatMessage
-
 
 Logger = Union[logging.Logger, logging.LoggerAdapter]
 
@@ -41,6 +43,11 @@ class BaseActor():
         self.log = log
         self.reply_queue = reply_queue
         self.parser = argparse.ArgumentParser()
+        self.llm = None
+        self.llm_params = None
+        self.llm_chain = None
+        self.embeddings = None
+        self.embeddings_params = None
 
     def process_message(self, message: HumanChatMessage):
         """Processes the message passed by the `Router`"""
@@ -63,6 +70,38 @@ class BaseActor():
             reply_to=message.id
         )
         self.reply_queue.put(m)
+
+    def get_llm_chain(self):
+        actor = ray.get_actor(ACTOR_TYPE.CHAT_PROVIDER)
+        handle = actor.get_provider.remote()
+        llm = ray.get(handle)
+
+        handle = actor.get_provider_params.remote()
+        llm_params = ray.get(handle)
+
+        if not llm:
+            return None
+        
+        if llm.__class__.__name__ != self.llm.__class__.__name__:
+            self.create_llm_chain(llm, llm_params)
+        return self.llm_chain
+    
+    def get_embeddings(self):
+        actor = ray.get_actor(ACTOR_TYPE.EMBEDDINGS_PROVIDER)
+        handle = actor.get_provider.remote()
+        provider = ray.get(handle)
+
+        handle = actor.get_provider_params.remote()
+        embedding_params = ray.get(handle)
+        
+        if not provider:
+            return None
+        if provider.__class__.__name__ != self.embeddings.__class__.__name__:
+            self.embeddings = provider(**embedding_params)
+        return self.embeddings
+    
+    def create_llm_chain(self, provider: BaseProvider, provider_params: Dict[str, str]):
+        raise NotImplementedError("Should be implemented by subclasses")
     
     def parse_args(self, message):
         args = message.body.split(' ')

--- a/packages/jupyter-ai/jupyter_ai/actors/chat_provider.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/chat_provider.py
@@ -21,13 +21,13 @@ class ChatProviderActor():
         provider = ray.get(p)
         
         if not provider:
-            return
+            raise ValueError(f"No provider and model found with '{config.model_provider}'")
+        
         auth_strategy = provider.auth_strategy
         api_keys = config.api_keys
         if auth_strategy:
             if auth_strategy.type == "env" and auth_strategy.name.lower() not in api_keys:
-                # raise error?
-                return
+                raise ValueError(f"Missing value for '{auth_strategy.name}' in the config.")
             
             provider_params = { "model_id": local_model_id}
             api_key_name = auth_strategy.name.lower()

--- a/packages/jupyter-ai/jupyter_ai/actors/chat_provider.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/chat_provider.py
@@ -1,0 +1,40 @@
+
+import os
+from typing import Optional
+from jupyter_ai.actors.base import Logger, ACTOR_TYPE
+from jupyter_ai.models import ProviderConfig
+from jupyter_ai_magics.utils import decompose_model_id
+import ray
+
+@ray.remote
+class ChatProviderActor():
+
+    def __init__(self, log: Logger):
+        self.log = log
+        self.provider = None
+
+    def update(self, config: ProviderConfig):
+        providers_actor = ray.get_actor(ACTOR_TYPE.PROVIDERS.value)
+        o = providers_actor.get_model_providers.remote()
+        providers = ray.get(o)
+        provider_id, local_model_id = decompose_model_id(model_id=config.model_provider, providers=providers)
+        
+        p = providers_actor.get_model_provider.remote(provider_id)
+        provider = ray.get(p)
+        
+        if not provider:
+            return
+        auth_strategy = provider.auth_strategy
+        api_keys = config.api_keys
+        if auth_strategy:
+            if auth_strategy.type == "env" and auth_strategy.name.lower() not in api_keys:
+                # raise error?
+                return
+            
+            provider_params = { "model_id": local_model_id}
+            api_key_name = auth_strategy.name.lower()
+            provider_params[api_key_name] = api_keys[api_key_name]
+            self.provider = provider(**provider_params)
+
+    def get_provider(self):
+        return self.provider

--- a/packages/jupyter-ai/jupyter_ai/actors/chat_provider.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/chat_provider.py
@@ -1,6 +1,3 @@
-
-import os
-from typing import Optional
 from jupyter_ai.actors.base import Logger, ACTOR_TYPE
 from jupyter_ai.models import ProviderConfig
 from jupyter_ai_magics.utils import decompose_model_id
@@ -12,6 +9,7 @@ class ChatProviderActor():
     def __init__(self, log: Logger):
         self.log = log
         self.provider = None
+        self.provider_params = None
 
     def update(self, config: ProviderConfig):
         providers_actor = ray.get_actor(ACTOR_TYPE.PROVIDERS.value)
@@ -34,7 +32,11 @@ class ChatProviderActor():
             provider_params = { "model_id": local_model_id}
             api_key_name = auth_strategy.name.lower()
             provider_params[api_key_name] = api_keys[api_key_name]
-            self.provider = provider(**provider_params)
+            self.provider = provider
+            self.provider_params = provider_params
 
     def get_provider(self):
         return self.provider
+    
+    def get_provider_params(self):
+        return self.provider_params

--- a/packages/jupyter-ai/jupyter_ai/actors/config.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/config.py
@@ -1,0 +1,53 @@
+import json
+import os
+from jupyter_ai.actors.base import ACTOR_TYPE, Logger
+from jupyter_ai.models import GlobalConfig
+import ray
+from jupyter_core.paths import jupyter_data_dir
+
+
+@ray.remote
+class ConfigActor():
+    """Provides model and embedding provider id along 
+    with the credentials to authenticate providers.
+    """
+
+    def __init__(self, log: Logger):
+        self.log = log
+        self.save_dir = os.path.join(jupyter_data_dir(), 'jupyter_ai')
+        self.save_path = os.path.join(self.save_dir, 'config.json')
+        self.config = None
+        self._load()
+
+    def update(self, config: GlobalConfig, save_to_disk: bool = True):
+        self._update_chat_provider(config)
+        self._update_embeddings_provider(config)
+        if save_to_disk:
+            self._save()
+        self.config = config
+    
+    def _update_chat_provider(self, config: GlobalConfig):
+        actor = ray.get_actor(ACTOR_TYPE.CHAT_PROVIDER)
+        handle = actor.update.remote(config)
+        ray.get(handle)
+
+    def _update_embeddings_provider(self, config: GlobalConfig):
+        actor = ray.get_actor(ACTOR_TYPE.EMBEDDINGS_PROVIDER)
+        handle = actor.update.remote(config)
+        ray.get(handle)
+
+    def _save(self, config: GlobalConfig):
+        if not os.path.exists:
+            os.makedirs(self.save_dir)
+        
+        with open(self.save_path, 'w') as f:
+                f.write(json.dumps(config))
+
+    def _load(self):
+        if os.path.exists(self.save_path):
+            with open(self.save_path, 'r', encoding='utf-8') as f:
+                config = GlobalConfig(**json.loads(f.read()))
+                self.update(config, False)
+
+    def get_config(self):
+        return self.config

--- a/packages/jupyter-ai/jupyter_ai/actors/default.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/default.py
@@ -12,8 +12,8 @@ from langchain.prompts import (
 
 from jupyter_ai.actors.base import BaseActor, Logger, ACTOR_TYPE
 from jupyter_ai.actors.memory import RemoteMemory
-from jupyter_ai.models import HumanChatMessage, ProviderConfig
-from jupyter_ai_magics.providers import ChatOpenAINewProvider
+from jupyter_ai.models import HumanChatMessage
+from jupyter_ai_magics.providers import BaseProvider
 
 SYSTEM_PROMPT = "The following is a friendly conversation between a human and an AI, whose name is Jupyter AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know."
 
@@ -21,27 +21,40 @@ SYSTEM_PROMPT = "The following is a friendly conversation between a human and an
 class DefaultActor(BaseActor):
     def __init__(self, reply_queue: Queue, log: Logger):
         super().__init__(reply_queue=reply_queue, log=log)
-        provider = ChatOpenAINewProvider(model_id="gpt-3.5-turbo")
-        
-        # Create a conversation memory
+        self.provider = None
+        self.chat_provider = None
+
+    def create_chat_provider(self, provider: BaseProvider):
         memory = RemoteMemory(actor_name=ACTOR_TYPE.MEMORY)
         prompt_template = ChatPromptTemplate.from_messages([
             SystemMessagePromptTemplate.from_template(SYSTEM_PROMPT),
             MessagesPlaceholder(variable_name="history"),
             HumanMessagePromptTemplate.from_template("{input}")
         ])
-        chain = ConversationChain(
-            llm=provider, 
+        self.provider = provider
+        self.chat_provider = ConversationChain(
+            llm=provider,
             prompt=prompt_template,
             verbose=True,
             memory=memory
         )
-        self.chat_provider = chain
 
-    def update_chat_provider(config: ProviderConfig):
-        # Placeholder for updating chat provider
-        pass
+    def _get_chat_provider(self):
+        actor = ray.get_actor(ACTOR_TYPE.CHAT_PROVIDER)
+        o = actor.get_provider.remote()
+        provider = ray.get(o)
+        
+        if not provider:
+            return None
+        
+        if provider.__class__.__name__ != self.provider.__class__.__name__:
+            self.create_chat_provider(provider)
+        return self.chat_provider
 
     def _process_message(self, message: HumanChatMessage):
-        response = self.chat_provider.predict(input=message.body)
+        chat_provider = self._get_chat_provider()
+        if not chat_provider:
+            response = "It seems like there is no chat provider set up currently to allow chat to work. Please follow the settings panel to configure a chat provider, before using the chat."
+        else:
+            response = self.chat_provider.predict(input=message.body)
         self.reply(response, message)

--- a/packages/jupyter-ai/jupyter_ai/actors/default.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/default.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from jupyter_ai_magics.utils import decompose_model_id
 import ray
 from ray.util.queue import Queue
@@ -21,40 +22,24 @@ SYSTEM_PROMPT = "The following is a friendly conversation between a human and an
 class DefaultActor(BaseActor):
     def __init__(self, reply_queue: Queue, log: Logger):
         super().__init__(reply_queue=reply_queue, log=log)
-        self.provider = None
-        self.chat_provider = None
 
-    def create_chat_provider(self, provider: BaseProvider):
+    def create_llm_chain(self, provider: BaseProvider, provider_params: Dict[str, str]):
+        llm = provider(**provider_params)
         memory = RemoteMemory(actor_name=ACTOR_TYPE.MEMORY)
         prompt_template = ChatPromptTemplate.from_messages([
             SystemMessagePromptTemplate.from_template(SYSTEM_PROMPT),
             MessagesPlaceholder(variable_name="history"),
             HumanMessagePromptTemplate.from_template("{input}")
         ])
-        self.provider = provider
-        self.chat_provider = ConversationChain(
-            llm=provider,
+        self.llm = llm
+        self.llm_chain = ConversationChain(
+            llm=llm,
             prompt=prompt_template,
             verbose=True,
             memory=memory
         )
 
-    def _get_chat_provider(self):
-        actor = ray.get_actor(ACTOR_TYPE.CHAT_PROVIDER)
-        o = actor.get_provider.remote()
-        provider = ray.get(o)
-        
-        if not provider:
-            return None
-        
-        if provider.__class__.__name__ != self.provider.__class__.__name__:
-            self.create_chat_provider(provider)
-        return self.chat_provider
-
     def _process_message(self, message: HumanChatMessage):
-        chat_provider = self._get_chat_provider()
-        if not chat_provider:
-            response = "It seems like there is no chat provider set up currently to allow chat to work. Please follow the settings panel to configure a chat provider, before using the chat."
-        else:
-            response = self.chat_provider.predict(input=message.body)
+        self.get_llm_chain()
+        response = self.llm_chain.predict(input=message.body)
         self.reply(response, message)

--- a/packages/jupyter-ai/jupyter_ai/actors/default.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/default.py
@@ -1,5 +1,4 @@
-from typing import Dict
-from jupyter_ai_magics.utils import decompose_model_id
+from typing import Dict, Type
 import ray
 from ray.util.queue import Queue
 
@@ -23,7 +22,7 @@ class DefaultActor(BaseActor):
     def __init__(self, reply_queue: Queue, log: Logger):
         super().__init__(reply_queue=reply_queue, log=log)
 
-    def create_llm_chain(self, provider: BaseProvider, provider_params: Dict[str, str]):
+    def create_llm_chain(self, provider: Type[BaseProvider], provider_params: Dict[str, str]):
         llm = provider(**provider_params)
         memory = RemoteMemory(actor_name=ACTOR_TYPE.MEMORY)
         prompt_template = ChatPromptTemplate.from_messages([

--- a/packages/jupyter-ai/jupyter_ai/actors/default.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/default.py
@@ -1,3 +1,4 @@
+from jupyter_ai_magics.utils import decompose_model_id
 import ray
 from ray.util.queue import Queue
 
@@ -11,7 +12,7 @@ from langchain.prompts import (
 
 from jupyter_ai.actors.base import BaseActor, Logger, ACTOR_TYPE
 from jupyter_ai.actors.memory import RemoteMemory
-from jupyter_ai.models import HumanChatMessage
+from jupyter_ai.models import HumanChatMessage, ProviderConfig
 from jupyter_ai_magics.providers import ChatOpenAINewProvider
 
 SYSTEM_PROMPT = "The following is a friendly conversation between a human and an AI, whose name is Jupyter AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know."
@@ -36,6 +37,10 @@ class DefaultActor(BaseActor):
             memory=memory
         )
         self.chat_provider = chain
+
+    def update_chat_provider(config: ProviderConfig):
+        # Placeholder for updating chat provider
+        pass
 
     def _process_message(self, message: HumanChatMessage):
         response = self.chat_provider.predict(input=message.body)

--- a/packages/jupyter-ai/jupyter_ai/actors/embeddings_provider.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/embeddings_provider.py
@@ -24,14 +24,13 @@ class EmbeddingsProviderActor():
         p = providers_actor.get_embeddings_provider.remote(provider_id)
         provider = ray.get(p)
         if not provider:
-            return
+            raise ValueError(f"No provider and model found with '{config.embeddings_provider}'")
         
         auth_strategy = provider.auth_strategy
         api_keys = config.api_keys
         if auth_strategy:
             if auth_strategy.type == "env" and auth_strategy.name.lower() not in api_keys:
-                # raise error?
-                return
+                raise ValueError(f"Missing value for '{auth_strategy.name}' in the config.")
             
             provider_params = {}
             provider_params[provider.model_id_key] = local_model_id

--- a/packages/jupyter-ai/jupyter_ai/actors/embeddings_provider.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/embeddings_provider.py
@@ -13,6 +13,7 @@ class EmbeddingsProviderActor():
     def __init__(self, log: Logger):
         self.log = log
         self.provider = None
+        self.provider_params = None
 
     def update(self, config: ProviderConfig):
         providers_actor = ray.get_actor(ACTOR_TYPE.PROVIDERS.value)
@@ -36,7 +37,11 @@ class EmbeddingsProviderActor():
             provider_params[provider.model_id_key] = local_model_id
             api_key_name = auth_strategy.name.lower()
             provider_params[api_key_name] = api_keys[api_key_name]
-            self.provider = provider.provider_klass(**provider_params)
+            self.provider = provider.provider_klass
+            self.provider_params = provider_params
 
     def get_provider(self):
         return self.provider
+    
+    def get_provider_params(self):
+        return self.provider_params

--- a/packages/jupyter-ai/jupyter_ai/actors/embeddings_provider.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/embeddings_provider.py
@@ -1,10 +1,5 @@
-
-
-
-from typing import Optional
 from jupyter_ai.actors.base import Logger, ACTOR_TYPE
-from jupyter_ai.models import ProviderConfig
-from jupyter_ai_magics.utils import decompose_model_id
+from jupyter_ai.models import GlobalConfig
 import ray
 
 @ray.remote
@@ -15,29 +10,29 @@ class EmbeddingsProviderActor():
         self.provider = None
         self.provider_params = None
 
-    def update(self, config: ProviderConfig):
-        providers_actor = ray.get_actor(ACTOR_TYPE.PROVIDERS.value)
-        o = providers_actor.get_embeddings_providers.remote()
-        providers = ray.get(o)
-        provider_id, local_model_id = decompose_model_id(model_id=config.embeddings_provider, providers=providers)
-
-        p = providers_actor.get_embeddings_provider.remote(provider_id)
-        provider = ray.get(p)
+    def update(self, config: GlobalConfig):
+        model_id = config.embeddings_provider_id
+        actor = ray.get_actor(ACTOR_TYPE.PROVIDERS.value)
+        local_model_id, provider = ray.get(
+            actor.get_embeddings_provider_data.remote(model_id)
+        )
+        
         if not provider:
-            raise ValueError(f"No provider and model found with '{config.embeddings_provider}'")
+            raise ValueError(f"No provider and model found with '{model_id}'")
+        
+        provider_params = {}
+        provider_params[provider.model_id_key] = local_model_id
         
         auth_strategy = provider.auth_strategy
-        api_keys = config.api_keys
-        if auth_strategy:
-            if auth_strategy.type == "env" and auth_strategy.name.lower() not in api_keys:
+        if auth_strategy and auth_strategy.type == "env":
+            api_keys = config.api_keys
+            name = auth_strategy.name.lower()
+            if name not in api_keys:
                 raise ValueError(f"Missing value for '{auth_strategy.name}' in the config.")
+            provider_params[name] = api_keys[name]
             
-            provider_params = {}
-            provider_params[provider.model_id_key] = local_model_id
-            api_key_name = auth_strategy.name.lower()
-            provider_params[api_key_name] = api_keys[api_key_name]
-            self.provider = provider.provider_klass
-            self.provider_params = provider_params
+        self.provider = provider.provider_klass
+        self.provider_params = provider_params
 
     def get_provider(self):
         return self.provider

--- a/packages/jupyter-ai/jupyter_ai/actors/embeddings_provider.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/embeddings_provider.py
@@ -1,0 +1,42 @@
+
+
+
+from typing import Optional
+from jupyter_ai.actors.base import Logger, ACTOR_TYPE
+from jupyter_ai.models import ProviderConfig
+from jupyter_ai_magics.utils import decompose_model_id
+import ray
+
+@ray.remote
+class EmbeddingsProviderActor():
+
+    def __init__(self, log: Logger):
+        self.log = log
+        self.provider = None
+
+    def update(self, config: ProviderConfig):
+        providers_actor = ray.get_actor(ACTOR_TYPE.PROVIDERS.value)
+        o = providers_actor.get_embeddings_providers.remote()
+        providers = ray.get(o)
+        provider_id, local_model_id = decompose_model_id(model_id=config.embeddings_provider, providers=providers)
+
+        p = providers_actor.get_embeddings_provider.remote(provider_id)
+        provider = ray.get(p)
+        if not provider:
+            return
+        
+        auth_strategy = provider.auth_strategy
+        api_keys = config.api_keys
+        if auth_strategy:
+            if auth_strategy.type == "env" and auth_strategy.name.lower() not in api_keys:
+                # raise error?
+                return
+            
+            provider_params = {}
+            provider_params[provider.model_id_key] = local_model_id
+            api_key_name = auth_strategy.name.lower()
+            provider_params[api_key_name] = api_keys[api_key_name]
+            self.provider = provider.provider_klass(**provider_params)
+
+    def get_provider(self):
+        return self.provider

--- a/packages/jupyter-ai/jupyter_ai/actors/generate.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/generate.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict
+from typing import Dict, Type
 
 import ray
 from ray.util.queue import Queue
@@ -204,7 +204,7 @@ class GenerateActor(BaseActor):
         self.root_dir = os.path.abspath(os.path.expanduser(root_dir))
         self.llm = None
 
-    def create_llm_chain(self, provider: BaseProvider, provider_params: Dict[str, str]):
+    def create_llm_chain(self, provider: Type[BaseProvider], provider_params: Dict[str, str]):
         llm = provider(**provider_params)
         self.llm = llm
         return llm

--- a/packages/jupyter-ai/jupyter_ai/actors/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/learn.py
@@ -1,5 +1,6 @@
 import os
 import argparse
+from typing import List
 
 import ray
 from ray.util.queue import Queue
@@ -11,6 +12,7 @@ from langchain.text_splitter import (
     RecursiveCharacterTextSplitter, PythonCodeTextSplitter,
     MarkdownTextSplitter, LatexTextSplitter
 )
+from langchain.schema import Document
 
 from jupyter_ai.models import HumanChatMessage
 from jupyter_ai.actors.base import BaseActor, Logger
@@ -121,3 +123,9 @@ class LearnActor(BaseActor):
                 self.index = FAISS.load_local(self.index_save_dir, embeddings, index_name=self.index_name)
             except Exception as e:
                 self.create()
+
+    def get_relevant_documents(self, question: str) -> List[Document]:
+        if self.index:
+            docs = self.index.similarity_search(question)
+            return docs
+        return []

--- a/packages/jupyter-ai/jupyter_ai/actors/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/learn.py
@@ -1,8 +1,5 @@
 import os
-import traceback
-from collections import Counter
 import argparse
-from jupyter_ai_magics.embedding_providers import BaseEmbeddingsProvider
 
 import ray
 from ray.util.queue import Queue
@@ -10,15 +7,13 @@ from ray.util.queue import Queue
 from jupyter_core.paths import jupyter_data_dir
 
 from langchain import FAISS
-from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.text_splitter import (
     RecursiveCharacterTextSplitter, PythonCodeTextSplitter,
     MarkdownTextSplitter, LatexTextSplitter
 )
 
 from jupyter_ai.models import HumanChatMessage
-from jupyter_ai.actors.base import ACTOR_TYPE, BaseActor, Logger
-from jupyter_ai_magics.providers import ChatOpenAINewProvider
+from jupyter_ai.actors.base import BaseActor, Logger
 from jupyter_ai.document_loaders.directory import RayRecursiveDirectoryLoader
 from jupyter_ai.document_loaders.splitter import ExtensionSplitter, NotebookSplitter
 
@@ -47,6 +42,10 @@ class LearnActor(BaseActor):
     def _process_message(self, message: HumanChatMessage):
         if not self.index:
             self.load_or_create()
+
+        # If index is not still there, embeddings are not present
+        if not self.index:
+            self.reply("Sorry, please select an embedding provider before using the `/learn` command.")
 
         args = self.parse_args(message)
         if args is None:

--- a/packages/jupyter-ai/jupyter_ai/actors/providers.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/providers.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from jupyter_ai_magics.utils import load_embedding_providers, load_providers
 import ray
 from jupyter_ai.actors.base import BaseActor, Logger
@@ -13,6 +14,18 @@ class ProvidersActor():
 
     def get_model_providers(self):
         return self.model_providers
+    
+    def get_model_provider(self, provider_id: Optional[str]):
+        if provider_id is None or provider_id not in self.model_providers:
+            return None
+
+        return self.model_providers[provider_id]
+    
+    def get_embeddings_provider(self, provider_id: Optional[str]):
+        if provider_id is None or provider_id not in self.embeddings_providers:
+            return None
+
+        return self.embeddings_providers[provider_id]
     
     def get_embeddings_providers(self):
         return self.embeddings_providers

--- a/packages/jupyter-ai/jupyter_ai/actors/providers.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/providers.py
@@ -1,0 +1,20 @@
+from jupyter_ai_magics.utils import load_embedding_providers, load_providers
+import ray
+from jupyter_ai.actors.base import BaseActor, Logger
+from ray.util.queue import Queue
+
+@ray.remote
+class ProvidersActor():
+    
+    def __init__(self, log: Logger):
+        self.log = log
+        self.model_providers = load_providers(log=log)
+        self.embeddings_providers = load_embedding_providers(log=log)
+
+    def get_model_providers(self):
+        return self.model_providers
+    
+    def get_embeddings_providers(self):
+        return self.embeddings_providers
+
+    

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -16,7 +16,15 @@ from jupyter_ai.actors.generate import GenerateActor
 from jupyter_ai.actors.base import ACTOR_TYPE
 from jupyter_ai.reply_processor import ReplyProcessor
 from jupyter_server.extension.application import ExtensionApp
-from .handlers import ChatHandler, ChatHistoryHandler, EmbeddingsModelProviderHandler, ModelProviderHandler, PromptAPIHandler, TaskAPIHandler
+from .handlers import (
+    ChatHandler, 
+    ChatHistoryHandler, 
+    EmbeddingsModelProviderHandler, 
+    ModelProviderHandler, 
+    PromptAPIHandler, 
+    TaskAPIHandler,
+    ProviderConfigHandler
+)
 from importlib_metadata import entry_points
 import inspect
 from .engine import BaseModelEngine
@@ -29,6 +37,7 @@ from ray.util.queue import Queue
 class AiExtension(ExtensionApp):
     name = "jupyter_ai"
     handlers = [
+        ("api/ai/config", ProviderConfigHandler),
         ("api/ai/prompt", PromptAPIHandler),
         (r"api/ai/tasks/?", TaskAPIHandler),
         (r"api/ai/tasks/([\w\-:]*)", TaskAPIHandler),

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import queue
+from jupyter_ai_magics.utils import load_providers
 from langchain.memory import ConversationBufferWindowMemory
 from jupyter_ai.actors.default import DefaultActor 
 from jupyter_ai.actors.ask import AskActor 
@@ -11,7 +12,7 @@ from jupyter_ai.actors.generate import GenerateActor
 from jupyter_ai.actors.base import ACTOR_TYPE
 from jupyter_ai.reply_processor import ReplyProcessor
 from jupyter_server.extension.application import ExtensionApp
-from .handlers import ChatHandler, ChatHistoryHandler, PromptAPIHandler, TaskAPIHandler
+from .handlers import ChatHandler, ChatHistoryHandler, ModelProviderHandler, PromptAPIHandler, TaskAPIHandler
 from importlib_metadata import entry_points
 import inspect
 from .engine import BaseModelEngine
@@ -29,6 +30,7 @@ class AiExtension(ExtensionApp):
         (r"api/ai/tasks/([\w\-:]*)", TaskAPIHandler),
         (r"api/ai/chats/?", ChatHandler),
         (r"api/ai/chats/history?", ChatHistoryHandler),
+        (r"api/ai/providers?", ModelProviderHandler),
     ]
 
     @property
@@ -90,6 +92,10 @@ class AiExtension(ExtensionApp):
 
         self.settings["ai_default_tasks"] = default_tasks
         self.log.info("Registered all default tasks.")
+
+        providers = load_providers(log=self.log)
+        self.settings["chat_providers"] = providers
+        self.log.info("Registered providers.")
 
         if ChatOpenAINewProvider.auth_strategy.name not in os.environ:
             raise EnvironmentError(f"`{ChatOpenAINewProvider.auth_strategy.name}` value not set in environment. For chat to work, this value should be provided.")

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import queue
-from jupyter_ai_magics.utils import load_providers
+from jupyter_ai_magics.utils import load_embedding_providers, load_providers
 from langchain.memory import ConversationBufferWindowMemory
 from jupyter_ai.actors.default import DefaultActor 
 from jupyter_ai.actors.ask import AskActor 
@@ -12,7 +12,7 @@ from jupyter_ai.actors.generate import GenerateActor
 from jupyter_ai.actors.base import ACTOR_TYPE
 from jupyter_ai.reply_processor import ReplyProcessor
 from jupyter_server.extension.application import ExtensionApp
-from .handlers import ChatHandler, ChatHistoryHandler, ModelProviderHandler, PromptAPIHandler, TaskAPIHandler
+from .handlers import ChatHandler, ChatHistoryHandler, EmbeddingsModelProviderHandler, ModelProviderHandler, PromptAPIHandler, TaskAPIHandler
 from importlib_metadata import entry_points
 import inspect
 from .engine import BaseModelEngine
@@ -31,6 +31,7 @@ class AiExtension(ExtensionApp):
         (r"api/ai/chats/?", ChatHandler),
         (r"api/ai/chats/history?", ChatHistoryHandler),
         (r"api/ai/providers?", ModelProviderHandler),
+        (r"api/ai/providers/embeddings?", EmbeddingsModelProviderHandler),
     ]
 
     @property
@@ -96,6 +97,10 @@ class AiExtension(ExtensionApp):
         providers = load_providers(log=self.log)
         self.settings["chat_providers"] = providers
         self.log.info("Registered providers.")
+
+        embeddings_providers = load_embedding_providers(log=self.log)
+        self.settings["embeddings_providers"] = embeddings_providers
+        self.log.info("Registered embeddings providers.")
 
         if ChatOpenAINewProvider.auth_strategy.name not in os.environ:
             raise EnvironmentError(f"`{ChatOpenAINewProvider.auth_strategy.name}` value not set in environment. For chat to work, this value should be provided.")

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -50,10 +50,6 @@ class APIHandler(BaseAPIHandler):
             self.settings["task_manager"] = TaskManager(engines=self.engines, default_tasks=self.default_tasks)
         return self.settings["task_manager"]
     
-    @property
-    def openai_chat(self):
-        return self.settings["openai_chat"]
-    
 class PromptAPIHandler(APIHandler):
     @tornado.web.authenticated
     async def post(self):

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -16,9 +16,10 @@ from jupyter_server.base.handlers import APIHandler as BaseAPIHandler, JupyterHa
 from jupyter_server.utils import ensure_async
 
 from .task_manager import TaskManager
+
 from .models import (
     ChatHistory, 
-    ListProviderEntry, 
+    ListProvidersEntry, 
     ListProvidersResponse, 
     PromptRequest, 
     ChatRequest, 
@@ -29,7 +30,6 @@ from .models import (
     ConnectionMessage, 
     ChatClient
 )
-
 
 
 class APIHandler(BaseAPIHandler):
@@ -279,7 +279,7 @@ class ModelProviderHandler(BaseAPIHandler):
         providers = []
         for provider in self.chat_providers.values():
             providers.append(
-                ListProviderEntry(
+                ListProvidersEntry(
                     id=provider.id,
                     name=provider.name,
                     models=provider.models,

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -291,6 +291,24 @@ class ModelProviderHandler(BaseAPIHandler):
         self.finish(response.json())
 
 
-class EmbeddingModelProviderHandler(BaseAPIHandler):
-    # Placeholder for embedding model provider handler
-    pass
+class EmbeddingsModelProviderHandler(BaseAPIHandler):
+    
+    @property
+    def embeddings_providers(self):
+        return self.settings['embeddings_providers']
+
+    @web.authenticated
+    def get(self):
+        providers = []
+        for provider in self.embeddings_providers.values():
+            providers.append(
+                ListProvidersEntry(
+                    id=provider.id,
+                    name=provider.name,
+                    models=provider.models,
+                    auth_strategy=provider.auth_strategy
+                )
+            )
+        
+        response = ListProvidersResponse(providers=sorted(providers, key=lambda p: p.name))
+        self.finish(response.json())

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -18,7 +18,8 @@ from jupyter_server.utils import ensure_async
 from .task_manager import TaskManager
 
 from .models import (
-    ChatHistory, 
+    ChatHistory,
+    ChatUser, 
     ListProvidersEntry, 
     ListProvidersResponse, 
     PromptRequest, 

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -16,7 +16,20 @@ from jupyter_server.base.handlers import APIHandler as BaseAPIHandler, JupyterHa
 from jupyter_server.utils import ensure_async
 
 from .task_manager import TaskManager
-from .models import ChatHistory, PromptRequest, ChatRequest, ChatMessage, Message, AgentChatMessage, HumanChatMessage, ConnectionMessage, ChatClient, ChatUser
+from .models import (
+    ChatHistory, 
+    ListProviderEntry, 
+    ListProvidersResponse, 
+    PromptRequest, 
+    ChatRequest, 
+    ChatMessage, 
+    Message, 
+    AgentChatMessage, 
+    HumanChatMessage, 
+    ConnectionMessage, 
+    ChatClient
+)
+
 
 
 class APIHandler(BaseAPIHandler):
@@ -254,3 +267,29 @@ class ChatHandler(
 
         self.log.info(f"Client disconnected. ID: {self.client_id}")
         self.log.debug("Chat clients: %s", self.chat_handlers.keys())
+
+
+class ModelProviderHandler(BaseAPIHandler):
+    @property
+    def chat_providers(self): 
+        return self.settings["chat_providers"]
+    
+    @web.authenticated
+    def get(self):
+        providers = []
+        for provider in self.chat_providers.values():
+            providers.append(
+                ListProviderEntry(
+                    id=provider.id,
+                    name=provider.name,
+                    models=provider.models,
+                    auth_strategy=provider.auth_strategy
+                )
+            )
+        response = ListProvidersResponse(providers=providers)
+        self.finish(response.json())
+
+
+class EmbeddingModelProviderHandler(BaseAPIHandler):
+    # Placeholder for embedding model provider handler
+    pass

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -286,7 +286,8 @@ class ModelProviderHandler(BaseAPIHandler):
                     auth_strategy=provider.auth_strategy
                 )
             )
-        response = ListProvidersResponse(providers=providers)
+        
+        response = ListProvidersResponse(providers=sorted(providers, key=lambda p: p.name))
         self.finish(response.json())
 
 

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -273,7 +273,9 @@ class ChatHandler(
 class ModelProviderHandler(BaseAPIHandler):
     @property
     def chat_providers(self): 
-        return self.settings["chat_providers"]
+        actor = ray.get_actor("providers")
+        o = actor.get_model_providers.remote()
+        return ray.get(o)
     
     @web.authenticated
     def get(self):
@@ -296,7 +298,9 @@ class EmbeddingsModelProviderHandler(BaseAPIHandler):
     
     @property
     def embeddings_providers(self):
-        return self.settings['embeddings_providers']
+        actor = ray.get_actor("providers")
+        o = actor.get_embeddings_providers.remote()
+        return ray.get(o)
 
     @web.authenticated
     def get(self):
@@ -313,3 +317,10 @@ class EmbeddingsModelProviderHandler(BaseAPIHandler):
         
         response = ListProvidersResponse(providers=sorted(providers, key=lambda p: p.name))
         self.finish(response.json())
+
+
+class ProviderConfigHandler(BaseAPIHandler):
+    
+    @web.authenticated
+    def get(self):
+        ...

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -1,3 +1,4 @@
+from jupyter_ai_magics.providers import AuthStrategy
 from pydantic import BaseModel 
 from typing import Dict, List, Union, Literal, Optional
 
@@ -80,3 +81,17 @@ class DescribeTaskResponse(BaseModel):
 class ChatHistory(BaseModel):
     """History of chat messages"""
     messages: List[ChatMessage]
+
+
+class ListProviderEntry(BaseModel):
+    """Model provider with supported models
+    and provider's authentication strategy
+    """
+    id: str
+    name: str
+    models: List[str]
+    auth_strategy: AuthStrategy
+
+
+class ListProvidersResponse(BaseModel):
+    providers: List[ListProviderEntry]

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -83,7 +83,7 @@ class ChatHistory(BaseModel):
     messages: List[ChatMessage]
 
 
-class ListProviderEntry(BaseModel):
+class ListProvidersEntry(BaseModel):
     """Model provider with supported models
     and provider's authentication strategy
     """
@@ -94,4 +94,4 @@ class ListProviderEntry(BaseModel):
 
 
 class ListProvidersResponse(BaseModel):
-    providers: List[ListProviderEntry]
+    providers: List[ListProvidersEntry]

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -1,4 +1,5 @@
-from jupyter_ai_magics.providers import AuthStrategy
+from jupyter_ai_magics.embedding_providers import BaseEmbeddingsProvider
+from jupyter_ai_magics.providers import AuthStrategy, BaseProvider
 from pydantic import BaseModel 
 from typing import Dict, List, Union, Literal, Optional
 
@@ -95,3 +96,9 @@ class ListProvidersEntry(BaseModel):
 
 class ListProvidersResponse(BaseModel):
     providers: List[ListProvidersEntry]
+
+
+class ProviderConfig(BaseModel):
+    model_provider: str
+    embeddings_provider: str
+    api_keys: Dict[str, str]

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -98,7 +98,7 @@ class ListProvidersResponse(BaseModel):
     providers: List[ListProvidersEntry]
 
 
-class ProviderConfig(BaseModel):
-    model_provider: str
-    embeddings_provider: str
+class GlobalConfig(BaseModel):
+    model_provider_id: str
+    embeddings_provider_id: str
     api_keys: Dict[str, str]


### PR DESCRIPTION
Fixes #102, #103, #105 

## Summary
This PR introduces the concept of `ProviderConfig`, that provides the values for the llm and embeddings provider and model, along with the api keys for the chat to work. 

### Actors 
1. **ProvidersActor**:  This actor loads and keeps a list of model and embeddings providers
2. **ChatProviderActor**: This actor stores the updated model provider (LLM) and provider params, which are updated when config is updated.
3. **EmbeddingsProviderActor**: This actor stores the updated embeddings provider and params, which are updated when config is updated.
4. **ConfigActor**: This actor stores the `ProviderConfig` object which is shared globally with other actors above, and is responsible for loading and saving the config from/to the disk.

### APIs
1. **GET /api/ai/providers**: Returns list of  model providers and models they support
2. **GET /api/ai/providers/embeddings**: Returns list of embeddings providers and supported model options
3. **GET /api/ai/config**: Returns the currently set config as `ProviderConfig`
4. **POST /api/ai/config**: Updates the config, saves to disk and updates chat provider and embeddings

## Notes
1. The anthropic models don't wrap the code segments in the response in a markdown code block; I have tried updating the prompt template and hasn't seen this working yet. 
    <img width="402" alt="Screen Shot 2023-04-26 at 7 40 41 PM" src="https://user-images.githubusercontent.com/289369/234760890-0d8f6313-9aeb-4354-8122-4af8e5cb16c8.png">


1. The current setup is not working with certain embeddings, particularly `Cohere` because of the way the `AskActor` references the vectorstore, and uses it to get the retriever. `Cohere` embeddings has some non-serializable parts, which causes errors when the `AskActor` loads it to set the retriever but is unable to de-serialize. 

    The last line here causes an exception
    ```python
    index_actor = ray.get_actor(ACTOR_TYPE.LEARN.value)
    handle = index_actor.get_index.remote()
    vectorstore = ray.get(handle)
    ```

    Here is the exception:
    ```python
    Traceback (most recent call last):
    File "/Users/pijain/projects/jupyter-ai-3.9/jupyter-ai/packages/jupyter-ai/jupyter_ai/actors/base.py", line 55, in process_message
        self._process_message(message)
    File "/Users/pijain/Library/Application Support/hatch/env/virtual/jupyter-ai-monorepo/X-JWbDZw/jupyter-ai-monorepo/lib/python3.9/site-packages/ray/util/tracing/tracing_helper.py", line 466, in _resume_span
        return method(self, *_args, **_kwargs)
    File "/Users/pijain/projects/jupyter-ai-3.9/jupyter-ai/packages/jupyter-ai/jupyter_ai/actors/ask.py", line 54, in _process_message
        vectorstore = ray.get(handle)
    File "/Users/pijain/Library/Application Support/hatch/env/virtual/jupyter-ai-monorepo/X-JWbDZw/jupyter-ai-monorepo/lib/python3.9/site-packages/ray/_private/client_mode_hook.py", line 105, in wrapper
        return func(*args, **kwargs)
    File "/Users/pijain/Library/Application Support/hatch/env/virtual/jupyter-ai-monorepo/X-JWbDZw/jupyter-ai-monorepo/lib/python3.9/site-packages/ray/_private/worker.py", line 2309, in get
        raise value.as_instanceof_cause()
    ray.exceptions.RayTaskError(TypeError): [36mray::LearnActor.get_index()[39m (pid=90820, ip=127.0.0.1, repr=<jupyter_ai.actors.learn.LearnActor object at 0x138093fd0>)
    File "/Users/pijain/Library/Application Support/hatch/env/virtual/jupyter-ai-monorepo/X-JWbDZw/jupyter-ai-monorepo/lib/python3.9/site-packages/ray/cloudpickle/cloudpickle_fast.py", line 73, in dumps
        cp.dump(obj)
    File "/Users/pijain/Library/Application Support/hatch/env/virtual/jupyter-ai-monorepo/X-JWbDZw/jupyter-ai-monorepo/lib/python3.9/site-packages/ray/cloudpickle/cloudpickle_fast.py", line 627, in dump
        return Pickler.dump(self, obj)
    TypeError: cannot pickle '_queue.SimpleQueue' object
    ```

1. Switching embedding providers will cause issues, since the saved index created with one provider is not portable to adding documents after switching to a new provider. In order to make this safely work for users, we have to make sure that the existing indexes are deleted when embeddings provider changes. Users should be aware of this change when they update config.
