### PR TITLE
Implement better non-collaborative identity

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -5,7 +5,7 @@ import ray
 import tornado
 import uuid
 import time
-import os
+import getpass
 
 from tornado.web import HTTPError
 from pydantic import ValidationError
@@ -167,7 +167,7 @@ class ChatHandler(
             return ChatUser(**asdict(self.current_user))
         
         
-        login = os.getlogin()
+        login = getpass.getuser()
         return ChatUser(
             username=self.current_user.username,
             initials=login[0].capitalize(),

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -5,6 +5,7 @@ import ray
 import tornado
 import uuid
 import time
+import os
 
 from tornado.web import HTTPError
 from pydantic import ValidationError
@@ -15,7 +16,7 @@ from jupyter_server.base.handlers import APIHandler as BaseAPIHandler, JupyterHa
 from jupyter_server.utils import ensure_async
 
 from .task_manager import TaskManager
-from .models import ChatHistory, PromptRequest, ChatRequest, ChatMessage, Message, AgentChatMessage, HumanChatMessage, ConnectionMessage, ChatClient
+from .models import ChatHistory, PromptRequest, ChatRequest, ChatMessage, Message, AgentChatMessage, HumanChatMessage, ConnectionMessage, ChatClient, ChatUser
 
 
 class APIHandler(BaseAPIHandler):
@@ -157,24 +158,39 @@ class ChatHandler(
         res = super().get(*args, **kwargs)
         await res
 
+    def get_current_user(self) -> ChatUser:
+        """Retrieves the current user. If collaborative mode is disabled, one
+        is synthesized from the login."""
+        collaborative = self.config.get("LabApp", {}).get("collaborative", False)
+
+        if collaborative:
+            return ChatUser(**asdict(self.current_user))
+        
+        
+        login = os.getlogin()
+        return ChatUser(
+            username=self.current_user.username,
+            initials=login[0],
+            name=login,
+            display_name=login,
+            color=None,
+            avatar_url=None
+        )
+
+
     def generate_client_id(self):
         """Generates a client ID to identify the current WS connection."""
-        # if collaborative mode is enabled, each client already has a UUID
-        # collaborative = self.config.get("LabApp", {}).get("collaborative", False)
-        # if collaborative:
-        #     return self.current_user.username
-
-        # if collaborative mode is not enabled, each client is assigned a UUID
         return uuid.uuid4().hex
 
     def open(self):
         """Handles opening of a WebSocket connection. Client ID can be retrieved
         from `self.client_id`."""
 
+        current_user = self.get_current_user().dict()
         client_id = self.generate_client_id()
 
         self.chat_handlers[client_id] = self
-        self.chat_clients[client_id] = ChatClient(**asdict(self.current_user), id=client_id)
+        self.chat_clients[client_id] = ChatClient(**current_user, id=client_id)
         self.client_id = client_id
         self.write_message(ConnectionMessage(client_id=client_id).dict())
 

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -170,7 +170,7 @@ class ChatHandler(
         login = os.getlogin()
         return ChatUser(
             username=self.current_user.username,
-            initials=login[0],
+            initials=login[0].capitalize(),
             name=login,
             display_name=login,
             color=None,

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -20,9 +20,9 @@ class ChatUser(BaseModel):
     avatar_url: Optional[str]
 
 class ChatClient(ChatUser):
-    # Client ID assigned by us. Necessary because different JupyterLab clients
-    # on the same device (i.e. running on multiple tabs/windows) may have the
-    # same user ID assigned to them by IdentityProvider.
+    # A unique client ID assigned to identify different JupyterLab clients on
+    # the same device (i.e. running on multiple tabs/windows), which may have
+    # the same username assigned to them by the IdentityProvider.
     id: str
 
 class AgentChatMessage(BaseModel):

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -10,11 +10,7 @@ class PromptRequest(BaseModel):
 class ChatRequest(BaseModel):
     prompt: str
 
-class ChatClient(BaseModel):
-    # Client ID assigned by us. Necessary because different JupyterLab clients
-    # on the same device (i.e. running on multiple tabs/windows) may have the
-    # same user ID assigned to them by IdentityProvider.
-    id: str
+class ChatUser(BaseModel):
     # User ID assigned by IdentityProvider.
     username: str
     initials: str
@@ -22,6 +18,12 @@ class ChatClient(BaseModel):
     display_name: str
     color: Optional[str]
     avatar_url: Optional[str]
+
+class ChatClient(ChatUser):
+    # Client ID assigned by us. Necessary because different JupyterLab clients
+    # on the same device (i.e. running on multiple tabs/windows) may have the
+    # same user ID assigned to them by IdentityProvider.
+    id: str
 
 class AgentChatMessage(BaseModel):
     type: Literal["agent"] = "agent"


### PR DESCRIPTION
# Description

Closes #75.

Uses `getpass.getuser()` to fill in the user's display name when collaborative mode is disabled, rather than relying on the IdentityProvider that produces a confusing "Anonymous XYZ" display name.

I also tested this locally with collaboration enabled to verify that there is no regression in the collaborative experience.

# Demo

<img width="392" alt="Screen Shot 2023-04-24 at 12 01 45 PM" src="https://user-images.githubusercontent.com/44106031/234091221-11bae77f-3edf-45c0-9367-765002ac347e.png">


