### PR TITLE
Handles /clear command with selection

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -195,7 +195,8 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
     async def _route(self, message):
         """Method that routes an incoming message to the appropriate handler."""
         default = self.chat_handlers["default"]
-        maybe_command = message.body.split(" ", 1)[0]
+        # Split on any whitespace, either spaces or newlines
+        maybe_command = message.body.split(None, 1)[0]
         is_command = (
             message.body.startswith("/")
             and maybe_command in self.chat_handlers.keys()


### PR DESCRIPTION
Fixes #295. Handles `/clear` (and other commands) followed by a newline, not just a space, by splitting the input on any whitespace. This makes it so that `/clear` followed by two newlines and a code block (as is sent when "Include selection" is checked) is properly interpreted as a command, not as a message to the language model.

This should be backported to 1.x.