### PR TITLE
SageMaker Endpoint magic command support

### DIFF
--- a/examples/sagemaker.ipynb
+++ b/examples/sagemaker.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "79ebfce1-f5ac-4e39-83db-11416e310e8e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Jupyter AI with the SageMaker endpoint\n",
+    "\n",
+    "This demo showcases the IPython magics Jupyter AI provides out-of-the-box for Amazon SageMaker.\n",
+    "\n",
+    "First, make sure that you've set your `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` environment variables either before starting JupyterLab or using the `%env` magic command within JupyterLab.\n",
+    "\n",
+    "Then, load the IPython extension:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "24f3f446-2b1d-4802-a47c-d298c06fc86e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext jupyter_ai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f2b0270-1c33-4918-b534-4ec104f90141",
+   "metadata": {},
+   "source": [
+    "Jupyter AI supports language models hosted on SageMaker Endpoints that use JSON APIs. The first step is to authenticate with AWS via the `boto3` SDK and have the credentials stored in the `default` profile.  Guidance on how to do this can be found in the [`boto3` documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html).\n",
+    "\n",
+    "All SageMaker endpoint requests require you to specify the `--region-name`, `--request-schema`, and `--response-path` options.\n",
+    "\n",
+    "The `--region-name` parameter is set to the [AWS region code](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html), such as `us-east-1` or `eu-west-1`.\n",
+    "\n",
+    "The `--request-schema` parameter is the JSON object the endpoint expects, with the prompt being substituted into any value that matches the string literal `\"<prompt>\"`. For example, the request schema `{\"text_inputs\":\"<prompt>\"}` generates a JSON object with the prompt stored under the `text_inputs` key.\n",
+    "\n",
+    "The `--response-path` option is a [JSONPath](https://goessner.net/articles/JsonPath/index.html) string that retrieves the language model's output from the endpoint's JSON response. For example, if your endpoint returns an object with the schema `{\"generated_texts\":[\"<output>\"]}`, its response path is `generated_texts.[0]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "31f3e6e3-48cf-4e60-96d3-8b8e1dd34bec",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "ename": "ValidationError",
+     "evalue": "1 validation error for SmEndpointProvider\n__root__\n  Could not load credentials to authenticate with AWS client. Please check that credentials in the specified profile name are valid. (type=value_error)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValidationError\u001b[0m                           Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mget_ipython\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun_cell_magic\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mai\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43msagemaker-endpoint:sm_llm --region-name=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mus-east-1\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m --request-schema=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m{\u001b[39;49m\u001b[38;5;130;43;01m\\\\\u001b[39;49;00m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mtext_inputs\u001b[39;49m\u001b[38;5;130;43;01m\\\\\u001b[39;49;00m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m:\u001b[39;49m\u001b[38;5;130;43;01m\\\\\u001b[39;49;00m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m<prompt>\u001b[39;49m\u001b[38;5;130;43;01m\\\\\u001b[39;49;00m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m}\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m --response-path=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mgenerated_texts.[0]\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mWrite some JavaScript code that prints \u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mhello world\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m to the console.\u001b[39;49m\u001b[38;5;130;43;01m\\n\u001b[39;49;00m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/opt/miniconda3/envs/jupyter-ai/lib/python3.10/site-packages/IPython/core/interactiveshell.py:2478\u001b[0m, in \u001b[0;36mInteractiveShell.run_cell_magic\u001b[0;34m(self, magic_name, line, cell)\u001b[0m\n\u001b[1;32m   2476\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbuiltin_trap:\n\u001b[1;32m   2477\u001b[0m     args \u001b[38;5;241m=\u001b[39m (magic_arg_s, cell)\n\u001b[0;32m-> 2478\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[43mfn\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   2480\u001b[0m \u001b[38;5;66;03m# The code below prevents the output from being displayed\u001b[39;00m\n\u001b[1;32m   2481\u001b[0m \u001b[38;5;66;03m# when using magics with decodator @output_can_be_silenced\u001b[39;00m\n\u001b[1;32m   2482\u001b[0m \u001b[38;5;66;03m# when the last Python token in the expression is a ';'.\u001b[39;00m\n\u001b[1;32m   2483\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mgetattr\u001b[39m(fn, magic\u001b[38;5;241m.\u001b[39mMAGIC_OUTPUT_CAN_BE_SILENCED, \u001b[38;5;28;01mFalse\u001b[39;00m):\n",
+      "File \u001b[0;32m~/git/jupyter-ai/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py:567\u001b[0m, in \u001b[0;36mAiMagics.ai\u001b[0;34m(self, line, cell)\u001b[0m\n\u001b[1;32m    564\u001b[0m ip \u001b[38;5;241m=\u001b[39m get_ipython()\n\u001b[1;32m    565\u001b[0m prompt \u001b[38;5;241m=\u001b[39m prompt\u001b[38;5;241m.\u001b[39mformat_map(FormatDict(ip\u001b[38;5;241m.\u001b[39muser_ns))\n\u001b[0;32m--> 567\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun_ai_cell\u001b[49m\u001b[43m(\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mprompt\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/git/jupyter-ai/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py:501\u001b[0m, in \u001b[0;36mAiMagics.run_ai_cell\u001b[0;34m(self, args, prompt)\u001b[0m\n\u001b[1;32m    498\u001b[0m     provider_params[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mrequest_schema\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m args\u001b[38;5;241m.\u001b[39mrequest_schema\n\u001b[1;32m    499\u001b[0m     provider_params[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mresponse_path\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m args\u001b[38;5;241m.\u001b[39mresponse_path\n\u001b[0;32m--> 501\u001b[0m provider \u001b[38;5;241m=\u001b[39m \u001b[43mProvider\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mprovider_params\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    503\u001b[0m \u001b[38;5;66;03m# generate output from model via provider\u001b[39;00m\n\u001b[1;32m    504\u001b[0m result \u001b[38;5;241m=\u001b[39m provider\u001b[38;5;241m.\u001b[39mgenerate([prompt])\n",
+      "File \u001b[0;32m~/git/jupyter-ai/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py:374\u001b[0m, in \u001b[0;36mSmEndpointProvider.__init__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    372\u001b[0m response_path \u001b[38;5;241m=\u001b[39m kwargs\u001b[38;5;241m.\u001b[39mpop(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mresponse_path\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m    373\u001b[0m content_handler \u001b[38;5;241m=\u001b[39m JsonContentHandler(request_schema\u001b[38;5;241m=\u001b[39mrequest_schema, response_path\u001b[38;5;241m=\u001b[39mresponse_path)\n\u001b[0;32m--> 374\u001b[0m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;21;43m__init__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcontent_handler\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcontent_handler\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/git/jupyter-ai/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py:113\u001b[0m, in \u001b[0;36mBaseProvider.__init__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    110\u001b[0m model_kwargs \u001b[38;5;241m=\u001b[39m {}\n\u001b[1;32m    111\u001b[0m model_kwargs[\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39mmodel_id_key] \u001b[38;5;241m=\u001b[39m kwargs[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmodel_id\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[0;32m--> 113\u001b[0m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;21;43m__init__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mmodel_kwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/opt/miniconda3/envs/jupyter-ai/lib/python3.10/site-packages/pydantic/main.py:341\u001b[0m, in \u001b[0;36mpydantic.main.BaseModel.__init__\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mValidationError\u001b[0m: 1 validation error for SmEndpointProvider\n__root__\n  Could not load credentials to authenticate with AWS client. Please check that credentials in the specified profile name are valid. (type=value_error)"
+     ]
+    }
+   ],
+   "source": [
+    "%%ai sagemaker-endpoint:sm_llm --region-name=\"us-east-1\" --request-schema=\"{\\\"text_inputs\\\":\\\"<prompt>\\\"}\" --response-path=\"generated_texts.[0]\"\n",
+    "Write some JavaScript code that prints \"hello world\" to the console."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ad8c62e-b0a5-4091-94e3-4067ed8d6c4a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -478,11 +478,26 @@ class AiMagics(Magics):
                     f"An authentication token is required to use models from the {Provider.name} provider.\n"
                     f"Please specify it via `%env {auth_strategy.name}=token`. "
                 ) from None
