### PR TITLE
Advises users to install pip via conda when creating env

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are not using JupyterLab and you only want to install the Jupyter AI `%%a
 
 First, install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) and create an environment that uses Python 3.10:
 
-    $ conda create -n jupyter-ai python=3.10
+    $ conda create -n jupyter-ai python=3.10 pip
     $ conda activate jupyter-ai
     $ pip install jupyter_ai
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are not using JupyterLab and you only want to install the Jupyter AI `%%a
 
 First, install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) and create an environment that uses Python 3.10:
 
-    $ conda create -n jupyter-ai python=3.10 pip
+    $ conda create -n jupyter-ai python=3.10 conda pip
     $ conda activate jupyter-ai
     $ pip install jupyter_ai
 

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -24,7 +24,7 @@ Due to a compatibility issue with Webpack, Node.js 18.15.0 does not work with Ju
 After you have installed the prerequisites, create a new conda environment and activate it. 
 
 ```
-conda create -n jupyter-ai python=3.10
+conda create -n jupyter-ai python=3.10 pip
 conda activate jupyter-ai
 ```
 

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -24,7 +24,7 @@ Due to a compatibility issue with Webpack, Node.js 18.15.0 does not work with Ju
 After you have installed the prerequisites, create a new conda environment and activate it. 
 
 ```
-conda create -n jupyter-ai python=3.10 pip
+conda create -n jupyter-ai python=3.10 conda pip
 conda activate jupyter-ai
 ```
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -95,7 +95,7 @@ If you are not using JupyterLab and you only want to install the Jupyter AI `%%a
 
 First, install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) and create an environment that uses Python 3.10:
 
-    $ conda create -n jupyter-ai python=3.10 pip
+    $ conda create -n jupyter-ai python=3.10 conda pip
     $ conda activate jupyter-ai
     $ pip install jupyter_ai
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -95,7 +95,7 @@ If you are not using JupyterLab and you only want to install the Jupyter AI `%%a
 
 First, install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) and create an environment that uses Python 3.10:
 
-    $ conda create -n jupyter-ai python=3.10
+    $ conda create -n jupyter-ai python=3.10 pip
     $ conda activate jupyter-ai
     $ pip install jupyter_ai
 

--- a/packages/jupyter-ai/README.md
+++ b/packages/jupyter-ai/README.md
@@ -28,7 +28,7 @@ Before you can use Jupyter AI, you will need to install any packages and set env
 
 First, install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) and create an environment that uses Python 3.10:
 
-    $ conda create -n jupyter-ai python=3.10
+    $ conda create -n jupyter-ai python=3.10 pip
     $ conda activate jupyter-ai
     $ pip install jupyter_ai
 

--- a/packages/jupyter-ai/README.md
+++ b/packages/jupyter-ai/README.md
@@ -28,7 +28,7 @@ Before you can use Jupyter AI, you will need to install any packages and set env
 
 First, install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) and create an environment that uses Python 3.10:
 
-    $ conda create -n jupyter-ai python=3.10 pip
+    $ conda create -n jupyter-ai python=3.10 conda pip
     $ conda activate jupyter-ai
     $ pip install jupyter_ai
 


### PR DESCRIPTION
Partial fix for #179.

Advises users to install `pip` in their `conda` environment when creating the env, so that a user does not inadvertently run a system-wide-installed `pip` instead. Thanks to @richlysakowski for reporting this!