### PR TITLE
Migrate to click

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -279,7 +279,7 @@ To clear the local vector database, you can run `/learn -d` and Jupyter AI will 
 
 To clear the chat panel, use the `/clear` command. This does not reset the AI model; the model may still remember previous messages that you sent it, and it may use them to inform its responses.
 
-## The `%%ai` magic command
+## The `%ai` and `%%ai` magic commands
 
 Jupyter AI can also be used in notebooks via Jupyter AI magics. This section
 provides guidance on how to use Jupyter AI magics effectively. The examples in
@@ -320,8 +320,11 @@ model you want to use and specify natural language prompts.
 
 ### Choosing a provider and model
 
-The `%%ai` magic command enables you to specify a model provider and model with the
-syntax `<provider-id>:<model-id>`. The natural language prompt starts on the second line of the cell.
+The `%%ai` cell magic allows you to invoke a language model of your choice with
+a given prompt. The model is identified with a **global model ID**, which is a string with the
+syntax `<provider-id>:<local-model-id>`, where `<provider-id>` is the ID of the
+provider and `<local-model-id>` is the ID of the model scoped to that provider.
+The prompt begins on the second line of the cell.
 
 For example, to send a text prompt to the provider `anthropic` and the model ID
 `claude-v1.2`, enter the following code into a cell and run it:
