### PR TITLE
Adds __str__ method for TextWithMetadata

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -48,7 +48,7 @@ class TextWithMetadata:
     def __init__(self, text, metadata):
         self.text = text
         self.metadata = metadata
-    
+
     def __str__(self):
         return self.text
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -48,6 +48,9 @@ class TextWithMetadata:
     def __init__(self, text, metadata):
         self.text = text
         self.metadata = metadata
+    
+    def __str__(self):
+        return self.text
 
     def _repr_mimebundle_(self, include=None, exclude=None):
         return ({"text/plain": self.text}, self.metadata)


### PR DESCRIPTION
Fixes #241. Adds `__str__` method to the `TextWithMetadata` class so that text outputs in the `Out` special array can be used via interpolation in prompts.

Before:

![Out objects are treated as objects when interpolated](https://user-images.githubusercontent.com/93281816/248407636-08c0de7e-0f95-4709-869e-03743b2cb7eb.png)

After:

![Out objects are treated as text when interpolated](https://github.com/jupyterlab/jupyter-ai/assets/93281816/f3b6fa77-0c05-4499-80e8-4676699c8c70)
