### PR TITLE
Updates docs to refer to JupyterLab versions

### DIFF
--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -6,7 +6,7 @@ This page is intended for people interested in building new or modified function
 
 You can develop Jupyter AI on any system that can run a supported Python version up to and including 3.11, including recent Windows, macOS, and Linux versions.
 
-Each Jupyter AI major version works with only one major version of JupyterLab. Jupyter AI 1.x supports JupyterLab 3.x, and Jupyter AI 2.x supports JupyterLab 4.x. The `main` branch supports the newest released major version of JupyterLab, which, as of July 2023, is 4.
+Each Jupyter AI major version works with only one major version of JupyterLab. Jupyter AI 1.x supports JupyterLab 3.x, and Jupyter AI 2.x supports JupyterLab 4.x.
 
 We highly recommend that you install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) to start developing on Jupyter AI, especially if you are developing on macOS on an Apple Silicon-based Mac (M1, M1 Pro, M2, etc.).
 

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -6,6 +6,8 @@ This page is intended for people interested in building new or modified function
 
 You can develop Jupyter AI on any system that can run a supported Python version up to and including 3.11, including recent Windows, macOS, and Linux versions.
 
+Each Jupyter AI major version works with only one major version of JupyterLab. Jupyter AI 1.x supports JupyterLab 3.x, and Jupyter AI 2.x supports JupyterLab 4.x. The `main` branch supports the newest released major version of JupyterLab, which, as of July 2023, is 4.
+
 We highly recommend that you install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) to start developing on Jupyter AI, especially if you are developing on macOS on an Apple Silicon-based Mac (M1, M1 Pro, M2, etc.).
 
 You will need Node.js 18 to use Jupyter AI. Node.js 18.16.0 is known to work.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -10,6 +10,18 @@ in JupyterLab and the Jupyter Notebook. More specifically, Jupyter AI offers:
 * Support for a wide range of generative model providers and models
   (AI21, Anthropic, Cohere, Hugging Face, OpenAI, SageMaker, etc.).
 
+## JupyterLab support
+
+**Each major version of Jupyter AI supports *only one* major version of JupyterLab.** Jupyter AI 1.x supports
+JupyterLab 3.x, and Jupyter AI 2.x supports JupyterLab 4.x. The feature sets of versions 1.0.0 and 2.0.0
+are the same. We will maintain support for JupyterLab 3 for as long as it remains maintained; that is,
+until JupyterLab 5.0.0 is available.
+
+The `main` branch of Jupyter AI will target JupyterLab 4. All new features and most bug fixes will be
+fixed in this branch, and will be available in JupyterLab 4. Features and bug fixes will be backported
+to work on JupyterLab 3 only if developers determine that they will add sufficient value.
+**We recommend that JupyterLab users who want the most advanced Jupyter AI functionality upgrade to JupyterLab 4.**
+
 ## Contents
 
 ```{toctree}

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -14,11 +14,9 @@ in JupyterLab and the Jupyter Notebook. More specifically, Jupyter AI offers:
 
 **Each major version of Jupyter AI supports *only one* major version of JupyterLab.** Jupyter AI 1.x supports
 JupyterLab 3.x, and Jupyter AI 2.x supports JupyterLab 4.x. The feature sets of versions 1.0.0 and 2.0.0
-are the same. We will maintain support for JupyterLab 3 for as long as it remains maintained; that is,
-until JupyterLab 5.0.0 is available.
+are the same. We will maintain support for JupyterLab 3 for as long as it remains maintained.
 
-The `main` branch of Jupyter AI targets the newest supported major version of JupyterLab, which, as of
-July 2023, is version 4. All new features and most bug fixes will be
+The `main` branch of Jupyter AI targets the newest supported major version of JupyterLab. All new features and most bug fixes will be
 committed to this branch. Features and bug fixes will be backported
 to work on JupyterLab 3 only if developers determine that they will add sufficient value.
 **We recommend that JupyterLab users who want the most advanced Jupyter AI functionality upgrade to JupyterLab 4.**

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -17,8 +17,9 @@ JupyterLab 3.x, and Jupyter AI 2.x supports JupyterLab 4.x. The feature sets of 
 are the same. We will maintain support for JupyterLab 3 for as long as it remains maintained; that is,
 until JupyterLab 5.0.0 is available.
 
-The `main` branch of Jupyter AI will target JupyterLab 4. All new features and most bug fixes will be
-fixed in this branch, and will be available in JupyterLab 4. Features and bug fixes will be backported
+The `main` branch of Jupyter AI targets the newest supported major version of JupyterLab, which, as of
+July 2023, is version 4. All new features and most bug fixes will be
+committed to this branch. Features and bug fixes will be backported
 to work on JupyterLab 3 only if developers determine that they will add sufficient value.
 **We recommend that JupyterLab users who want the most advanced Jupyter AI functionality upgrade to JupyterLab 4.**
 


### PR DESCRIPTION
Fixes #299 by updating documentation to refer to major JupyterLab versions associated with Jupyter AI versions.

This change should be backported to the 1.x branch.