### PR TITLE
Chat settings UI

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/actors/chat_provider.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/chat_provider.py
@@ -25,10 +25,10 @@ class ChatProviderActor():
         auth_strategy = provider.auth_strategy
         if auth_strategy and auth_strategy.type == "env":
             api_keys = config.api_keys
-            name = auth_strategy.name.lower()
+            name = auth_strategy.name
             if name not in api_keys:
                 raise ValueError(f"Missing value for '{auth_strategy.name}' in the config.")
-            provider_params[name] = api_keys[name]
+            provider_params[name.lower()] = api_keys[name]
             
         self.provider = provider
         self.provider_params = provider_params

--- a/packages/jupyter-ai/jupyter_ai/actors/config.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/config.py
@@ -27,10 +27,16 @@ class ConfigActor():
         self.config = config
     
     def _update_chat_provider(self, config: GlobalConfig):
+        if not config.model_provider_id:
+            return
+
         actor = ray.get_actor(ACTOR_TYPE.CHAT_PROVIDER)
         ray.get(actor.update.remote(config))
 
     def _update_embeddings_provider(self, config: GlobalConfig):
+        if not config.embeddings_provider_id:
+            return
+
         actor = ray.get_actor(ACTOR_TYPE.EMBEDDINGS_PROVIDER)
         ray.get(actor.update.remote(config))
 
@@ -46,6 +52,10 @@ class ConfigActor():
             with open(self.save_path, 'r', encoding='utf-8') as f:
                 config = GlobalConfig(**json.loads(f.read()))
                 self.update(config, False)
+            return
+        
+        # otherwise, create a new empty config file
+        self.update(GlobalConfig(), True)
 
     def get_config(self):
         return self.config

--- a/packages/jupyter-ai/jupyter_ai/actors/embeddings_provider.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/embeddings_provider.py
@@ -27,10 +27,10 @@ class EmbeddingsProviderActor():
         auth_strategy = provider.auth_strategy
         if auth_strategy and auth_strategy.type == "env":
             api_keys = config.api_keys
-            name = auth_strategy.name.lower()
+            name = auth_strategy.name
             if name not in api_keys:
                 raise ValueError(f"Missing value for '{auth_strategy.name}' in the config.")
-            provider_params[name] = api_keys[name]
+            provider_params[name.lower()] = api_keys[name]
             
         self.provider = provider.provider_klass
         self.provider_params = provider_params

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -270,6 +270,10 @@ class ModelProviderHandler(BaseAPIHandler):
     def get(self):
         providers = []
         for provider in self.chat_providers.values():
