### PR TITLE
Removes comment from magic command

### DIFF
--- a/examples/magics.ipynb
+++ b/examples/magics.ipynb
@@ -145,7 +145,7 @@
     }
    ],
    "source": [
-    "%%ai j2-jumbo-instruct # infers AI21 provider\n",
+    "%%ai j2-jumbo-instruct\n",
     "Write some JavaScript code that prints \"hello world\" to the console."
    ]
   },


### PR DESCRIPTION
Fixes #203 by modifying the example notebook for magic commands to remove the comment that no longer works with our new parsing logic (#188).