### PR TITLE
Allows specifying chunk size and overlap with /learn

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -328,7 +328,7 @@ To clear the local vector database, you can run `/learn -d` and Jupyter AI will 
     alt='Screen shot of a "/learn -d" command and a response.'
     class="screenshot" />
 
-With the `/learn` command, some models work better with custom chunk sizes and chunk overlaps. To override the defaults,
+With the `/learn` command, some models work better with custom chunk size and chunk overlap values. To override the defaults,
 use the `-c` or `--chunk-size` option and the `-o` or `--chunk-overlap` option.
 
 ```

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -328,6 +328,20 @@ To clear the local vector database, you can run `/learn -d` and Jupyter AI will 
     alt='Screen shot of a "/learn -d" command and a response.'
     class="screenshot" />
 
+With the `/learn` command, some models work better with custom chunk sizes and chunk overlaps. To override the defaults,
+use the `-c` or `--chunk-size` option and the `-o` or `--chunk-overlap` option.
+
+```
+# default chunk size and chunk overlap
+/learn <directory>
+
+# chunk size of 500, and chunk overlap of 50
+/learn -c 500 -o 50 <directory>
+
+# chunk size of 1000, and chunk overlap of 200
+/learn --chunk-size 1000 --chunk-overlap 200 <directory>
+```
+
 ### Additional chat commands
 
 To clear the chat panel, use the `/clear` command. This does not reset the AI model; the model may still remember previous messages that you sent it, and it may use them to inform its responses.

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -133,33 +133,18 @@ class LearnChatHandler(BaseChatHandler, BaseRetriever):
         {dir_list}"""
         return message
 
-    async def learn_dir(
-        self, path: str, chunk_size: int, chunk_overlap: int
-    ):
+    async def learn_dir(self, path: str, chunk_size: int, chunk_overlap: int):
         dask_client = await self.dask_client_future
-        splitter_kwargs = {
-            chunk_size: chunk_size,
-            chunk_overlap: chunk_overlap
-        }
+        splitter_kwargs = {chunk_size: chunk_size, chunk_overlap: chunk_overlap}
         splitters = {
-            ".py": PythonCodeTextSplitter(
-                **splitter_kwargs
-            ),
-            ".md": MarkdownTextSplitter(
-                **splitter_kwargs
-            ),
-            ".tex": LatexTextSplitter(
-                **splitter_kwargs
-            ),
-            ".ipynb": NotebookSplitter(
-                **splitter_kwargs
-            ),
+            ".py": PythonCodeTextSplitter(**splitter_kwargs),
+            ".md": MarkdownTextSplitter(**splitter_kwargs),
+            ".tex": LatexTextSplitter(**splitter_kwargs),
+            ".ipynb": NotebookSplitter(**splitter_kwargs),
         }
         splitter = ExtensionSplitter(
             splitters=splitters,
-            default_splitter=RecursiveCharacterTextSplitter(
-                **splitter_kwargs
-            ),
+            default_splitter=RecursiveCharacterTextSplitter(**splitter_kwargs),
         )
 
         delayed = split(path, splitter=splitter)

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -134,27 +134,31 @@ class LearnChatHandler(BaseChatHandler, BaseRetriever):
         return message
 
     async def learn_dir(
-        self, path: str, chunk_size: int = 2000, chunk_overlap: int = 100
+        self, path: str, chunk_size: int, chunk_overlap: int
     ):
         dask_client = await self.dask_client_future
+        splitter_kwargs = {
+            chunk_size: chunk_size,
+            chunk_overlap: chunk_overlap
+        }
         splitters = {
             ".py": PythonCodeTextSplitter(
-                chunk_size=chunk_size, chunk_overlap=chunk_overlap
+                **splitter_kwargs
             ),
             ".md": MarkdownTextSplitter(
-                chunk_size=chunk_size, chunk_overlap=chunk_overlap
+                **splitter_kwargs
             ),
             ".tex": LatexTextSplitter(
-                chunk_size=chunk_size, chunk_overlap=chunk_overlap
+                **splitter_kwargs
             ),
             ".ipynb": NotebookSplitter(
-                chunk_size=chunk_size, chunk_overlap=chunk_overlap
+                **splitter_kwargs
             ),
         }
         splitter = ExtensionSplitter(
             splitters=splitters,
             default_splitter=RecursiveCharacterTextSplitter(
-                chunk_size=chunk_size, chunk_overlap=chunk_overlap
+                **splitter_kwargs
             ),
         )
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -7,11 +7,11 @@ from dask.distributed import Client as DaskClient
 from jupyter_ai.document_loaders.directory import get_embeddings, split
 from jupyter_ai.document_loaders.splitter import ExtensionSplitter, NotebookSplitter
 from jupyter_ai.models import (
-    DEFAULT_CHUNK_OVERLAP, 
-    DEFAULT_CHUNK_SIZE, 
-    HumanChatMessage, 
-    IndexedDir, 
-    IndexMetadata
+    DEFAULT_CHUNK_OVERLAP,
+    DEFAULT_CHUNK_SIZE,
+    HumanChatMessage,
+    IndexedDir,
+    IndexMetadata,
 )
 from jupyter_core.paths import jupyter_data_dir
 from langchain import FAISS
@@ -40,8 +40,16 @@ class LearnChatHandler(BaseChatHandler, BaseRetriever):
         self.parser.add_argument("-v", "--verbose", action="store_true")
         self.parser.add_argument("-d", "--delete", action="store_true")
         self.parser.add_argument("-l", "--list", action="store_true")
-        self.parser.add_argument("-c", "--chunk-size", action="store", default=DEFAULT_CHUNK_SIZE, type=int)
-        self.parser.add_argument("-o", "--chunk-overlap", action="store", default=DEFAULT_CHUNK_OVERLAP, type=int)
+        self.parser.add_argument(
+            "-c", "--chunk-size", action="store", default=DEFAULT_CHUNK_SIZE, type=int
+        )
+        self.parser.add_argument(
+            "-o",
+            "--chunk-overlap",
+            action="store",
+            default=DEFAULT_CHUNK_OVERLAP,
+            type=int,
+        )
         self.parser.add_argument("path", nargs=argparse.REMAINDER)
         self.index_name = "default"
         self.index = None
@@ -125,7 +133,9 @@ class LearnChatHandler(BaseChatHandler, BaseRetriever):
         {dir_list}"""
         return message
 
-    async def learn_dir(self, path: str, chunk_size: int =2000, chunk_overlap: int = 100):
+    async def learn_dir(
+        self, path: str, chunk_size: int = 2000, chunk_overlap: int = 100
+    ):
         dask_client = await self.dask_client_future
         splitters = {
             ".py": PythonCodeTextSplitter(
@@ -162,7 +172,11 @@ class LearnChatHandler(BaseChatHandler, BaseRetriever):
         dirs = self.metadata.dirs
         index = next((i for i, dir in enumerate(dirs) if dir.path == path), None)
         if not index:
-            dirs.append(IndexedDir(path=path, chunk_size=chunk_size, chunk_overlap=chunk_overlap))
+            dirs.append(
+                IndexedDir(
+                    path=path, chunk_size=chunk_size, chunk_overlap=chunk_overlap
+                )
+            )
         self.metadata.dirs = dirs
 
     async def delete_and_relearn(self):

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -6,7 +6,13 @@ from typing import Any, Awaitable, Coroutine, List
 from dask.distributed import Client as DaskClient
 from jupyter_ai.document_loaders.directory import get_embeddings, split
 from jupyter_ai.document_loaders.splitter import ExtensionSplitter, NotebookSplitter
-from jupyter_ai.models import HumanChatMessage, IndexedDir, IndexMetadata
+from jupyter_ai.models import (
+    DEFAULT_CHUNK_OVERLAP, 
+    DEFAULT_CHUNK_SIZE, 
+    HumanChatMessage, 
+    IndexedDir, 
+    IndexMetadata
+)
 from jupyter_core.paths import jupyter_data_dir
 from langchain import FAISS
 from langchain.schema import BaseRetriever, Document
@@ -30,12 +36,12 @@ class LearnChatHandler(BaseChatHandler, BaseRetriever):
         super().__init__(*args, **kwargs)
         self.root_dir = root_dir
         self.dask_client_future = dask_client_future
-        self.chunk_size = 2000
-        self.chunk_overlap = 100
         self.parser.prog = "/learn"
         self.parser.add_argument("-v", "--verbose", action="store_true")
         self.parser.add_argument("-d", "--delete", action="store_true")
         self.parser.add_argument("-l", "--list", action="store_true")
+        self.parser.add_argument("-c", "--chunk-size", action="store", default=DEFAULT_CHUNK_SIZE, type=int)
+        self.parser.add_argument("-o", "--chunk-overlap", action="store", default=DEFAULT_CHUNK_OVERLAP, type=int)
         self.parser.add_argument("path", nargs=argparse.REMAINDER)
         self.index_name = "default"
         self.index = None
@@ -102,7 +108,7 @@ class LearnChatHandler(BaseChatHandler, BaseRetriever):
         if args.verbose:
             self.reply(f"Loading and splitting files for {load_path}", message)
 
-        await self.learn_dir(load_path)
+        await self.learn_dir(load_path, args.chunk_size, args.chunk_overlap)
         self.save()
 
         response = f"""🎉 I have learned documents at **{load_path}** and I am ready to answer questions about them.
@@ -119,26 +125,26 @@ class LearnChatHandler(BaseChatHandler, BaseRetriever):
         {dir_list}"""
         return message
 
-    async def learn_dir(self, path: str):
+    async def learn_dir(self, path: str, chunk_size: int =2000, chunk_overlap: int = 100):
         dask_client = await self.dask_client_future
         splitters = {
             ".py": PythonCodeTextSplitter(
-                chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap
+                chunk_size=chunk_size, chunk_overlap=chunk_overlap
             ),
             ".md": MarkdownTextSplitter(
-                chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap
+                chunk_size=chunk_size, chunk_overlap=chunk_overlap
             ),
             ".tex": LatexTextSplitter(
-                chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap
+                chunk_size=chunk_size, chunk_overlap=chunk_overlap
             ),
             ".ipynb": NotebookSplitter(
-                chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap
+                chunk_size=chunk_size, chunk_overlap=chunk_overlap
             ),
         }
         splitter = ExtensionSplitter(
             splitters=splitters,
             default_splitter=RecursiveCharacterTextSplitter(
-                chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap
+                chunk_size=chunk_size, chunk_overlap=chunk_overlap
             ),
         )
 
@@ -149,14 +155,14 @@ class LearnChatHandler(BaseChatHandler, BaseRetriever):
         delayed = get_embeddings(doc_chunks, em_provider_cls, em_provider_args)
         embedding_records = await dask_client.compute(delayed)
         self.index.add_embeddings(*embedding_records)
-        self._add_dir_to_metadata(path)
+        self._add_dir_to_metadata(path, chunk_size, chunk_overlap)
         self.prev_em_id = em_provider_cls.id + ":" + em_provider_args["model_id"]
 
-    def _add_dir_to_metadata(self, path: str):
+    def _add_dir_to_metadata(self, path: str, chunk_size: int, chunk_overlap: int):
         dirs = self.metadata.dirs
         index = next((i for i, dir in enumerate(dirs) if dir.path == path), None)
         if not index:
-            dirs.append(IndexedDir(path=path))
+            dirs.append(IndexedDir(path=path, chunk_size=chunk_size, chunk_overlap=chunk_overlap))
         self.metadata.dirs = dirs
 
     async def delete_and_relearn(self):
@@ -213,7 +219,7 @@ class LearnChatHandler(BaseChatHandler, BaseRetriever):
         for dir in metadata.dirs:
             # TODO: do not relearn directories in serial, but instead
             # concurrently or in parallel
-            await self.learn_dir(dir.path)
+            await self.learn_dir(dir.path, dir.chunk_size, dir.chunk_overlap)
 
         self.save()
 

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -4,6 +4,9 @@ from jupyter_ai_magics.providers import AuthStrategy, Field
 from pydantic import BaseModel
 
 
+DEFAULT_CHUNK_SIZE = 2000
+DEFAULT_CHUNK_OVERLAP = 100
+
 # the type of message used to chat with the agent
 class ChatRequest(BaseModel):
     prompt: str
@@ -86,6 +89,8 @@ class ListProvidersResponse(BaseModel):
 
 class IndexedDir(BaseModel):
     path: str
+    chunk_size: int = DEFAULT_CHUNK_SIZE
+    chunk_overlap: int = DEFAULT_CHUNK_OVERLAP
 
 
 class IndexMetadata(BaseModel):

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -3,9 +3,9 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from jupyter_ai_magics.providers import AuthStrategy, Field
 from pydantic import BaseModel
 
-
 DEFAULT_CHUNK_SIZE = 2000
 DEFAULT_CHUNK_OVERLAP = 100
+
 
 # the type of message used to chat with the agent
 class ChatRequest(BaseModel):


### PR DESCRIPTION
## Summary
Current implementation of `/learn` has fixed values for chunk size and overlap which is impractical for all document types and models. Adding options for specifying these attributes will allow power users to quickly experiment and select the options that work best for their document types and model selected. This PR adds these new options to the `/learn` command and stores these values in the metadata, so that relearn works when embedding models are switched.

### Usage
```bash
# default chunk size of 2000, and chunk overlap of 100
/learn <directory>

# chunk size of 500, and chunk overlap of 50
/learn -c 500 -o 50 <directory>

# chunk size of 1000, and chunk overlap of 200
/learn --chunk-size 1000 --chunk-overlap 200 <directory>
```