+            # skip old legacy OpenAI chat provider used only in magics
+            if provider.id == "openai-chat":
+                continue
+
             providers.append(
                 ListProvidersEntry(
                     id=provider.id,

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -97,17 +97,13 @@ class ListProvidersEntry(BaseModel):
 class ListProvidersResponse(BaseModel):
     providers: List[ListProvidersEntry]
 
-
-class GlobalConfig(BaseModel):
-    model_provider_id: str
-    embeddings_provider_id: str
-    api_keys: Dict[str, str]
-
-
 class IndexedDir(BaseModel):
     path: str
-
 
 class IndexMetadata(BaseModel):
     dirs: List[IndexedDir]
 
+class GlobalConfig(BaseModel):
+    model_provider_id: Optional[str] = None
+    embeddings_provider_id: Optional[str] = None
+    api_keys: Dict[str, str] = {}

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -1,0 +1,269 @@
+import React, { useEffect, useState } from 'react';
+import { Box } from '@mui/system';
+import {
+  Alert,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  TextField,
+  CircularProgress
+} from '@mui/material';
+import { AiService } from '../handler';
+
+enum ChatSettingsState {
+  // chat settings is making initial fetches
+  Loading,
+  // chat settings is ready (happy path)
+  Ready,
+  // chat settings failed to make initial fetches
+  FetchError,
+  // chat settings failed to submit the save request
+  SubmitError,
+  // chat settings successfully submitted the save request
+  Success
+}
+
+export function ChatSettings() {
+  const [state, setState] = useState<ChatSettingsState>(
+    ChatSettingsState.Loading
+  );
+  // error message from initial fetch
+  const [fetchEmsg, setFetchEmsg] = useState<string>();
+
+  // state fetched on initial render
+  const [config, setConfig] = useState<AiService.GetConfigResponse>();
+  const [lmProviders, setLmProviders] =
+    useState<AiService.ListProvidersResponse>();
+  const [emProviders, setEmProviders] =
+    useState<AiService.ListProvidersResponse>();
+
+  // user inputs
+  const [inputConfig, setInputConfig] = useState<AiService.Config>({
+    model_provider_id: null,
+    embeddings_provider_id: null,
+    api_keys: {}
+  });
+
+  // whether the form is currently saving
+  const [saving, setSaving] = useState<boolean>(false);
+  // error message from submission
+  const [saveEmsg, setSaveEmsg] = useState<string>();
+
+  /**
+   * Effect: call APIs on initial render
+   */
+  useEffect(() => {
+    async function getConfig() {
+      try {
+        const [config, lmProviders, emProviders] = await Promise.all([
+          AiService.getConfig(),
+          AiService.listLmProviders(),
+          AiService.listEmProviders()
+        ]);
+        setConfig(config);
+        setInputConfig(config);
+        setLmProviders(lmProviders);
+        setEmProviders(emProviders);
+        setState(ChatSettingsState.Ready);
+      } catch (e) {
+        console.error(e);
+        if (e instanceof Error) {
+          setFetchEmsg(e.message);
+        }
+        setState(ChatSettingsState.FetchError);
+      }
+    }
+    getConfig();
+  }, []);
+
+  /**
+   * Effect: re-initialize API keys object whenever the selected LM/EM changes.
+   */
+  useEffect(() => {
+    const selectedLmpId = inputConfig.model_provider_id?.split(':')[0];
+    const selectedEmpId = inputConfig.embeddings_provider_id?.split(':')[0];
+    const lmp = lmProviders?.providers.find(
+      provider => provider.id === selectedLmpId
+    );
+    const emp = emProviders?.providers.find(
+      provider => provider.id === selectedEmpId
+    );
+    const newApiKeys: Record<string, string> = {};
+
+    if (lmp?.auth_strategy && lmp.auth_strategy.type === 'env') {
+      newApiKeys[lmp.auth_strategy.name] =
+        config?.api_keys[lmp.auth_strategy.name] || '';
+    }
+    if (emp?.auth_strategy && emp.auth_strategy.type === 'env') {
+      newApiKeys[emp.auth_strategy.name] =
+        config?.api_keys[emp.auth_strategy.name] || '';
+    }
+
+    setInputConfig(inputConfig => ({
+      ...inputConfig,
+      api_keys: { ...config?.api_keys, ...newApiKeys }
+    }));
+  }, [inputConfig.model_provider_id, inputConfig.embeddings_provider_id]);
+
+  const handleSave = async () => {
+    const inputConfigCopy: AiService.Config = {
+      ...inputConfig,
+      api_keys: { ...inputConfig.api_keys }
+    };
+
+    // replace config fields with value '' with value `null`
+    let key: keyof AiService.Config;
+    for (key in inputConfigCopy) {
+      if (key !== 'api_keys' && inputConfigCopy[key] === '') {
+        inputConfigCopy[key] = null;
+      }
+    }
+
+    // delete any empty api keys
+    for (const apiKey in inputConfigCopy.api_keys) {
+      if (inputConfigCopy.api_keys[apiKey] === '') {
+        delete inputConfigCopy.api_keys[apiKey];
+      }
+    }
+
+    setSaving(true);
+    try {
+      await AiService.updateConfig(inputConfigCopy);
+    } catch (e) {
+      console.error(e);
+      if (e instanceof Error) {
+        setSaveEmsg(e.message);
+      }
+      setState(ChatSettingsState.SubmitError);
+    }
+    setSaving(false);
+  };
+
+  if (state === ChatSettingsState.Loading) {
+    return (
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          boxSizing: 'border-box',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-around'
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (
+    state === ChatSettingsState.FetchError ||
+    !lmProviders ||
+    !emProviders ||
+    !config
+  ) {
+    return (
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          padding: 4,
+          boxSizing: 'border-box'
+        }}
+      >
+        <Alert severity="error">
+          {fetchEmsg
+            ? `An error occurred. Error details:\n\n${fetchEmsg}`
+            : 'An unknown error occurred. Check the console for more details.'}
+        </Alert>
+      </Box>
+    );
+  }
+
+  console.log({ inputConfig });
+
+  return (
+    <Box sx={{ padding: 4, boxSizing: 'border-box' }}>
+      {state === ChatSettingsState.SubmitError && (
+        <Alert severity="error">
+          {saveEmsg
+            ? `An error occurred. Error details:\n\n${saveEmsg}`
+            : 'An unknown error occurred. Check the console for more details.'}
+        </Alert>
+      )}
+      <FormControl fullWidth>
+        <InputLabel>Language model</InputLabel>
+        <Select
+          value={inputConfig.model_provider_id}
+          label="Language model"
+          onChange={e =>
+            setInputConfig(inputConfig => ({
+              ...inputConfig,
+              model_provider_id: e.target.value
+            }))
+          }
+        >
+          <MenuItem value="">None</MenuItem>
+          {lmProviders.providers.map(lmp =>
+            lmp.models
+              .filter(lm => lm !== '*') // TODO: support registry providers
+              .map(lm => (
+                <MenuItem value={`${lmp.id}:${lm}`}>
+                  {lmp.name} :: {lm}
+                </MenuItem>
+              ))
+          )}
+        </Select>
+      </FormControl>
+      <FormControl fullWidth>
+        <InputLabel>Embedding model</InputLabel>
+        <Select
+          value={inputConfig.embeddings_provider_id}
+          label="Embedding model"
+          onChange={e =>
+            setInputConfig(inputConfig => ({
+              ...inputConfig,
+              embeddings_provider_id: e.target.value
+            }))
+          }
+        >
+          <MenuItem value="">None</MenuItem>
+          {emProviders.providers.map(emp =>
+            emp.models
+              .filter(em => em !== '*') // TODO: support registry providers
+              .map(em => (
+                <MenuItem value={`${emp.id}:${em}`}>
+                  {emp.name} :: {em}
+                </MenuItem>
+              ))
+          )}
+        </Select>
+      </FormControl>
+      {Object.entries(inputConfig.api_keys).map(
+        ([apiKey, apiKeyValue], idx) => (
+          <TextField
+            key={idx}
+            label={apiKey}
+            value={apiKeyValue}
+            fullWidth
+            hidden
+            onChange={e =>
+              setInputConfig(inputConfig => ({
+                ...inputConfig,
+                api_keys: {
+                  ...inputConfig.api_keys,
+                  [apiKey]: e.target.value
+                }
+              }))
+            }
+          />
+        )
+      )}
+      <Button onClick={handleSave} disabled={saving}>
+        Save changes
+      </Button>
+    </Box>
+  );
+}

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -138,6 +138,7 @@ export function ChatSettings() {
       }
       setState(ChatSettingsState.SubmitError);
     }
+    setState(ChatSettingsState.Success);
     setSaving(false);
   };
 