@@ -331,8 +334,7 @@ For example, to send a text prompt to the provider `anthropic` and the model ID
 Write a poem about C++.
 ```
 
-We support the following providers, and all model IDs for each of these
-providers, as defined in [`langchain.llms`](https://langchain.readthedocs.io/en/latest/reference/modules/llms.html#module-langchain.llms):
+We currently support the following language model providers:
 
 - `ai21`
 - `anthropic`
@@ -342,14 +344,29 @@ providers, as defined in [`langchain.llms`](https://langchain.readthedocs.io/en/
 - `openai-chat`
 - `sagemaker-endpoint`
 
-You can find a list of supported providers and models by running `%ai list`. Some providers
-define a list of supported models. If a provider does not define a list of supported models,
-consult the vendor's documentation. The [Hugging Face web site](https://huggingface.co/)
-includes a list of models, for example.
+:::{warning}
+As of v0.8.0, only the `%%ai` *cell* magic may be used to invoke a language
+model, while the `%ai` *line* magic is reserved for invoking subcommands.
+:::
 
-Optionally, you can pass a provider ID as a parameter to `%ai list` to get all
-models provided by one provider. For example, `%ai list openai` will display only models
-provided by the `openai` provider.
+### Listing available models
+
+Jupyter AI also includes multiple subcommands, which may be invoked via the
+`%ai` *line* magic. Jupyter AI uses subcommands to provide additional utilities
+in notebooks while keeping the same concise syntax for invoking a language model.
+
+The `%ai list` subcommand prints a list of available providers and models. Some
+providers explicitly define a list of supported models in their API. However,
+other providers, like HuggingFace Hub, lack a well-defined list of available
+models. In such cases, it's best to consult the provider's upstream
+documentation. The [HuggingFace website](https://huggingface.co/) includes a
+list of models, for example.
+
+Optionally, you can specify a provider ID as a positional argument to `%ai list`
+to get all models provided by one provider. For example, `%ai list openai` will
+display only models provided by the `openai` provider.
+
+### Abbreviated syntax
 
 If your model ID is associated with only one provider, you can omit the `provider-id` and
 the colon from the first line. For example, because `ai21` is the only provider of the

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
@@ -1,0 +1,70 @@
+import click
+from pydantic import BaseModel
+from typing import Optional, Literal, get_args
+
+FORMAT_CHOICES_TYPE = Literal["code", "html", "image", "json", "markdown", "math", "md", "text"]
+FORMAT_CHOICES = list(get_args(FORMAT_CHOICES_TYPE))
+
+class CellArgs(BaseModel):
+    type: Literal["root"] = "root"
+    model_id: str
+    format: FORMAT_CHOICES_TYPE
+    reset: bool
+
+class HelpArgs(BaseModel):
+    type: Literal["help"] = "help"
+
+class ListArgs(BaseModel):
+    type: Literal["list"] = "list"
+    provider_id: Optional[str]
+
+class LineMagicGroup(click.Group):
+    """Helper class to print the help string for cell magics as well when
+    `%ai --help` is called."""
+    def get_help(self, ctx):
+        with click.Context(cell_magic_parser, info_name="%%ai") as ctx:
+            click.echo(cell_magic_parser.get_help(ctx))
+        click.echo('-' * 78)
+        with click.Context(line_magic_parser, info_name="%ai") as ctx:
+            click.echo(super().get_help(ctx))
+
+@click.command()
+@click.argument('model_id')
+@click.option('-f', '--format',
+    type=click.Choice(FORMAT_CHOICES, case_sensitive=False),
+    default="markdown",
+    help="""IPython display to use when rendering output. [default="markdown"]"""
+)
+@click.option('-r', '--reset', is_flag=True,
+    help="""Clears the conversation transcript used when interacting with an
+    OpenAI chat model provider. Does nothing with other providers."""
+)
+def cell_magic_parser(**kwargs):
+    """
+    Invokes a language model identified by MODEL_ID, with the prompt being
+    contained in all lines after the first. Both local model IDs and global
+    model IDs (with the provider ID explicitly prefixed, followed by a colon)
+    are accepted.
+
+    To view available language models, please run `%ai list`.
+    """
+    return CellArgs(**kwargs)
+
+@click.group(cls=LineMagicGroup)
+def line_magic_parser():
+    """
+    Invokes a subcommand.
+    """
+
+@line_magic_parser.command(name='help')
+def help_subparser():
+    """Show this message and exit."""
+    return HelpArgs()
+
+@line_magic_parser.command(name='list',
+    short_help="List language models. See `%ai list --help` for more."
+)
+@click.argument('provider_id', required=False)
+def list_subparser(**kwargs):
+    """List language models, optionally scoped to PROVIDER_ID."""
+    return ListArgs(**kwargs)

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
@@ -62,7 +62,7 @@ def help_subparser():
     return HelpArgs()
 
 @line_magic_parser.command(name='list',
-    short_help="List language models. See `%ai list --help` for more."
+    short_help="List language models. See `%ai list --help` for options."
 )
 @click.argument('provider_id', required=False)
 def list_subparser(**kwargs):

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "pydantic",
     "importlib_metadata~=5.2.0",
     "langchain==0.0.159",
-    "typing_extensions==4.5.0"
+    "typing_extensions==4.5.0",
+    "click~=8.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

- Closes #117 

Uses `click` to parse arguments. Notable features:

- **Declarative handling of subcommands.** Adding new subcommands is done easily by using the `@line_magic_parser.command()` decorator.
- **Support for subcommand arguments.** Use the `@click.option()` or `@click.argument()` decorators to add new arguments to a subcommand.
- **Automatically generated help strings.**
- Mitigates the issues of Python version compatibility involved with using `argparse`, which may include breaking changes version-to-version.

# Demo


https://github.com/jupyterlab/jupyter-ai/assets/44106031/57074c44-935a-493d-a299-dc035936981d


# Breaking changes

**Language models can no longer be invoked by a line magic.** The reason for this is that parsers do not handle [variadic arguments](https://click.palletsprojects.com/en/8.1.x/arguments/#variadic-arguments) correctly when using subcommands. Both `argparse` and `click` fail for such a use-case. So for example, `%ai list openai` will make `click` think that you want to execute the `list` model with the prompt `openai`, rather than dispatching to `openai`. I really, really tried getting this to work, with [one hacky workaround](https://stackoverflow.com/questions/54896044/click-group-with-options-and-commands-at-the-same-time) after [another](https://stackoverflow.com/questions/65789839/click-how-can-i-nest-subcommands-under-a-command-with-positional-arguments). Unfortunately, in the current landscape of CLI parsers in Python, it looks like there's no way of doing this while also parsing subcommands declaratively.

However, I believe this is a good breaking change to make. Users rarely have enough horizontal space to fit their entire prompt into a single line, along with the magic command itself and its arguments. This helps keep the first line of each magic short, which also avoids clipping the cell toolbar in JupyterLab. This also makes building the parsers easier, since it allows us to have two separate parsers: one for the cell magic and one for the line magic.
