### PR TITLE
Pinning python version to 3.10.x

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -15,12 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_version: '3.10.x'
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: minor
-          python-version: '3.10.x'
       - name: Runner debug info
         if: always()
         run: |


### PR DESCRIPTION
## Summary
Check release workflow is running Python 3.11 as default, which fails the build for Jupyter AI since it only supports Python <3.11. Pinning the Python version to 3.10.x fixes the workflow.