@@ -182,16 +183,23 @@ export function ChatSettings() {
     );
   }
 
-  console.log({ inputConfig });
-
   return (
-    <Box sx={{ padding: 4, boxSizing: 'border-box' }}>
+    <Box
+      sx={{
+        padding: 4,
+        boxSizing: 'border-box',
+        '& > .MuiAlert-root': { marginBottom: 2 }
+      }}
+    >
       {state === ChatSettingsState.SubmitError && (
         <Alert severity="error">
           {saveEmsg
             ? `An error occurred. Error details:\n\n${saveEmsg}`
             : 'An unknown error occurred. Check the console for more details.'}
         </Alert>
+      )}
+      {state === ChatSettingsState.Success && (
+        <Alert severity="success">Settings saved successfully.</Alert>
       )}
       <FormControl fullWidth>
         <InputLabel>Language model</InputLabel>
@@ -204,6 +212,7 @@ export function ChatSettings() {
               model_provider_id: e.target.value
             }))
           }
+          MenuProps={{ sx: { maxHeight: '50%', minHeight: 400 } }}
         >
           <MenuItem value="">None</MenuItem>
           {lmProviders.providers.map(lmp =>
@@ -228,6 +237,7 @@ export function ChatSettings() {
               embeddings_provider_id: e.target.value
             }))
           }