-        
+
         # configure and instantiate provider
         provider_params = { "model_id": local_model_id }
         if provider_id == "openai-chat":
             provider_params["prefix_messages"] = self.transcript_openai
+        # for SageMaker, validate that required params are specified
+        if provider_id == "sagemaker-endpoint":
+            if (
+                args.region_name is None or
+                args.request_schema is None or
+                args.response_path is None
+            ):
+                raise ValueError(
+                    "When using the sagemaker-endpoint provider, you must specify all of " +
+                    "the --region-name, --request-schema, and --response-path options."
+                )
+            provider_params["region_name"] = args.region_name
+            provider_params["request_schema"] = args.request_schema
+            provider_params["response_path"] = args.response_path
+
         provider = Provider(**provider_params)
 
         # generate output from model via provider

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
@@ -6,17 +6,42 @@ FORMAT_CHOICES_TYPE = Literal["code", "html", "image", "json", "markdown", "math
 FORMAT_CHOICES = list(get_args(FORMAT_CHOICES_TYPE))
 FORMAT_HELP = """IPython display to use when rendering output. [default="markdown"]"""
 
+REGION_NAME_SHORT_OPTION = '-n'
+REGION_NAME_LONG_OPTION = '--region-name'
+REGION_NAME_HELP = ("AWS region name, e.g. 'us-east-1'. Required for SageMaker provider; " +
+    "does nothing with other providers.")
+
+REQUEST_SCHEMA_SHORT_OPTION = '-q'
+REQUEST_SCHEMA_LONG_OPTION = '--request-schema'
+REQUEST_SCHEMA_HELP = ("The JSON object the endpoint expects, with the prompt being " +
+    "substituted into any value that matches the string literal '<prompt>'. " +
+    "Required for SageMaker provider; does nothing with other providers.")
+
+RESPONSE_PATH_SHORT_OPTION = '-p'
+RESPONSE_PATH_LONG_OPTION = '--response-path'
+RESPONSE_PATH_HELP = ("A JSONPath string that retrieves the language model's output " +
+    "from the endpoint's JSON response. Required for SageMaker provider; " +
+    "does nothing with other providers.")
+
 class CellArgs(BaseModel):
     type: Literal["root"] = "root"
     model_id: str
     format: FORMAT_CHOICES_TYPE
     reset: bool
+    # The following parameters are required only for SageMaker models
+    region_name: Optional[str]
+    request_schema: Optional[str]
+    response_path: Optional[str]
 
 # Should match CellArgs, but without "reset"
 class ErrorArgs(BaseModel):
     type: Literal["error"] = "error"
     model_id: str
     format: FORMAT_CHOICES_TYPE
+    # The following parameters are required only for SageMaker models
+    region_name: Optional[str]
+    request_schema: Optional[str]
+    response_path: Optional[str]
 
 class HelpArgs(BaseModel):
     type: Literal["help"] = "help"
@@ -60,6 +85,9 @@ class LineMagicGroup(click.Group):
     help="""Clears the conversation transcript used when interacting with an
     OpenAI chat model provider. Does nothing with other providers."""
 )
