### PR TITLE
use Dask to parallelize document learning

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/actors/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/learn.py
@@ -7,6 +7,8 @@ from typing import List
 import ray
 from ray.util.queue import Queue
 
+from dask.distributed import Client as DaskClient
+
 from jupyter_core.paths import jupyter_data_dir
 
 from langchain import FAISS
@@ -18,12 +20,15 @@ from langchain.schema import Document
 
 from jupyter_ai.models import HumanChatMessage, IndexedDir, IndexMetadata
 from jupyter_ai.actors.base import BaseActor, Logger
-from jupyter_ai.document_loaders.directory import RayRecursiveDirectoryLoader
+from jupyter_ai.document_loaders.directory import split, get_embeddings
 from jupyter_ai.document_loaders.splitter import ExtensionSplitter, NotebookSplitter
 
 
 INDEX_SAVE_DIR = os.path.join(jupyter_data_dir(), 'jupyter_ai', 'indices')
 METADATA_SAVE_PATH = os.path.join(INDEX_SAVE_DIR, 'metadata.json')
+
+def compute_delayed(delayed):
+    return delayed.compute()
 
 @ray.remote
 class LearnActor(BaseActor):
@@ -42,6 +47,9 @@ class LearnActor(BaseActor):
         self.index = None
         self.metadata = IndexMetadata(dirs=[])
         
+        # initialize dask client
+        self.dask_client = DaskClient()
+
         if not os.path.exists(INDEX_SAVE_DIR):
             os.makedirs(INDEX_SAVE_DIR)
         
@@ -100,6 +108,7 @@ class LearnActor(BaseActor):
         return message
 
     def learn_dir(self, path: str):
+        start = time.time()
         splitters={
             '.py': PythonCodeTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
             '.md': MarkdownTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap),
@@ -111,10 +120,22 @@ class LearnActor(BaseActor):
             default_splitter=RecursiveCharacterTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap)
         )
 
-        loader = RayRecursiveDirectoryLoader(path)
-        texts = loader.load_and_split(text_splitter=splitter)
-        self.index.add_documents(texts)
+        delayed = split(path, splitter=splitter)
+        future = self.dask_client.submit(compute_delayed, delayed)
+        doc_chunks = future.result()
+
+        self.log.error(f"[/learn] Finished chunking documents. Time: {round((time.time() - start) * 1000)}ms")
+
+        em = self.get_embeddings()
+        delayed = get_embeddings(doc_chunks, em)
+        future = self.dask_client.submit(compute_delayed, delayed)
+        embedding_records = future.result()
+        self.log.error(f"[/learn] Finished computing embeddings. Time: {round((time.time() - start) * 1000)}ms")
+
+        self.index.add_embeddings(*embedding_records)
         self._add_dir_to_metadata(path)
+        
+        self.log.error(f"[/learn] Complete. Time: {round((time.time() - start) * 1000)}ms")
     
     def _add_dir_to_metadata(self, path: str):
         dirs = self.metadata.dirs

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -1,18 +1,19 @@
-from typing import List, Optional
+from typing import List, Tuple, Type
 from pathlib import Path
 import hashlib
 import itertools
+import os
 
-import ray
+import dask
 
-from langchain.document_loaders.base import BaseLoader
 from langchain.schema import Document
-from langchain.document_loaders.directory import _is_visible
 from langchain.text_splitter import (
-    RecursiveCharacterTextSplitter, TextSplitter,
+    TextSplitter,
 )
 
-@ray.remote
+from jupyter_ai_magics.utils import decompose_model_id, load_embedding_providers, load_providers
+from jupyter_ai_magics.embedding_providers import BaseEmbeddingsProvider
+
 def path_to_doc(path):
     with open(str(path), 'r') as f:
         text = f.read()
@@ -21,53 +22,65 @@ def path_to_doc(path):
         metadata = {'path': str(path), 'sha256': m.digest(), 'extension': path.suffix}
         return Document(page_content=text, metadata=metadata)
 
-class ExcludePattern(Exception):
-    pass
-    
-def iter_paths(path, extensions, exclude):
-    for p in Path(path).rglob('*'):
-        if p.is_dir():
-            continue
-        if not _is_visible(p.relative_to(path)):
-            continue
-        try:
-            for pattern in exclude:
-                if pattern in str(p):
-                    raise ExcludePattern()
-        except ExcludePattern:
-            continue
-        if p.suffix in extensions:
-            yield p
+EXCLUDE_DIRS = {'.ipynb_checkpoints', 'node_modules', 'lib', 'build', '.git', '.DS_Store'}
+SUPPORTED_EXTS = {'.py', '.md', '.R', '.Rmd', '.jl', '.sh', '.ipynb', '.js', '.ts', '.jsx', '.tsx', '.txt'}
 
