### PR TITLE
Pin LangChain version

### DIFF
--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "openai~=0.26",
     "aiosqlite~=0.18",
     "importlib_metadata~=5.2.0",
-    "langchain~=0.0.144",
+    "langchain<=0.0.153",
     "tiktoken", # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "ray~=2.4.0", # Requires grpcio installation from conda

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "openai~=0.26",
     "aiosqlite~=0.18",
     "importlib_metadata~=5.2.0",
-    "langchain<=0.0.153",
+    "langchain==0.0.153",
     "tiktoken", # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "ray~=2.4.0", # Requires grpcio installation from conda

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -4,7 +4,7 @@
 #
 # see: https://github.com/lerna/lerna/issues/2369
 
-(npx -p lerna -y lerna version \
+(npx -p lerna@6.4.1 -y lerna version \
     --no-git-tag-version \
     --no-push \
     --force-publish \


### PR DESCRIPTION
The latest version of langchain has moved some files, which breaks the imports in jupyter-ai.