### PR TITLE
Sets font color for intro text

### DIFF
--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -125,7 +125,7 @@ function ChatBody({
         }}
       >
         <Stack spacing={4}>
-          <p>
+          <p className="jp-ai-ChatSettings-welcome">
             Welcome to Jupyter AI! To get started, please select a language
             model to chat with from the settings panel. You will also likely
             need to provide API credentials, so be sure to have those handy.

--- a/packages/jupyter-ai/style/chat-settings.css
+++ b/packages/jupyter-ai/style/chat-settings.css
@@ -3,3 +3,7 @@
   font-weight: 400;
   color: var(--jp-ui-font-color1);
 }
+
+.jp-ai-ChatSettings-welcome {
+  color: var(--jp-ui-font-color1);
+}


### PR DESCRIPTION
Fixes #186.

Sets a font color, using a CSS variable, for the introductory text. This text is now visible in both light and dark themes.

![Screen Shot 2023-07-13 at 3 32 26 PM](https://github.com/jupyterlab/jupyter-ai/assets/93281816/1f754ab3-05d3-4fed-9021-2e4de85da2ca)

![Screen Shot 2023-07-13 at 3 35 39 PM](https://github.com/jupyterlab/jupyter-ai/assets/93281816/d1dbe20e-cb67-43aa-b828-d3529c74c9f7)

