### PR TITLE
fix: Correct recursion error on load in JupyterHub

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -172,7 +172,7 @@ class ChatHandler(
         
         login = getpass.getuser()
         return ChatUser(
-            username=self.current_user.username,
+            username=login,
             initials=login[0].capitalize(),
             name=login,
             display_name=login,

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -161,7 +161,7 @@ class ChatHandler(
         res = super().get(*args, **kwargs)
         await res
 
-    def get_current_user(self) -> ChatUser:
+    def get_chat_user(self) -> ChatUser:
         """Retrieves the current user. If collaborative mode is disabled, one
         is synthesized from the login."""
         collaborative = self.config.get("LabApp", {}).get("collaborative", False)
@@ -172,7 +172,7 @@ class ChatHandler(
         
         login = getpass.getuser()
         return ChatUser(
-            username=login,
+            username=self.current_user.username,
             initials=login[0].capitalize(),
             name=login,
             display_name=login,
@@ -189,7 +189,7 @@ class ChatHandler(
         """Handles opening of a WebSocket connection. Client ID can be retrieved
         from `self.client_id`."""
 
-        current_user = self.get_current_user().dict()
+        current_user = self.get_chat_user().dict()
         client_id = self.generate_client_id()
 
         self.chat_handlers[client_id] = self


### PR DESCRIPTION
Fixes #168 

`RequestHandler.current_user` calls `RequestHandler.get_current_user()` when not set initially.  This causes a recursive loop on load when running the extension in JupyterHub.  Changed to use the `login` value which is being used for the other User fields. 