-class RayRecursiveDirectoryLoader(BaseLoader):
-    
-    def __init__(
-        self,
-        path,
-        extensions={'.py', '.md', '.R', '.Rmd', '.jl', '.sh', '.ipynb', '.js', '.ts', '.jsx', '.tsx', '.txt'},
-        exclude={'.ipynb_checkpoints', 'node_modules', 'lib', 'build', '.git', '.DS_Store'}
-    ):
-        self.path = path
-        self.extensions = extensions
-        self.exclude=exclude
-    
-    def load(self) -> List[Document]:
-        paths = iter_paths(self.path, self.extensions, self.exclude)
-        doc_refs = list(map(path_to_doc.remote, paths))
-        return ray.get(doc_refs)
-    
-    def load_and_split(
-        self, text_splitter: Optional[TextSplitter] = None
-    ) -> List[Document]:
-        if text_splitter is None:
-            _text_splitter = RecursiveCharacterTextSplitter()
-        else:
-            _text_splitter = text_splitter
+def split_document(document, splitter: TextSplitter) -> List[Document]:
+    return splitter.split_documents([document])
 
-        @ray.remote
-        def split(doc):
-            return _text_splitter.split_documents([doc])
+def flatten(*chunk_lists):
+    return list(itertools.chain(*chunk_lists))
+
+def split(path, splitter):
+    chunks = []
+
+    for dir, _, filenames in os.walk(path):
+        if dir in EXCLUDE_DIRS:
+            continue
         
-        paths = iter_paths(self.path, self.extensions, self.exclude)
-        doc_refs = map(split.remote, map(path_to_doc.remote, paths))
-        return list(itertools.chain(*ray.get(list(doc_refs))))
+        for filename in filenames:
+            filepath = Path(os.path.join(dir, filename))
+            if filepath.suffix not in SUPPORTED_EXTS:
+                continue
+
+            document = dask.delayed(path_to_doc)(filepath)
+            chunk = dask.delayed(split_document)(document, splitter)
+            chunks.append(chunk)
+    
+    flattened_chunks = dask.delayed(flatten)(*chunks)
+    return flattened_chunks
+
+def join(embeddings):
+    embedding_records = []
+    metadatas = []
+
+    for embedding_record, metadata in embeddings:
+        embedding_records.append(embedding_record)
+        metadatas.append(metadata)
+    
+    return (embedding_records, metadatas)
+
+def embed_chunk(chunk, em):
+    metadata = chunk.metadata
+    content = chunk.page_content
+    embedding = em.embed_query(content)
+    return ((content, embedding), metadata)
+
+# TODO: figure out how to declare the typing of this fn
+# dask.delayed.Delayed doesn't work, nor does dask.Delayed
+def get_embeddings(chunks, em):
+    # split documents in parallel w.r.t. each file
+    embeddings = []
+
+    # compute embeddings in parallel
+    for chunk in chunks:
+        embedding = dask.delayed(embed_chunk)(chunk, em)
+        embeddings.append(embedding)
+    
+    return dask.delayed(join)(embeddings)
+
+# def get_ep(self, model_id: str) -> Tuple[str, Type[BaseEmbeddingsProvider]]:
+#     """Returns the embedding provider class that matches the provider id"""
+#     provider_id, local_model_id = decompose_model_id(model_id, self.embeddings_providers)
+#     provider = self.embeddings_providers.get(provider_id, None)
+#     return local_model_id, provider

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -125,7 +125,6 @@ class AiExtension(ExtensionApp):
         # memory object used by the LM chain.
         self.settings["chat_history"] = []
 
-
         reply_queue = Queue()
         self.settings["reply_queue"] = reply_queue
 
@@ -154,7 +153,7 @@ class AiExtension(ExtensionApp):
         learn_actor = LearnActor.options(name=ACTOR_TYPE.LEARN.value).remote(
             reply_queue=reply_queue,
             log=self.log,
-            root_dir=self.serverapp.root_dir,
+            root_dir=self.serverapp.root_dir
         )
         ask_actor = AskActor.options(name=ACTOR_TYPE.ASK.value).remote(
             reply_queue=reply_queue, 

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "tiktoken", # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "ray~=2.4.0", # Requires grpcio installation from conda
+    "dask[distributed]",
     "faiss-cpu", # Not distributed by official repo
     "wcmatch",
 ]


### PR DESCRIPTION
# Description

Uses Dask to parallelize document learning via `/learn`. The current approach sees roughly a 2-3x performance boost.

Before:
```
(LearnActor pid=13273) [/learn] Finished chunking documents. Time: 1308ms
(LearnActor pid=13273) [/learn] Completed. Time: 8117ms
```

After:
```
(LearnActor pid=33141) [/learn] Finished chunking documents. Time: 2685ms
(LearnActor pid=33141) [/learn] Finished computing embeddings. Time: 4571ms
(LearnActor pid=33141) [/learn] Complete. Time: 4573ms
```

# Notes

The majority of the time spent by Dask is actually from the overhead of spawning a process. The grey bars represent deserialization of pickled data in each worker process:

![Screen Shot 2023-05-22 at 12 07 49 PM](https://github.com/jupyterlab/jupyter-ai/assets/44106031/b86065a0-14d4-4c9a-9c72-b2f3f6a768ab)

There are some substantial improvements that can be made here.