### PR TITLE
Drops support for Python 3.7, mandates 3.8 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation is available on [ReadTheDocs](https://jupyter-ai.readthedocs.io/en
 
 You can use `conda` or `pip` to install Jupyter AI. If you're using macOS on an Apple Silicon-based Mac (M1, M1 Pro, M2, etc.), we strongly recommend using `conda`.
 
-Because of Ray's incompatibility with Python 3.11, you must use Python 3.7, 3.8, 3.9, or 3.10 with Jupyter AI. The instructions below presume that you are using Python 3.10.
+Python 3.8 or newer is required; older versions of Python do not support the `typing` module we use, and as of June 30, 2023, have reached end of life. Because of Ray's incompatibility with Python 3.11, you must use Python 3.8, 3.9, or 3.10 with Jupyter AI. The instructions below presume that you are using Python 3.10.
 
 Before you can use Jupyter AI, you will need to install any packages and set environment variables with API keys for the model providers that you will use. See [our documentation](https://jupyter-ai.readthedocs.io/en/latest/users/index.html) for details about what you'll need.
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -76,7 +76,7 @@ provider's pricing information before submitting requests via Jupyter AI.
 
 You can use `conda` or `pip` to install Jupyter AI. If you're using macOS on an Apple Silicon-based Mac (M1, M1 Pro, M2, etc.), we strongly recommend using `conda`.
 
-Because of Ray's incompatibility with Python 3.11, you must use Python 3.9, or 3.10 with Jupyter AI. The instructions below presume that you are using Python 3.10.
+Python 3.8 or newer is required; older versions of Python do not support the `typing` module we use, and as of June 30, 2023, have reached end of life. Because of Ray's incompatibility with Python 3.11, you must use Python 3.8, 3.9, or 3.10 with Jupyter AI. The instructions below presume that you are using Python 3.10.
 
 Before you can use Jupyter AI, you will need to install any packages and set environment variables with API keys for the model providers that you will use. See [our documentation](https://jupyter-ai.readthedocs.io/en/latest/users/index.html) for details about what you'll need.
 

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -6,13 +6,12 @@ build-backend = "hatchling.build"
 name = "jupyter_ai_magics"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Framework :: Jupyter",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.labextension_name}}/pyproject.toml
+++ b/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.labextension_name}}/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "{{ cookiecutter.python_name }}"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyter_ai"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.7,<3.11"
+requires-python = ">=3.8,<3.11"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "jupyter_ai_monorepo"
 dynamic = ["version", "description", "authors", "urls", "keywords"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = []
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Fixes #183
- Fixes #172.

Drops support for Python 3.7, which reaches end of life (EOL) next month, and which is not compatible. Given the choice between good typing and 3.7 compatibility, we're choosing good typing.