### PR TITLE
Strips language indicator from start of code output

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import warnings
 from typing import Optional
 
@@ -375,8 +376,10 @@ class AiMagics(Magics):
 
         # if the user wants code, add another cell with the output.
         if args.format == 'code':
-            # Strip leading and trailing triple-backticks
-            output = output.removeprefix('```\n').removesuffix('\n```')
+            # Strip a leading language indicator and trailing triple-backticks
+            lang_indicator = r'^```[a-zA-Z0-9]*\n'
+            output = re.sub(lang_indicator, '', output)
+            output = output.removesuffix('\n```')
             new_cell_payload = dict(
                 source='set_next_input',
                 text=output,


### PR DESCRIPTION
Fixes #110. Strips a leading language indicator, such as <code>\`\`\`python</code>, from the beginning of AI-generated output. The beginning of a code block without a language indicator, like <code>\`\`\`</code> on a line by itself, is still stripped.