### PR TITLE
Changes chat messages to use absolute timestamps

### DIFF
--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -70,7 +70,6 @@
     "@jupyterlab/ui-components": "^3.6.3",
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.0",
-    "date-fns": "^2.29.3",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-markdown": "^8.0.6",

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -108,29 +108,25 @@ export function ChatMessages(props: ChatMessagesProps) {
    * Effect: update cached timestamp strings upon receiving a new message.
    */
   useEffect(() => {
-    function updateTimestamps() {
-      const newTimestamps: Record<string, string> = {};
-      let timestampAdded: boolean = false;
+    const newTimestamps: Record<string, string> = {};
+    let timestampAdded: boolean = false;
 
-      for (const message of props.messages) {
-        if (!(message.id in newTimestamps)) {
-          // Use the browser's default locale
-          newTimestamps[message.id] =
-            new Date(message.time * 1000) // Convert message time to milliseconds
-              .toLocaleTimeString([], {
-                hour: 'numeric', // Avoid leading zero for hours; we don't want "03:15 PM"
-                minute: '2-digit'
-              });
+    for (const message of props.messages) {
+      if (!(message.id in newTimestamps)) {
+        // Use the browser's default locale
+        newTimestamps[message.id] =
+          new Date(message.time * 1000) // Convert message time to milliseconds
+            .toLocaleTimeString([], {
+              hour: 'numeric', // Avoid leading zero for hours; we don't want "03:15 PM"
+              minute: '2-digit'
+            });
 
-          timestampAdded = true;
-        }
-      }
-      if (timestampAdded) {
-        setTimestamps(newTimestamps);
+        timestampAdded = true;
       }
     }
-
-    updateTimestamps();
+    if (timestampAdded) {
+      setTimestamps(newTimestamps);
+    }
   }, [props.messages]);
 
   return (

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -110,6 +110,8 @@ export function ChatMessages(props: ChatMessagesProps) {
   useEffect(() => {
     function updateTimestamps() {
       const newTimestamps: Record<string, string> = {};
+      let timestampAdded: boolean = false;
+
       for (const message of props.messages) {
         if (!(message.id in newTimestamps)) {
           // Use the browser's default locale
@@ -119,9 +121,13 @@ export function ChatMessages(props: ChatMessagesProps) {
                 hour: 'numeric', // Avoid leading zero for hours; we don't want "03:15 PM"
                 minute: '2-digit'
               });
+
+          timestampAdded = true;
         }
       }
-      setTimestamps(newTimestamps);
+      if (timestampAdded) {
+        setTimestamps(newTimestamps);
+      }
     }
 
     updateTimestamps();

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -108,7 +108,7 @@ export function ChatMessages(props: ChatMessagesProps) {
    * Effect: update cached timestamp strings upon receiving a new message.
    */
   useEffect(() => {
-    const newTimestamps: Record<string, string> = {};
+    const newTimestamps: Record<string, string> = { ...timestamps };
     let timestampAdded: boolean = false;
 
     for (const message of props.messages) {

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 
 import { Avatar, Box, Typography } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material';
-import { formatDistanceToNowStrict, fromUnixTime } from 'date-fns';
 import ReactMarkdown from 'react-markdown';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
@@ -106,24 +105,26 @@ export function ChatMessages(props: ChatMessagesProps) {
   const [timestamps, setTimestamps] = useState<Record<string, string>>({});
 
   /**
-   * Effect: update cached timestamp strings upon receiving a new message and
-   * every 5 seconds after that.
+   * Effect: update cached timestamp strings upon receiving a new message.
    */
   useEffect(() => {
     function updateTimestamps() {
       const newTimestamps: Record<string, string> = {};
       for (const message of props.messages) {
-        newTimestamps[message.id] =
-          formatDistanceToNowStrict(fromUnixTime(message.time)) + ' ago';
+        if (!(message.id in newTimestamps)) {
+          // Use the browser's default locale
+          newTimestamps[message.id] =
+            new Date(message.time * 1000) // Convert message time to milliseconds
+              .toLocaleTimeString([], {
+                hour: 'numeric', // Avoid leading zero for hours; we don't want "03:15 PM"
+                minute: '2-digit'
+              });
+        }
       }
       setTimestamps(newTimestamps);
     }
 
     updateTimestamps();
-    const intervalId = setInterval(updateTimestamps, 5000);
-    return () => {
-      clearInterval(intervalId);
-    };
   }, [props.messages]);
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4694,13 +4694,6 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^2.29.3:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
-
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"


### PR DESCRIPTION
Fixes #87.

Instead of relative time (X minutes ago), displays messages using 12-hour or 24-hour time, based on the user's locale. Message timestamps are only computed once, not repeatedly every 5 seconds.

![Screen Shot 2023-05-10 at 4 12 30 PM](https://github.com/jupyterlab/jupyter-ai/assets/93281816/d63888d1-474f-4650-a6a9-15e26620f305)
