### PR TITLE
Fix check release by allowing Python 3.11

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: minor
-          python-version: '3.10.x'
       - name: Runner debug info
         if: always()
         run: |

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -4,11 +4,11 @@ This page is intended for people interested in building new or modified function
 
 ## Prerequisites
 
-You can develop Jupyter AI on any system that can run a supported Python version up to and including 3.10, including recent Windows, macOS, and Linux versions.
+You can develop Jupyter AI on any system that can run a supported Python version up to and including 3.11, including recent Windows, macOS, and Linux versions.
 
 :::{important}
-:name: python-3-11-not-supported
-Because the [ray](https://pypi.org/project/ray/) library that Jupyter AI uses is not compatible with Python 3.11, please use a supported version of Python up to and including Python 3.10.
+:name: python-3-12-not-supported
+Jupyter AI uses is not compatible with Python 3.12, please use a supported version of Python up to and including Python 3.11.
 :::
 
 We highly recommend that you install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) to start developing on Jupyter AI, especially if you are developing on macOS on an Apple Silicon-based Mac (M1, M1 Pro, M2, etc.).

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -7,17 +7,17 @@ please see our {doc}`contributor's guide </contributors/index>`.
 
 ## Prerequisites
 
-You can run Jupyter AI on any system that can run a supported Python version from 3.8 to 3.10, including recent Windows, macOS, and Linux versions.
+You can run Jupyter AI on any system that can run a supported Python version from 3.8 to 3.11, including recent Windows, macOS, and Linux versions.
 
 :::{important}
-:name: python-3-11-not-supported
-Because the [ray](https://pypi.org/project/ray/) library that Jupyter AI uses is not compatible with Python 3.11, please use Python 3.8 to Python 3.10, inclusive.
+:name: python-3-12-not-supported
+Jupyter AI is not compatible with Python 3.11, please use Python 3.8 to Python 3.11, inclusive.
 :::
 
-If you use `conda`, you can install Python 3.10 in your environment by running:
+If you use `conda`, you can install Python 3.11 in your environment by running:
 
 ```
-conda install python=3.10
+conda install python=3.11
 ```
 
 To use the `jupyter_ai` package, you will also need to have a currently-maintained version of JupyterLab 3 installed. We do not yet support JupyterLab 4. If you use `conda`, you can install JupyterLab in your environment by running:

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyter_ai"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8,<3.11"
+requires-python = ">=3.8,<3.12"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",


### PR DESCRIPTION
Python 3.10 was pinned in #74 because ray 2.2 did not support Python 3.11 (see #73).

Python 3.11 is supported since ray 2.3. Ray [2.4](https://github.com/ray-project/ray/releases/tag/ray-2.4.0) is already required since https://github.com/jupyterlab/jupyter-ai/pull/127, so it should be possible to move on - let's see what CI has to say.

`python-version` was incorrectly added in #197 and generates a warning on CI since:

```
Unexpected input(s) 'python-version', valid inputs are ['token', 'version_spec', 'steps_to_skip']
```

![image](https://github.com/jupyterlab/jupyter-ai/assets/5832902/1013c00c-6a17-40c3-95bb-32bdec98adb8)