### PR TITLE
Fixes "replace selection" behavior when nothing is selected

### DIFF
--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -98,9 +98,7 @@ function ChatBody({
     // no need to append to messageGroups state variable, since that's already
     // handled in the effect hooks.
     const reply = await chatHandler.replyFor(messageId);
-    // Need to check that the selection is both non-null and has text, so as not to replace
-    // the active cell with no selection in it
-    if (replaceSelection && selection && selection.text) {
+    if (replaceSelection && selection) {
       const { cellId, ...selectionProps } = selection;
       replaceSelectionFn({
         ...selectionProps,
@@ -147,7 +145,6 @@ function ChatBody({
 
   // If there is no selection, the "replace selection" button will not be
   // visible; treat it as disabled
-  const hasSelection = !!selection?.text;
   return (
     <>
       <ScrollContainer sx={{ flexGrow: 1 }}>
@@ -157,12 +154,12 @@ function ChatBody({
         value={input}
         onChange={setInput}
         onSend={onSend}
-        hasSelection={hasSelection}
+        hasSelection={!!selection?.text}
         includeSelection={includeSelection}
         toggleIncludeSelection={() =>
           setIncludeSelection(includeSelection => !includeSelection)
         }
-        replaceSelection={hasSelection && replaceSelection}
+        replaceSelection={replaceSelection}
         toggleReplaceSelection={() =>
           setReplaceSelection(replaceSelection => !replaceSelection)
         }

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -145,6 +145,9 @@ function ChatBody({
     );
   }
 
+  // If there is no selection, the "replace selection" button will not be
+  // visible; treat it as disabled
+  const hasSelection = !!selection?.text;
   return (
     <>
       <ScrollContainer sx={{ flexGrow: 1 }}>
@@ -154,12 +157,12 @@ function ChatBody({
         value={input}
         onChange={setInput}
         onSend={onSend}
-        hasSelection={!!selection?.text}
+        hasSelection={hasSelection}
         includeSelection={includeSelection}
         toggleIncludeSelection={() =>
           setIncludeSelection(includeSelection => !includeSelection)
         }
-        replaceSelection={replaceSelection}
+        replaceSelection={hasSelection && replaceSelection}
         toggleReplaceSelection={() =>
           setReplaceSelection(replaceSelection => !replaceSelection)
         }

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -98,7 +98,9 @@ function ChatBody({
     // no need to append to messageGroups state variable, since that's already
     // handled in the effect hooks.
     const reply = await chatHandler.replyFor(messageId);
-    if (replaceSelection && selection) {
+    // Need to check that the selection is both non-null and has text, so as not to replace
+    // the active cell with no selection in it
+    if (replaceSelection && selection && selection.text) {
       const { cellId, ...selectionProps } = selection;
       replaceSelectionFn({
         ...selectionProps,

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -143,8 +143,6 @@ function ChatBody({
     );
   }
 
-  // If there is no selection, the "replace selection" button will not be
-  // visible; treat it as disabled
   return (
     <>
       <ScrollContainer sx={{ flexGrow: 1 }}>

--- a/packages/jupyter-ai/src/selection-watcher.ts
+++ b/packages/jupyter-ai/src/selection-watcher.ts
@@ -58,6 +58,11 @@ function getTextSelection(widget: Widget | null): Selection | null {
     .getSource()
     .substring(startOffset, endOffset);
 
+  // Do not return a Selection object if no text is selected
+  if (!text) {
+    return null;
+  }
+
   // ensure start <= end
   // required for editor.model.sharedModel.updateSource()
   if (startOffset > endOffset) {


### PR DESCRIPTION
Fixes #239. To repro:

1. In cell 1, highlight some text, and use the Jupyter AI's chat UI to ask a question, with both the "include selection" and "replace selection" boxes checked. 
2. After the prompt runs and the output replaces the selection, run cell 1. Cell 2 is now active, and nothing in cell 2 is selected. 
3. Ask a question in the chat UI — note that neither "Include selection" nor "replace selection" appear as options.
4. Verify that the response **is not** added to either cell 1 or cell 2.