### PR TITLE
fix: Correct recursion error on load when running in JupyterHub

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -172,7 +172,7 @@ class ChatHandler(
         
         login = getpass.getuser()
         return ChatUser(
-            username=self.current_user.username,
+            username=login,
             initials=login[0].capitalize(),
             name=login,
             display_name=login,


### PR DESCRIPTION
Fixes #168 

`RequestHandler.current_user` calls `RequestHandler.get_current_user` when not set initially.  This causes a recursive loop on load when running the extension in JupyterHub.  Changed this to just use the `login` value from `getpass.getuser()` which is also being used for the other fields. 