### PR TITLE
Add GPT4All local provider

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -219,7 +219,7 @@ The chat backend remembers the last two exchanges in your conversation and passe
     alt='Screen shot of an example follow up question sent to Jupyternaut, who responds with the improved code and explanation.'
     class="screenshot" />
 
-### Using the chat interface with SageMaker endpoints
+### SageMaker endpoints usage
 
 Jupyter AI supports language models hosted on SageMaker endpoints that use JSON
 schemas. The first step is to authenticate with AWS via the `boto3` SDK and have
@@ -254,6 +254,37 @@ string that retrieves the language model's output from the endpoint's JSON
 response.  In this example, the endpoint returns an object with the schema
 `{"generated_texts":["<output>"]}`, hence the response path is
 `generated_texts.[0]`.
+
+### GPT4All usage (early-stage)
+
+Currently, we offer experimental support for GPT4All. To get started, first
+decide which models you will use. We currently offer three models from GPT4All:
+
+| Model name                   | Model size | Model bin URL                                              |
+|------------------------------|------------|------------------------------------------------------------|
+| `ggml-gpt4all-l13b-snoozy`   | 7.6 GB     | `http://gpt4all.io/models/ggml-gpt4all-l13b-snoozy.bin`    |
+| `ggml-gpt4all-j-v1.2-jazzy`  | 3.8 GB     | `https://gpt4all.io/models/ggml-gpt4all-j-v1.2-jazzy.bin`  |
+| `ggml-gpt4all-j-v1.3-groovy` | 3.8 GB     | `https://gpt4all.io/models/ggml-gpt4all-j-v1.3-groovy.bin` |
+
+
+Note that each model comes with its own license, and that users are themselves
+responsible for verifying that their usage complies with the license. You can
+find licensing details on the [GPT4All official site](https://gpt4all.io/index.html).
+
+For each model you use, you will have to run the command
+
+```
+curl -LO --output-dir ~/.cache/gpt4all "<model-bin-url>"
+```
+
+, where `<model-bin-url>` should be substituted with the corresponding URL
+hosting the model binary (within the double quotes). After restarting the
+server, the GPT4All models installed in the previous step should be available to
+use in the chat interface.
+
+GPT4All support is still an early-stage feature, so some bugs may be encountered
+during usage. Our team is still actively improving support for locally-hosted
+models.
 
 ### Asking about something in your notebook
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
@@ -18,6 +18,7 @@ from .providers import (
     ChatOpenAINewProvider,
     ChatOpenAIProvider,
     CohereProvider,
+    GPT4AllProvider,
     HfHubProvider,
     OpenAIProvider,
     SmEndpointProvider,

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -71,7 +71,12 @@ class MultilineTextField(Field):
     type: Literal["text-multiline"] = "text-multiline"
 
 
-Field = Union[TextField, MultilineTextField]
+class IntegerField(BaseModel):
+    type: Literal["integer"] = "integer"
+    key: str
+    label: str
+
+Field = Union[TextField, MultilineTextField, IntegerField]
 
 
 class BaseProvider(BaseModel):
@@ -256,6 +261,9 @@ class GPT4AllProvider(BaseProvider, GPT4All):
             kwargs["backend"] = "gptj"
 
         kwargs['allow_download'] = True
+        n_threads = kwargs.get('n_threads', None)
+        if n_threads is not None:
+            kwargs['n_threads'] = max(int(n_threads), 1)
         super().__init__(**kwargs)
 
     id = "gpt4all"
@@ -270,6 +278,12 @@ class GPT4AllProvider(BaseProvider, GPT4All):
     model_id_key = "model"
     pypi_package_deps = ["gpt4all"]
     auth_strategy = None
+    fields = [
+        IntegerField(
+            key="n_threads",
+            label="Threads"
+        )
+    ]
 
 
 HUGGINGFACE_HUB_VALID_TASKS = (

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -260,7 +260,7 @@ class GPT4AllProvider(BaseProvider, GPT4All):
         else:
             kwargs["backend"] = "gptj"
 
-        kwargs['allow_download'] = True
+        kwargs['allow_download'] = False
         n_threads = kwargs.get('n_threads', None)
         if n_threads is not None:
             kwargs['n_threads'] = max(int(n_threads), 1)

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -278,7 +278,10 @@ class GPT4AllProvider(BaseProvider, GPT4All):
     model_id_key = "model"
     pypi_package_deps = ["gpt4all"]
     auth_strategy = None
-    fields = [IntegerField(key="n_threads", label="Threads")]
+    fields = [IntegerField(key="n_threads", label="CPU thread count (optional)")]
+
+    async def _acall(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
+        return await self._call_in_executor(*args, **kwargs)
 
 
 HUGGINGFACE_HUB_VALID_TASKS = (

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -18,6 +18,7 @@ from langchain.llms import (
     HuggingFaceHub,
     OpenAI,
     OpenAIChat,
+    GPT4All,
     SagemakerEndpoint,
 )
 from langchain.llms.sagemaker_endpoint import LLMContentHandler
@@ -243,6 +244,32 @@ class CohereProvider(BaseProvider, Cohere):
 
     async def _acall(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
         return await self._call_in_executor(*args, **kwargs)
+
+
+class GPT4AllProvider(BaseProvider, GPT4All):
+
+    def __init__(self, **kwargs):
+        model = kwargs.get("model_id")
+        if model == "ggml-gpt4all-l13b-snoozy":
+            kwargs["backend"] = "llama"
+        else:
+            kwargs["backend"] = "gptj"
+
+        kwargs['allow_download'] = True
+        super().__init__(**kwargs)
+
+    id = "gpt4all"
+    name = "GPT4All"
+    docs = "https://docs.gpt4all.io/gpt4all_python.html"
+    models = [
+        "ggml-gpt4all-j-v1.2-jazzy",
+        "ggml-gpt4all-j-v1.3-groovy",
+        # this one needs llama backend and has licence restriction
+        "ggml-gpt4all-l13b-snoozy"
+    ]
+    model_id_key = "model"
+    pypi_package_deps = ["gpt4all"]
+    auth_strategy = None
 
 
 HUGGINGFACE_HUB_VALID_TASKS = (

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -15,10 +15,10 @@ from langchain.llms import (
     Anthropic,
     Bedrock,
     Cohere,
+    GPT4All,
     HuggingFaceHub,
     OpenAI,
     OpenAIChat,
-    GPT4All,
     SagemakerEndpoint,
 )
 from langchain.llms.sagemaker_endpoint import LLMContentHandler
@@ -75,6 +75,7 @@ class IntegerField(BaseModel):
     type: Literal["integer"] = "integer"
     key: str
     label: str
+
 
 Field = Union[TextField, MultilineTextField, IntegerField]
 
@@ -252,7 +253,6 @@ class CohereProvider(BaseProvider, Cohere):
 
 
 class GPT4AllProvider(BaseProvider, GPT4All):
-
     def __init__(self, **kwargs):
         model = kwargs.get("model_id")
         if model == "ggml-gpt4all-l13b-snoozy":
@@ -260,10 +260,10 @@ class GPT4AllProvider(BaseProvider, GPT4All):
         else:
             kwargs["backend"] = "gptj"
 
-        kwargs['allow_download'] = False
-        n_threads = kwargs.get('n_threads', None)
+        kwargs["allow_download"] = False
+        n_threads = kwargs.get("n_threads", None)
         if n_threads is not None:
-            kwargs['n_threads'] = max(int(n_threads), 1)
+            kwargs["n_threads"] = max(int(n_threads), 1)
         super().__init__(**kwargs)
 
     id = "gpt4all"
@@ -273,17 +273,12 @@ class GPT4AllProvider(BaseProvider, GPT4All):
         "ggml-gpt4all-j-v1.2-jazzy",
         "ggml-gpt4all-j-v1.3-groovy",
         # this one needs llama backend and has licence restriction
-        "ggml-gpt4all-l13b-snoozy"
+        "ggml-gpt4all-l13b-snoozy",
     ]
     model_id_key = "model"
     pypi_package_deps = ["gpt4all"]
     auth_strategy = None
-    fields = [
-        IntegerField(
-            key="n_threads",
-            label="Threads"
-        )
-    ]
+    fields = [IntegerField(key="n_threads", label="Threads")]
 
 
 HUGGINGFACE_HUB_VALID_TASKS = (

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "ipython",
     "pydantic",
     "importlib_metadata~=5.2.0",
-    "langchain==0.0.220",
+    "langchain==0.0.223",
     "typing_extensions==4.5.0",
     "click~=8.0",
     "jsonpath-ng~=1.5.3",

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -46,6 +46,7 @@ all = [
     "ai21",
     "anthropic~=0.2.10",
     "cohere",
+    "gpt4all",
     "huggingface_hub",
     "ipywidgets",
     "pillow",
@@ -57,6 +58,7 @@ all = [
 ai21 = "jupyter_ai_magics:AI21Provider"
 anthropic = "jupyter_ai_magics:AnthropicProvider"
 cohere = "jupyter_ai_magics:CohereProvider"
+gpt4all = "jupyter_ai_magics:GPT4AllProvider"
 huggingface_hub = "jupyter_ai_magics:HfHubProvider"
 openai = "jupyter_ai_magics:OpenAIProvider"
 openai-chat = "jupyter_ai_magics:ChatOpenAIProvider"

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "openai~=0.26",
     "aiosqlite~=0.18",
     "importlib_metadata~=5.2.0",
-    "langchain==0.0.220",
+    "langchain==0.0.223",
     "tiktoken", # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "dask[distributed]",

--- a/packages/jupyter-ai/src/components/settings/model-fields.tsx
+++ b/packages/jupyter-ai/src/components/settings/model-fields.tsx
@@ -18,6 +18,10 @@ export function ModelField(props: ModelFieldProps): JSX.Element {
   function handleChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) {
+    if (!('format' in props.field)) {
+      return;
+    }
+
     // Perform validation based on the field format
     switch (props.field.format) {
       case 'json':

--- a/packages/jupyter-ai/src/components/settings/model-fields.tsx
+++ b/packages/jupyter-ai/src/components/settings/model-fields.tsx
@@ -49,6 +49,18 @@ export function ModelField(props: ModelFieldProps): JSX.Element {
     });
   }
 
+  if (props.field.type === 'integer') {
+    return (
+      <TextField
+        label={props.field.label}
+        value={props.config.fields[props.gmid]?.[props.field.key]}
+        onChange={handleChange}
+        inputProps={{ inputMode: 'numeric', pattern: '[0-9]*' }}
+        fullWidth
+      />
+    );
+  }
+
   if (props.field.type === 'text') {
     return (
       <TextField

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -145,7 +145,13 @@ export namespace AiService {
     format: string;
   };
 
-  export type Field = TextField | MultilineTextField;
+  export type IntegerField = {
+    type: 'integer';
+    key: string;
+    label: string;
+  };
+
+  export type Field = TextField | MultilineTextField | IntegerField;
 
   export type ListProvidersEntry = {
     id: string;


### PR DESCRIPTION
This is proof of concept for #190. I tried a number of models and GPT4All appears to be most straighforward to install.

| Example 1 | Example 2 (snoozy) | Example 3 (groovy) |
|---|--|--|
| ![Screenshot from 2023-06-04 18-19-36](https://github.com/jupyterlab/jupyter-ai/assets/5832902/5a6fb8b9-3526-44b0-ae32-55359daa7ba8) |![Screenshot from 2023-06-04 20-01-59](https://github.com/jupyterlab/jupyter-ai/assets/5832902/322d055a-a089-458a-ad9f-741079874c4e) | ![Screenshot from 2023-06-04 20-01-46](https://github.com/jupyterlab/jupyter-ai/assets/5832902/48d23a24-3971-4ae3-a191-2390825e49c8) |

It would be good if the language of the document selection gets included from were included in the prompt (here the model assumed it is C# for some reason). Results, as seen above, are not great for coding tasks, but supposedly these models are good at reasoning and conversations.

#### Langchain updates

A newer `langchain` version is required because:
-  `>= 0.0.174`: the bindings switched from `pygpt4all` to a new official `gpt4all` package (https://github.com/hwchase17/langchain/pull/4567)
- `>= 0.0.188`: to support `allow_download` attribute (https://github.com/hwchase17/langchain/pull/5512)

#### Model download

`GPT4All` bindings have a native support for downloading model weights (disabled by default in langchain). If we decide to toggle it on by default user would not not have to do anything and the model would just work. The experience will depend on network speed as downloading the model can take from minutes to hours, but then it is cached in `~/.cache/gpt4all/`. The progress bar displays only in terminal, but download failures show up in UI as exception tracebacks. Ideally we would have a way to show that download is in progress in the UI.

Alternatively, users can download the model directly, e.g.

```python
cd ~/.cache/gpt4all/
wget http://gpt4all.io/models/ggml-gpt4all-l13b-snoozy.bin
```

The download sizes are:
- l13b-snoozy: 7.6G
- j-v1.3-groovy: 3.79 GB
- j-v1.2-jazzy: 3.79 GB

#### Performance

`GPT4All` runs on CPU (there is also a GPU version, `GPT4AllGPU` but there are no buindings in lanchaing - although we could contribute). The performance of CPU versions somewhat depends on number of threads (but then using too many threads can slow it down). This PR makes number of threads user-configurable.

Additionally a number of fields could be added to enhance user configurability, e.g. `temp`, `n_predict` (max output tokens), [etc](https://github.com/hwchase17/langchain/blob/8fea0529c1be9c9f5308a9b5a51f8381067a269a/langchain/llms/gpt4all.py#L33-L86).