+@click.option(REGION_NAME_SHORT_OPTION, REGION_NAME_LONG_OPTION, required=False, help=REGION_NAME_HELP)
+@click.option(REQUEST_SCHEMA_SHORT_OPTION, REQUEST_SCHEMA_LONG_OPTION, required=False, help=REQUEST_SCHEMA_HELP)
+@click.option(RESPONSE_PATH_SHORT_OPTION, RESPONSE_PATH_LONG_OPTION, required=False, help=RESPONSE_PATH_HELP)
 def cell_magic_parser(**kwargs):
     """
     Invokes a language model identified by MODEL_ID, with the prompt being
@@ -84,6 +112,9 @@ def line_magic_parser():
     default="markdown",
     help=FORMAT_HELP
 )
+@click.option('-n', '--region-name', required=False, help=REGION_NAME_HELP)
+@click.option('-q', '--request-schema', required=False, help=REQUEST_SCHEMA_HELP)
+@click.option('-p', '--response-path', required=False, help=RESPONSE_PATH_HELP)
 def error_subparser(**kwargs):
     """
     Explains the most recent error. Takes the same options (except -r) as


### PR DESCRIPTION
Fixes #36.

Adds three new mandatory parameters, `--region-name`, `--request-schema`, and `--response-path`, for SageMaker requests made from `%%ai` magic commands.

WIP at the moment; my SageMaker requests aren't going through via either chat or magics at the moment.