+          MenuProps={{ sx: { maxHeight: '50%', minHeight: 400 } }}
         >
           <MenuItem value="">None</MenuItem>
           {emProviders.providers.map(emp =>
@@ -261,9 +271,11 @@ export function ChatSettings() {
           />
         )
       )}
-      <Button onClick={handleSave} disabled={saving}>
-        Save changes
-      </Button>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Button variant="contained" onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving...' : 'Save changes'}
+        </Button>
+      </Box>
     </Box>
   );
 }

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -248,7 +248,7 @@ export function ChatSettings() {
             label={apiKey}
             value={apiKeyValue}
             fullWidth
-            hidden
+            type="password"
             onChange={e =>
               setInputConfig(inputConfig => ({
                 ...inputConfig,

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -3,13 +3,12 @@ import { Box } from '@mui/system';
 import {
   Alert,
   Button,
-  FormControl,
-  InputLabel,
-  Select,
   MenuItem,
   TextField,
   CircularProgress
 } from '@mui/material';
+
+import { Select } from './select';
 import { AiService } from '../handler';
 
 enum ChatSettingsState {
@@ -113,14 +112,6 @@ export function ChatSettings() {
       api_keys: { ...inputConfig.api_keys }
     };
 
-    // replace config fields with value '' with value `null`
-    let key: keyof AiService.Config;
-    for (key in inputConfigCopy) {
-      if (key !== 'api_keys' && inputConfigCopy[key] === '') {
-        inputConfigCopy[key] = null;
-      }
-    }
-
     // delete any empty api keys
     for (const apiKey in inputConfigCopy.api_keys) {
       if (inputConfigCopy.api_keys[apiKey] === '') {
@@ -201,56 +192,50 @@ export function ChatSettings() {
       {state === ChatSettingsState.Success && (
         <Alert severity="success">Settings saved successfully.</Alert>
       )}
-      <FormControl fullWidth>
-        <InputLabel>Language model</InputLabel>
-        <Select
-          value={inputConfig.model_provider_id}
-          label="Language model"
-          onChange={e =>
-            setInputConfig(inputConfig => ({
-              ...inputConfig,
-              model_provider_id: e.target.value
-            }))
-          }
-          MenuProps={{ sx: { maxHeight: '50%', minHeight: 400 } }}
-        >
-          <MenuItem value="">None</MenuItem>
-          {lmProviders.providers.map(lmp =>
-            lmp.models
-              .filter(lm => lm !== '*') // TODO: support registry providers
-              .map(lm => (
-                <MenuItem value={`${lmp.id}:${lm}`}>
-                  {lmp.name} :: {lm}
-                </MenuItem>
-              ))
-          )}
-        </Select>
-      </FormControl>
-      <FormControl fullWidth>
-        <InputLabel>Embedding model</InputLabel>
-        <Select
-          value={inputConfig.embeddings_provider_id}
-          label="Embedding model"
-          onChange={e =>
-            setInputConfig(inputConfig => ({
-              ...inputConfig,
-              embeddings_provider_id: e.target.value
-            }))
-          }
-          MenuProps={{ sx: { maxHeight: '50%', minHeight: 400 } }}
-        >
-          <MenuItem value="">None</MenuItem>
-          {emProviders.providers.map(emp =>
-            emp.models
-              .filter(em => em !== '*') // TODO: support registry providers
-              .map(em => (
-                <MenuItem value={`${emp.id}:${em}`}>
-                  {emp.name} :: {em}
-                </MenuItem>
-              ))
-          )}
-        </Select>
-      </FormControl>
+      <Select
+        value={inputConfig.model_provider_id}
+        label="Language model"
+        onChange={e =>
+          setInputConfig(inputConfig => ({
+            ...inputConfig,
+            model_provider_id: e.target.value
+          }))
+        }
+        MenuProps={{ sx: { maxHeight: '50%', minHeight: 400 } }}
+      >
+        <MenuItem value="null">None</MenuItem>
+        {lmProviders.providers.map(lmp =>
+          lmp.models
+            .filter(lm => lm !== '*') // TODO: support registry providers
+            .map(lm => (
+              <MenuItem value={`${lmp.id}:${lm}`}>
+                {lmp.name} :: {lm}
+              </MenuItem>
+            ))
+        )}
+      </Select>
+      <Select
+        value={inputConfig.embeddings_provider_id}
+        label="Embedding model"
+        onChange={e =>
+          setInputConfig(inputConfig => ({
+            ...inputConfig,
+            embeddings_provider_id: e.target.value
+          }))
+        }
+        MenuProps={{ sx: { maxHeight: '50%', minHeight: 400 } }}
+      >
+        <MenuItem value="null">None</MenuItem>
+        {emProviders.providers.map(emp =>
+          emp.models
+            .filter(em => em !== '*') // TODO: support registry providers
+            .map(em => (
+              <MenuItem value={`${emp.id}:${em}`}>
+                {emp.name} :: {em}
+              </MenuItem>
+            ))
+        )}
+      </Select>
       {Object.entries(inputConfig.api_keys).map(
         ([apiKey, apiKeyValue], idx) => (
           <TextField

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Box } from '@mui/system';
-import { IconButton } from '@mui/material';
+import { Button, IconButton, Stack } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import type { Awareness } from 'y-protocols/awareness';
@@ -21,9 +21,10 @@ import { ScrollContainer } from './scroll-container';
 
 type ChatBodyProps = {
   chatHandler: ChatHandler;
+  setChatView: (view: ChatView) => void
 };
 
-function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
+function ChatBody({ chatHandler, setChatView: chatViewHandler }: ChatBodyProps): JSX.Element {
   const [messages, setMessages] = useState<AiService.ChatMessage[]>([]);
   const [showWelcomeMessage, setShowWelcomeMessage] = useState<boolean>(false);
   const [includeSelection, setIncludeSelection] = useState(true);
@@ -102,6 +103,11 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
     }
   };
 
+  const openSettingsView = () => {
+    setShowWelcomeMessage(false)
+    chatViewHandler(ChatView.Settings)
+  }
+
   if (showWelcomeMessage) {
     return (
       <Box
@@ -109,13 +115,25 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
           padding: 4,
           display: 'flex',
           flexGrow: 1,
-          alignItems: 'center',
+          alignItems: 'top',
           justifyContent: 'space-around'
         }}
       >
-        Welcome to Jupyter AI! To get started, please select a language model to
-        chat with from the settings menu at the top right. You will also likely
-        need to provide API credentials, so be sure to have those handy.
+        <Stack spacing={4}>
+          <p>
+            Welcome to Jupyter AI! To get started, please select a language
+            model to chat with from the settings panel. You will also likely
+            need to provide API credentials, so be sure to have those handy.
+          </p>
+          <Button 
+            variant="contained" 
+            startIcon={<SettingsIcon />} 
+            size={'large'}
+            onClick={() => openSettingsView()}
+            >
+              Start Here
+          </Button>
+        </Stack>
       </Box>
     );
   }
@@ -147,7 +165,7 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
         }}
         helperText={
           <span>
-            <b>Press Shift</b> + <b>Enter</b> to submit message
+            Press <b>Shift</b> + <b>Enter</b> to submit message
           </span>
         }
       />
@@ -159,6 +177,7 @@ export type ChatProps = {
   selectionWatcher: SelectionWatcher;
   chatHandler: ChatHandler;
   globalAwareness: Awareness | null;
+  chatView?: ChatView
 };
 
 enum ChatView {
@@ -167,7 +186,7 @@ enum ChatView {
 }
 
 export function Chat(props: ChatProps) {
-  const [view, setView] = useState<ChatView>(ChatView.Chat);
+  const [view, setView] = useState<ChatView>(props.chatView || ChatView.Chat);
 
   return (
     <JlThemeProvider>
@@ -204,7 +223,7 @@ export function Chat(props: ChatProps) {
             </Box>
             {/* body */}
             {view === ChatView.Chat && (
-              <ChatBody chatHandler={props.chatHandler} />
+              <ChatBody chatHandler={props.chatHandler} setChatView={setView}/>
             )}
             {view === ChatView.Settings && <ChatSettings />}
           </Box>

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -1,10 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { Box } from '@mui/system';
+import { IconButton } from '@mui/material';
+import SettingsIcon from '@mui/icons-material/Settings';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import type { Awareness } from 'y-protocols/awareness';
 
 import { JlThemeProvider } from './jl-theme-provider';
 import { ChatMessages } from './chat-messages';
 import { ChatInput } from './chat-input';
+import { ChatSettings } from './chat-settings';
 import { AiService } from '../handler';
 import {
   SelectionContextProvider,
@@ -90,18 +94,7 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
   };
 
   return (
-    <Box
-      // root box should not include padding as it offsets the vertical
-      // scrollbar to the left
-      sx={{
-        width: '100%',
-        height: '100%',
-        boxSizing: 'border-box',
-        background: 'var(--jp-layout-color0)',
-        display: 'flex',
-        flexDirection: 'column'
-      }}
-    >
+    <>
       <ScrollContainer sx={{ flexGrow: 1 }}>
         <ChatMessages messages={messages} />
       </ScrollContainer>
@@ -127,7 +120,7 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
         }}
         helperText={<span><b>Press Shift</b> + <b>Enter</b> to submit message</span>}
       />
-    </Box>
+    </>
   );
 }
 
@@ -137,12 +130,53 @@ export type ChatProps = {
   globalAwareness: Awareness | null;
 };
 
+enum ChatView {
+  Chat,
+  Settings
+}
+
 export function Chat(props: ChatProps) {
+  const [view, setView] = useState<ChatView>(ChatView.Chat);
+
   return (
     <JlThemeProvider>
       <SelectionContextProvider selectionWatcher={props.selectionWatcher}>
         <CollaboratorsContextProvider globalAwareness={props.globalAwareness}>
-          <ChatBody chatHandler={props.chatHandler} />
+          <Box
+            // root box should not include padding as it offsets the vertical
+            // scrollbar to the left
+            sx={{
+              width: '100%',
+              height: '100%',
+              boxSizing: 'border-box',
+              background: 'var(--jp-layout-color0)',
+              display: 'flex',
+              flexDirection: 'column'
+            }}
+          >
+            {/* top bar */}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+              {view !== ChatView.Chat ? (
+                <IconButton onClick={() => setView(ChatView.Chat)}>
+                  <ArrowBackIcon />
+                </IconButton>
+              ) : (
+                <Box />
+              )}
+              {view === ChatView.Chat ? (
+                <IconButton onClick={() => setView(ChatView.Settings)}>
+                  <SettingsIcon />
+                </IconButton>
+              ) : (
+                <Box />
+              )}
+            </Box>
+            {/* body */}
+            {view === ChatView.Chat && (
+              <ChatBody chatHandler={props.chatHandler} />
+            )}
+            {view === ChatView.Settings && <ChatSettings />}
+          </Box>
         </CollaboratorsContextProvider>
       </SelectionContextProvider>
     </JlThemeProvider>

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -34,10 +34,7 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
       try {
         const history = await chatHandler.getHistory();
         setMessages(history.messages);
-      } catch (e) {
-        
-      }
-      
+      } catch (e) {}
     }
 
     fetchHistory();
@@ -71,7 +68,9 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
 
     const prompt =
       input +
-      (includeSelection && selection?.text ? '\n\n```\n' + selection.text + '```': '');
+      (includeSelection && selection?.text
+        ? '\n\n```\n' + selection.text + '```'
+        : '');
 
     // send message to backend
     const messageId = await chatHandler.sendMessage({ prompt });
@@ -105,8 +104,6 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
     >
       <ScrollContainer sx={{ flexGrow: 1 }}>
         <ChatMessages messages={messages} />
-        {/* https://css-tricks.com/books/greatest-css-tricks/pin-scrolling-to-bottom/ */}
-        <Box sx={{ overflowAnchor: 'auto', height: '1px' }} />
       </ScrollContainer>
       <ChatInput
         value={input}

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -25,6 +25,7 @@ type ChatBodyProps = {
 
 function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
   const [messages, setMessages] = useState<AiService.ChatMessage[]>([]);
+  const [showWelcomeMessage, setShowWelcomeMessage] = useState<boolean>(false);
   const [includeSelection, setIncludeSelection] = useState(true);
   const [replaceSelection, setReplaceSelection] = useState(false);
   const [input, setInput] = useState('');
@@ -36,9 +37,17 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
   useEffect(() => {
     async function fetchHistory() {
       try {
-        const history = await chatHandler.getHistory();
+        const [history, config] = await Promise.all([
+          chatHandler.getHistory(),
+          AiService.getConfig()
+        ]);
         setMessages(history.messages);
-      } catch (e) {}
+        if (!config.model_provider_id) {
+          setShowWelcomeMessage(true);
+        }
+      } catch (e) {
+        console.error(e);
+      }
     }
 
     fetchHistory();
@@ -93,6 +102,24 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
     }
   };
 
+  if (showWelcomeMessage) {
+    return (
+      <Box
+        sx={{
+          padding: 4,
+          display: 'flex',
+          flexGrow: 1,
+          alignItems: 'center',
+          justifyContent: 'space-around'
+        }}
+      >
+        Welcome to Jupyter AI! To get started, please select a language model to
+        chat with from the settings menu at the top right. You will also likely
+        need to provide API credentials, so be sure to have those handy.
+      </Box>
+    );
+  }
+
   return (
     <>
       <ScrollContainer sx={{ flexGrow: 1 }}>
@@ -118,7 +145,11 @@ function ChatBody({ chatHandler }: ChatBodyProps): JSX.Element {
           paddingBottom: 0,
           borderTop: '1px solid var(--jp-border-color1)'
         }}
-        helperText={<span><b>Press Shift</b> + <b>Enter</b> to submit message</span>}
+        helperText={
+          <span>
+            <b>Press Shift</b> + <b>Enter</b> to submit message
+          </span>
+        }
       />
     </>
   );

--- a/packages/jupyter-ai/src/components/select.tsx
+++ b/packages/jupyter-ai/src/components/select.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { FormControl, InputLabel, Select as MuiSelect } from '@mui/material';
+import type {
+  SelectChangeEvent,
+  SelectProps as MuiSelectProps
+} from '@mui/material';
+
+export type SelectProps = Omit<MuiSelectProps<string>, 'value' | 'onChange'> & {
+  value: string | null;
+  onChange: (
+    event: SelectChangeEvent<string | null>,
+    child: React.ReactNode
+  ) => void;
+};
+
+/**
+ * A helpful wrapper around MUI's native `Select` component that provides the
+ * following services:
+ *
+ * - automatically wraps base `Select` component in `FormControl` context and
+ * prepends an input label derived from `props.label`.
+ *
+ * - limits max height of menu
+ *
+ * - handles `null` values by coercing them to the string `'null'`. The
+ * corresponding `MenuItem` should have the value `'null'`.
+ */
+export function Select(props: SelectProps) {
+  return (
+    <FormControl fullWidth>
+      <InputLabel>{props.label}</InputLabel>
+      <MuiSelect
+        {...props}
+        value={props.value === null ? 'null' : props.value}
+        label={props.label}
+        onChange={(e, child) => {
+          if (e.target.value === 'null') {
+            e.target.value = null as any;
+          }
+          props.onChange?.(e, child);
+        }}
+        MenuProps={{ sx: { maxHeight: '50%', minHeight: 400 } }}
+      >
+        {props.children}
+      </MuiSelect>
+    </FormControl>
+  );
+}

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -99,11 +99,15 @@ export namespace AiService {
   };
 
   export type ClearMessage = {
-    type: 'clear'
-  }
+    type: 'clear';
+  };
 
   export type ChatMessage = AgentChatMessage | HumanChatMessage;
-  export type Message = AgentChatMessage | HumanChatMessage | ConnectionMessage | ClearMessage;
+  export type Message =
+    | AgentChatMessage
+    | HumanChatMessage
+    | ConnectionMessage
+    | ClearMessage;
 
   export type ChatHistory = {
     messages: ChatMessage[];
@@ -159,5 +163,58 @@ export namespace AiService {
     id: string
   ): Promise<DescribeTaskResponse> {
     return requestAPI<DescribeTaskResponse>(`tasks/${id}`);
+  }
+
+  export type Config = {
+    model_provider_id: string | null;
+    embeddings_provider_id: string | null;
+    api_keys: Record<string, string>;
+  };
+
+  export type GetConfigResponse = Config;
+
+  export type UpdateConfigRequest = Config;
+
+  export async function getConfig(): Promise<GetConfigResponse> {
+    return requestAPI<GetConfigResponse>('config');
+  }
+
+  export type EnvAuthStrategy = {
+    type: 'env';
+    name: string;
+  };
+
+  export type AwsAuthStrategy = {
+    type: 'aws';
+  };
+
+  export type AuthStrategy = EnvAuthStrategy | AwsAuthStrategy | null;
+
+  export type ListProvidersEntry = {
+    id: string;
+    name: string;
+    models: string[];
+    auth_strategy: AuthStrategy;
+  };
+
+  export type ListProvidersResponse = {
+    providers: ListProvidersEntry[];
+  };
+
+  export async function listLmProviders(): Promise<ListProvidersResponse> {
+    return requestAPI<ListProvidersResponse>('providers');
+  }
+
+  export async function listEmProviders(): Promise<ListProvidersResponse> {
+    return requestAPI<ListProvidersResponse>('providers/embeddings');
+  }
+
+  export async function updateConfig(
+    config: UpdateConfigRequest
+  ): Promise<void> {
+    return requestAPI<void>('config', {
+      method: 'POST',
+      body: JSON.stringify(config)
+    });
   }
 }


### PR DESCRIPTION
# Description

https://user-images.githubusercontent.com/44106031/236072832-4b8d9055-0f7e-4469-8fdc-3a0474d5a3a9.mov

Implement basic chat settings UI that allows users to switch language models, embedding models, and add API keys. Other changes:

- Model config is now created automatically on initialization if one doesn't exist
- Prefer upper-case environment variables in the config file

# Screenshots

<img width="405" alt="Screen Shot 2023-05-03 at 11 50 14 AM" src="https://user-images.githubusercontent.com/44106031/236015284-a77c97f7-cbe2-4502-9e4b-37461f236949.png">

This UI also handles loading and error states for the initial fetch. The loading state is an animated spinner, though this isn't captured well via screenshot.

<img width="555" alt="Screen Shot 2023-05-02 at 2 34 21 PM" src="https://user-images.githubusercontent.com/44106031/236015483-56947cae-6975-46c1-b32b-566743dc3569.png">

<img width="683" alt="Screen Shot 2023-05-02 at 2 38 23 PM" src="https://user-images.githubusercontent.com/44106031/236015369-f8e22470-ba48-4950-9521-9431b494c579.png">
