### PR TITLE
Add documentation for running magics in remote kernels

### DIFF
--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -81,6 +81,25 @@ or restart the server.
 If you make changes to the **user interface** or **lab extension**, run `jlpm build` and then
 refresh your browser tab.
 
+## Building documentation
+
+The `./scripts/install.sh` should automatically install the documentation
+dependencies. To build the documentation locally, run
+
+```
+cd docs/
+make html
+```
+
+and open `file://<JUPYTER-AI-ABSOLUTE-PATH>/docs/build/html/index.html`, where
+`<JUPYTER-AI-ABSOLUTE-PATH>` is the absolute path of the Jupyter AI monorepo on
+your local filesystem. It is helpful to bookmark this path in your browser of
+choice to easily view your local documentation build.
+
+After making any changes, make sure to rebuild the documentation locally via
+`make html`, and then refresh your browser to verify the changes visually.
+
+
 ## Development uninstall
 
 To uninstall your Jupyter AI development environment, deactivate and remove the Conda environment:

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -281,10 +281,19 @@ To clear the chat panel, use the `/clear` command. This does not reset the AI mo
 
 ## The `%%ai` magic command
 
-The examples in this section are based on the [Jupyter AI example notebooks](https://github.com/jupyterlab/jupyter-ai/blob/main/examples/).
+Jupyter AI can also be used in notebooks via Jupyter AI magics. This section
+provides guidance on how to use Jupyter AI magics effectively. The examples in
+this section are based on the [Jupyter AI example notebooks](https://github.com/jupyterlab/jupyter-ai/blob/main/examples/).
 
-Before you send your first prompt to an AI model, load the IPython extension by running 
-the following code in a notebook cell or IPython shell:
+If you already have `jupyter_ai` installed, the magics package
+`jupyter_ai_magics` is installed automatically. Otherwise, run
+
+    pip install jupyter_ai_magics
+
+in your terminal to install the magics package.
+
+Before you send your first prompt to an AI model, load the IPython extension by
+running the following code in a notebook cell or IPython shell:
 
 ```
 %load_ext jupyter_ai_magics
@@ -292,8 +301,22 @@ the following code in a notebook cell or IPython shell:
 
 This command should not produce any output.
 
-The `%%ai` magic command is user-friendly and enables you to quickly pick which model you want to use
-and specify natural language prompts.
+:::{note}
+If you are using remote kernels (e.g.  Amazon SageMaker Studio), the above
+command will throw an error. This means that need to install the magics package
+on your remote kernel separately, even if you already have `jupyter_ai_magics`
+installed in your server's environment. In a notebook, run
+
+```
+%pip install jupyter_ai_magics
+```
+
+and re-run `%load_ext jupyter_ai_magics`.
+:::
+
+
+The `%%ai` magic command is user-friendly and enables you to quickly pick which
+model you want to use and specify natural language prompts.
 
 ### Choosing a provider and model
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-pip install jupyterlab
+# install core packages
+pip install jupyterlab~=3.0
 cp playground/config.example.py playground/config.py
 jlpm install
 jlpm dev-install
 
+# install docs packages
+pip install sphinx
+pip install -r docs/requirements.txt
+
+# install grpcio via conda for ARM platforms to preserve compatibility with Ray
 if [[ $(uname -m) == 'arm64' ]]; then
     pip uninstall grpcio && conda install -y grpcio
 fi


### PR DESCRIPTION
- Fixes #195

Adds guidance on how to run magics in remote kernels. Other changes:

- Updates dev install script to install dependencies for building documentation locally
- Adds guidance on building documentation locally in the contributor documentation 