### PR TITLE
Chat help message on load

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/__init__.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/__init__.py
@@ -3,4 +3,5 @@ from .base import BaseChatHandler
 from .clear import ClearChatHandler
 from .default import DefaultChatHandler
 from .generate import GenerateChatHandler
+from .help import HelpChatHandler
 from .learn import LearnChatHandler

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -31,12 +31,7 @@ class DefaultChatHandler(BaseChatHandler):
     def __init__(self, chat_history: List[ChatMessage], *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.memory = ConversationBufferWindowMemory(return_messages=True, k=2)
-
-        # If there's nothing in the history, add a help message.
-        if (len(chat_history) == 0):
-            self.chat_history = [HelpMessage()]
-        else:
-            self.chat_history = chat_history
+        self.chat_history = chat_history
 
 
     def create_llm_chain(

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -13,7 +13,6 @@ from langchain.prompts import (
 from langchain.schema import AIMessage
 
 from .base import BaseChatHandler
-from .help import HelpMessage
 
 SYSTEM_PROMPT = """
 You are Jupyternaut, a conversational assistant living in JupyterLab to help users.
@@ -32,7 +31,6 @@ class DefaultChatHandler(BaseChatHandler):
         super().__init__(*args, **kwargs)
         self.memory = ConversationBufferWindowMemory(return_messages=True, k=2)
         self.chat_history = chat_history
-
 
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -13,6 +13,7 @@ from langchain.prompts import (
 from langchain.schema import AIMessage
 
 from .base import BaseChatHandler
+from .help import HelpMessage
 
 SYSTEM_PROMPT = """
 You are Jupyternaut, a conversational assistant living in JupyterLab to help users.
@@ -30,7 +31,13 @@ class DefaultChatHandler(BaseChatHandler):
     def __init__(self, chat_history: List[ChatMessage], *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.memory = ConversationBufferWindowMemory(return_messages=True, k=2)
-        self.chat_history = chat_history
+
+        # If there's nothing in the history, add a help message.
+        if (len(chat_history) == 0):
+            self.chat_history = [HelpMessage()]
+        else:
+            self.chat_history = chat_history
+
 
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -19,21 +19,22 @@ For more information about Jupyternaut, see the
 [Jupyter AI documentation](https://jupyter-ai.readthedocs.io).
 """
 
+def HelpMessage():
+    return AgentChatMessage(
+        id=uuid4().hex,
+        time=time.time(),
+        body=HELP_MESSAGE,
+        reply_to="",
+    )
+
 class HelpChatHandler(BaseChatHandler):
-    def __init__(self, chat_history: List[ChatMessage], *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._chat_history = chat_history
 
     async def _process_message(self, _):
-        self._chat_history.clear()
         for handler in self._root_chat_handlers.values():
             if not handler:
                 continue
 
-            handler.broadcast_message(AgentChatMessage(
-                id=uuid4().hex,
-                time=time.time(),
-                body=HELP_MESSAGE,
-                reply_to="",
-            ))
+            handler.broadcast_message(HelpMessage())
             break

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -1,5 +1,4 @@
 import time
-
 from typing import List
 from uuid import uuid4
 
@@ -7,7 +6,7 @@ from jupyter_ai.models import AgentChatMessage, ChatMessage
 
 from .base import BaseChatHandler
 
-HELP_MESSAGE = """Hi there! I'm Jupyternaut, your programming assistant. 
+HELP_MESSAGE = """Hi there! I'm Jupyternaut, your programming assistant.
 You can send me a message using the text box below. You can also send me commands:
 * `/learn` — Teach Jupyternaut about files on your system
 * `/ask` — Ask a question to be answered using learned data
@@ -15,9 +14,10 @@ You can send me a message using the text box below. You can also send me command
 * `/clear` — Clear the chat window
 * `/help` — Display this help message
 
-For more information about Jupyternaut, see the 
+For more information about Jupyternaut, see the
 [Jupyter AI documentation](https://jupyter-ai.readthedocs.io).
 """
+
 
 def HelpMessage():
     return AgentChatMessage(
@@ -26,6 +26,7 @@ def HelpMessage():
         body=HELP_MESSAGE,
         reply_to="",
     )
+
 
 class HelpChatHandler(BaseChatHandler):
     def __init__(self, *args, **kwargs):

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -2,7 +2,7 @@ import time
 from typing import List
 from uuid import uuid4
 
-from jupyter_ai.models import AgentChatMessage, ChatMessage
+from jupyter_ai.models import AgentChatMessage, HumanChatMessage
 
 from .base import BaseChatHandler
 
@@ -32,10 +32,5 @@ class HelpChatHandler(BaseChatHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    async def _process_message(self, _):
-        for handler in self._root_chat_handlers.values():
-            if not handler:
-                continue
-
-            handler.broadcast_message(HelpMessage())
-            break
+    async def _process_message(self, message: HumanChatMessage):
+        self.reply(HELP_MESSAGE, message)

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -9,7 +9,7 @@ from .base import BaseChatHandler
 HELP_MESSAGE = """Hi there! I'm Jupyternaut, your programming assistant.
 You can ask me a question using the text box below. You can also send me commands:
 * `/learn` — Teach Jupyternaut about files on your system
-* `/ask` — Ask a question to be answered using learned data
+* `/ask` — Ask a question about your learned data
 * `/generate` — Generate a Jupyter notebook from a text prompt
 * `/clear` — Clear the chat window
 * `/help` — Display this help message

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -14,6 +14,9 @@ You can send me a message using the text box below. You can also send me command
 * `/generate` — Generate a Jupyter notebook from a text prompt
 * `/clear` — Clear the chat window
 * `/help` — Display this help message
+
+For more information about Jupyternaut, see the 
+[Jupyter AI documentation](https://jupyter-ai.readthedocs.io).
 """
 
 class HelpChatHandler(BaseChatHandler):

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -7,15 +7,15 @@ from jupyter_ai.models import AgentChatMessage, HumanChatMessage
 from .base import BaseChatHandler
 
 HELP_MESSAGE = """Hi there! I'm Jupyternaut, your programming assistant.
-You can ask me a question using the text box below. You can also send me commands:
+You can ask me a question using the text box below. You can also use these commands:
 * `/learn` — Teach Jupyternaut about files on your system
 * `/ask` — Ask a question about your learned data
 * `/generate` — Generate a Jupyter notebook from a text prompt
 * `/clear` — Clear the chat window
 * `/help` — Display this help message
 
-For more information about Jupyternaut, see the
-[Jupyter AI documentation](https://jupyter-ai.readthedocs.io).
+Jupyter AI includes magic commands that you can use in your notebook.
+For more information, see the [documentation](https://jupyter-ai.readthedocs.io).
 """
 
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -14,7 +14,7 @@ You can ask me a question using the text box below. You can also use these comma
 * `/clear` — Clear the chat window
 * `/help` — Display this help message
 
-Jupyter AI includes magic commands that you can use in your notebooks.
+Jupyter AI includes [magic commands](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#the-ai-and-ai-magic-commands) that you can use in your notebooks.
 For more information, see the [documentation](https://jupyter-ai.readthedocs.io).
 """
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -7,7 +7,7 @@ from jupyter_ai.models import AgentChatMessage, ChatMessage
 from .base import BaseChatHandler
 
 HELP_MESSAGE = """Hi there! I'm Jupyternaut, your programming assistant.
-You can send me a message using the text box below. You can also send me commands:
+You can ask me a question using the text box below. You can also send me commands:
 * `/learn` — Teach Jupyternaut about files on your system
 * `/ask` — Ask a question to be answered using learned data
 * `/generate` — Generate a Jupyter notebook from a text prompt

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -1,0 +1,36 @@
+import time
+
+from typing import List
+from uuid import uuid4
+
+from jupyter_ai.models import AgentChatMessage, ChatMessage
+
+from .base import BaseChatHandler
+
+HELP_MESSAGE = """Hi there! I'm Jupyternaut, your programming assistant. 
+You can send me a message using the text box below. You can also send me commands:
+* `/learn` — Teach Jupyternaut about files on your system
+* `/ask` — Ask a question to be answered using learned data
+* `/generate` — Generate a Jupyter notebook from a text prompt
+* `/clear` — Clear the chat window
+* `/help` — Display this help message
+"""
+
+class HelpChatHandler(BaseChatHandler):
+    def __init__(self, chat_history: List[ChatMessage], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._chat_history = chat_history
+
+    async def _process_message(self, _):
+        self._chat_history.clear()
+        for handler in self._root_chat_handlers.values():
+            if not handler:
+                continue
+
+            handler.broadcast_message(AgentChatMessage(
+                id=uuid4().hex,
+                time=time.time(),
+                body=HELP_MESSAGE,
+                reply_to="",
+            ))
+            break

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -14,7 +14,7 @@ You can ask me a question using the text box below. You can also use these comma
 * `/clear` — Clear the chat window
 * `/help` — Display this help message
 
-Jupyter AI includes magic commands that you can use in your notebook.
+Jupyter AI includes magic commands that you can use in your notebooks.
 For more information, see the [documentation](https://jupyter-ai.readthedocs.io).
 """
 

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -91,9 +91,7 @@ class AiExtension(ExtensionApp):
             root_dir=self.serverapp.root_dir,
             dask_client_future=dask_client_future,
         )
-        help_chat_handler = HelpChatHandler(
-            **chat_handler_kwargs, chat_history=self.settings["chat_history"]
-        )
+        help_chat_handler = HelpChatHandler(**chat_handler_kwargs)
         ask_chat_handler = AskChatHandler(
             **chat_handler_kwargs, retriever=learn_chat_handler
         )

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -12,6 +12,7 @@ from .chat_handlers import (
     HelpChatHandler,
     LearnChatHandler,
 )
+from .chat_handlers.help import HelpMessage
 from .config_manager import ConfigManager
 from .handlers import (
     ChatHistoryHandler,
@@ -55,7 +56,7 @@ class AiExtension(ExtensionApp):
         # list of chat messages to broadcast to new clients
         # this is only used to render the UI, and is not the conversational
         # memory object used by the LM chain.
-        self.settings["chat_history"] = []
+        self.settings["chat_history"] = [HelpMessage()]
 
         # get reference to event loop
         # `asyncio.get_event_loop()` is deprecated in Python 3.11+, in favor of

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -9,6 +9,7 @@ from .chat_handlers import (
     ClearChatHandler,
     DefaultChatHandler,
     GenerateChatHandler,
+    HelpChatHandler,
     LearnChatHandler,
 )
 from .config_manager import ConfigManager
@@ -90,6 +91,9 @@ class AiExtension(ExtensionApp):
             root_dir=self.serverapp.root_dir,
             dask_client_future=dask_client_future,
         )
+        help_chat_handler = HelpChatHandler(
+            **chat_handler_kwargs, chat_history=self.settings["chat_history"]
+        )
         ask_chat_handler = AskChatHandler(
             **chat_handler_kwargs, retriever=learn_chat_handler
         )
@@ -99,6 +103,7 @@ class AiExtension(ExtensionApp):
             "/clear": clear_chat_handler,
             "/generate": generate_chat_handler,
             "/learn": learn_chat_handler,
+            "/help": help_chat_handler,
         }
 
         latency_ms = round((time.time() - start) * 1000)

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -60,7 +60,7 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
           variant="outlined"
           multiline
           onKeyDown={handleKeyDown}
-          placeholder="Ask Jupyternaut anything"
+          placeholder="Ask Jupyternaut"
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -127,8 +127,8 @@ function ChatBody({
         <Stack spacing={4}>
           <p className="jp-ai-ChatSettings-welcome">
             Welcome to Jupyter AI! To get started, please select a language
-            model to chat with from the settings panel. You will also likely
-            need to provide API credentials, so be sure to have those handy.
+            model to chat with from the settings panel. You may also need to
+            provide API credentials, so have those handy.
           </p>
           <Button
             variant="contained"

--- a/packages/jupyter-ai/style/react-markdown.css
+++ b/packages/jupyter-ai/style/react-markdown.css
@@ -6,6 +6,10 @@
   padding: 0;
 }
 
+.jp-RenderedHTMLCommon.jp-ai-react-markdown ul:not(.list-inline) {
+  padding-left: 1em;
+}
+
 /* !important specifier required to override inline styles from Prism */
 .jp-ai-code {
   font-family: var(--jp-code-font-family) !important;


### PR DESCRIPTION
On initial load, or after running `/help`, Jupyternaut now sends a helpful message to the user.

Fixes #93. This change also applies minor copy edits to the initial config message. It shortens the chat box placeholder from "Ask JupyterLab anything" to "Ask JupyterLab", so that it no longer appears on two lines at the default width of the left panel.

<img width="286" alt="initial-help-message" src="https://github.com/jupyterlab/jupyter-ai/assets/93281816/9601a409-5f1a-4e07-83c1-5e867f646c57">
