### PR TITLE
WIP: Chat options on the command line

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/actors/config.py
+++ b/packages/jupyter-ai/jupyter_ai/actors/config.py
@@ -12,12 +12,25 @@ class ConfigActor():
     with the credentials to authenticate providers.
     """
 
-    def __init__(self, log: Logger):
+    def __init__(self, log: Logger, config):
         self.log = log
         self.save_dir = os.path.join(jupyter_data_dir(), 'jupyter_ai')
         self.save_path = os.path.join(self.save_dir, 'config.json')
         self.config = None
         self._load()
+        # For each key in the config, override what's in self.config,
+        # if the value is not None
+        configChanged = False;
+        newConfig = {}
+        for configKey in config:
+            # TODO: Validate that configKey is in GlobalConfig
+            if (config[configKey] is not None):
+                newConfig[configKey] = config[configKey]
+                configChanged = True
+        # Save the config, if it has changed
+        if configChanged:
+            newConfig = GlobalConfig({ **self.get_config(), **newConfig })
+            self.update(newConfig, True)
 
     def update(self, config: GlobalConfig, save_to_disk: bool = True):
         self._update_chat_provider(config)

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -57,7 +57,6 @@ class AiExtension(ExtensionApp):
         help="Model provider ID, as provider:model",
         config=True
     )
-    # TODO: Pass traitlets to ConfigActor's constructor
 
     @property
     def ai_engines(self): 
@@ -72,6 +71,11 @@ class AiExtension(ExtensionApp):
 
         # EP := entry point
         eps = entry_points()
+
+        # Create a config based on specified options on startup
+        config = {
+            "model_provider_id": self.model_provider_id
+        }
         
         ## step 1: instantiate model engines and bind them to settings
         model_engine_class_eps = eps.select(group="jupyter_ai.model_engine_classes")
@@ -153,6 +157,7 @@ class AiExtension(ExtensionApp):
         )
         config_actor = ConfigActor.options(name=ACTOR_TYPE.CONFIG.value).remote(
             log=self.log,
+            config=config,
         )
         chat_provider_actor = ChatProviderActor.options(name=ACTOR_TYPE.CHAT_PROVIDER.value).remote(
             log=self.log,

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -36,6 +36,7 @@ import ray
 from ray.util.queue import Queue
 from jupyter_ai_magics.utils import load_providers
 
+from traitlets import Unicode
 
 class AiExtension(ExtensionApp):
     name = "jupyter_ai"
@@ -49,6 +50,14 @@ class AiExtension(ExtensionApp):
         (r"api/ai/providers?", ModelProviderHandler),
         (r"api/ai/providers/embeddings?", EmbeddingsModelProviderHandler),
     ]
+
+    # Traitlets for customization in config
+    model_provider_id = Unicode(
+        allow_none = True,
+        help="Model provider ID, as provider:model",
+        config=True
+    )
+    # TODO: Pass traitlets to ConfigActor's constructor
 
     @property
     def ai_engines(self): 


### PR DESCRIPTION
Draft PR to add `model_provider_id` as an option on the command line, or in a config file, via `traitlets`. Fixes #218.

Currently, this does not work as intended, since `GlobalConfig` cannot be modified once created, and I haven't yet found a way to merge an existing `GlobalConfig` object with a new config option.