### PR TITLE
Adds missing newline before closing code block

### DIFF
--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -83,7 +83,7 @@ function ChatBody({ chatHandler, setChatView: chatViewHandler }: ChatBodyProps):
     const prompt =
       input +
       (includeSelection && selection?.text
-        ? '\n\n```\n' + selection.text + '```'
+        ? '\n\n```\n' + selection.text + '\n```'
         : '');
 
     // send message to backend


### PR DESCRIPTION
Fixes #151.

Before this change, a closing triple-backtick is visible after source code that I've chosen to include with a prompt:

![image](https://user-images.githubusercontent.com/93281816/236933905-926b3aba-7e63-408f-94f3-cf2c4fc09dd3.png)

With this change, the closing triple-backtick is on a line by itself, so it is no longer visible:

![image](https://user-images.githubusercontent.com/93281816/236933820-c3da4657-7562-4b81-b1b0-69263136a07e.png)
