### PR TITLE
Prompt template override in BaseProvider

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -522,6 +522,20 @@ A function that computes the lowest common multiples of two integers, and
 a function that runs 5 test cases of the lowest common multiple function
 ```
 
+### Prompt templates
+
+Each provider can define **prompt templates** for each supported format. A prompt
+template guides the language model to produce output in a particular
+format. The default prompt templates are a
+[Python dictionary mapping formats to templates](https://github.com/jupyterlab/jupyter-ai/blob/57a758fa5cdd5a87da5519987895aa688b3766a8/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py#L138-L166).
+Developers who write subclasses of `BaseProvider` can override templates per
+output format, per model, and based on the prompt being submitted, by
+implementing their own
+[`get_prompt_template` function](https://github.com/jupyterlab/jupyter-ai/blob/57a758fa5cdd5a87da5519987895aa688b3766a8/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py#L186-L195).
+Each prompt template includes the string `{prompt}`, which is replaced with
+the user-provided prompt when the user runs a magic command.
+
+
 ### Clearing the OpenAI chat history
 
 With the `openai-chat` provider *only*, you can run a cell magic command using the `-r` or

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -469,15 +469,6 @@ class AiMagics(Magics):
             self.transcript_openai = []
             return
 
-        # Apply a prompt template.
-        prompt = Provider.prompt_template(args.format, local_model_id).format(
-            prompt=prompt
-        )
-
-        # interpolate user namespace into prompt
-        ip = get_ipython()
-        prompt = prompt.format_map(FormatDict(ip.user_ns))
-
         # Determine provider and local model IDs
         # If this is a custom chain, send the message to the custom chain.
         if args.model_id in self.custom_model_registry and isinstance(
@@ -529,6 +520,13 @@ class AiMagics(Magics):
                 ) from None
 
         provider = Provider(**provider_params)
+
+        # Apply a prompt template.
+        prompt = provider.prompt_template(args.format).format(prompt=prompt)
+
+        # interpolate user namespace into prompt
+        ip = get_ipython()
+        prompt = prompt.format_map(FormatDict(ip.user_ns))
 
         # generate output from model via provider
         result = provider.generate([prompt])

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -470,7 +470,9 @@ class AiMagics(Magics):
             return
 
         # Apply a prompt template.
-        prompt = Provider.prompt_template(args.format, local_model_id).format(prompt=prompt)
+        prompt = Provider.prompt_template(args.format, local_model_id).format(
+            prompt=prompt
+        )
 
         # interpolate user namespace into prompt
         ip = get_ipython()

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -522,7 +522,7 @@ class AiMagics(Magics):
         provider = Provider(**provider_params)
 
         # Apply a prompt template.
-        prompt = provider.prompt_template(args.format).format(prompt=prompt)
+        prompt = provider.get_prompt_template(args.format).format(prompt=prompt)
 
         # interpolate user namespace into prompt
         ip = get_ipython()

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -12,6 +12,7 @@ from IPython import get_ipython
 from IPython.core.magic import Magics, line_cell_magic, magics_class
 from IPython.display import HTML, JSON, Markdown, Math
 from jupyter_ai_magics.utils import decompose_model_id, get_lm_providers
+from langchain import PromptTemplate
 from langchain.chains import LLMChain
 
 from .parsers import (
@@ -80,7 +81,9 @@ DISPLAYS_BY_FORMAT = {
 
 NA_MESSAGE = '<abbr title="Not applicable">N/A</abbr>'
 
-MARKDOWN_PROMPT_TEMPLATE = "{prompt}\n\nProduce output in markdown format only."
+MARKDOWN_PROMPT_TEMPLATE = PromptTemplate.from_template(
+    "{prompt}\n\nProduce output in markdown format only."
+)
 
 PROVIDER_NO_MODELS = "This provider does not define a list of models."
 
@@ -92,16 +95,26 @@ CANNOT_DETERMINE_MODEL_MARKDOWN = """Cannot determine model provider from model 
 
 To see a list of models you can use, run `%ai list`"""
 
-
+# These are defaults, which can be overridden by model providers
 PROMPT_TEMPLATES_BY_FORMAT = {
-    "code": "{prompt}\n\nProduce output as source code only, with no text or explanation before or after it.",
-    "html": "{prompt}\n\nProduce output in HTML format only, with no markup before or afterward.",
-    "image": "{prompt}\n\nProduce output as an image only, with no text before or after it.",
+    "code": PromptTemplate.from_template(
+        "{prompt}\n\nProduce output as source code only, with no text or explanation before or after it."
+    ),
+    "html": PromptTemplate.from_template(
+        "{prompt}\n\nProduce output in HTML format only, with no markup before or afterward."
+    ),
+    "image": PromptTemplate.from_template(
+        "{prompt}\n\nProduce output as an image only, with no text before or after it."
+    ),
     "markdown": MARKDOWN_PROMPT_TEMPLATE,
     "md": MARKDOWN_PROMPT_TEMPLATE,
-    "math": "{prompt}\n\nProduce output in LaTeX format only, with $$ at the beginning and end.",
-    "json": "{prompt}\n\nProduce output in JSON format only, with nothing before or after it.",
-    "text": "{prompt}",  # No customization
+    "math": PromptTemplate.from_template(
+        "{prompt}\n\nProduce output in LaTeX format only, with $$ at the beginning and end."
+    ),
+    "json": PromptTemplate.from_template(
+        "{prompt}\n\nProduce output in JSON format only, with nothing before or after it."
+    ),
+    "text": PromptTemplate.from_template("{prompt}"),  # No customization
 }
 
 AI_COMMANDS = {"delete", "error", "help", "list", "register", "update"}

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -176,6 +176,12 @@ class BaseProvider(BaseModel):
         _call_with_args = functools.partial(self._call, *args, **kwargs)
         return await loop.run_in_executor(executor, _call_with_args)
 
+    def update_prompt_template(format: str, template: str):
+        """
+        Changes the class-level prompt template for a given format.
+        """
+        prompt_templates[format] = PromptTemplate.from_template(template)
+
     def prompt_template(self, format) -> PromptTemplate:
         """
         Produce a prompt template suitable for use with a particular model, to

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -118,7 +118,7 @@ class BaseProvider(BaseModel):
     # instance attrs
     #
     model_id: str
-    _prompt_templates: Dict[str, PromptTemplate]
+    prompt_templates: Dict[str, PromptTemplate]
     """Prompt templates for each output type. Can be overridden with
     `update_prompt_template`. The function `prompt_template`, in the base class,
     refers to this."""
@@ -135,9 +135,7 @@ class BaseProvider(BaseModel):
         if self.__class__.model_id_key != "model_id":
             model_kwargs[self.__class__.model_id_key] = kwargs["model_id"]
 
-        super().__init__(*args, **kwargs, **model_kwargs)
-
-        self._prompt_templates = {
+        model_kwargs["prompt_templates"] = {
             "code": PromptTemplate.from_template(
                 "{prompt}\n\nProduce output as source code only, "
                 "with no text or explanation before or after it."
@@ -167,6 +165,9 @@ class BaseProvider(BaseModel):
             "text": PromptTemplate.from_template("{prompt}"),  # No customization
         }
 
+        super().__init__(*args, **kwargs, **model_kwargs)
+
+
     async def _call_in_executor(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
         """
         Calls self._call() asynchronously in a separate thread for providers
@@ -181,7 +182,7 @@ class BaseProvider(BaseModel):
         """
         Changes the class-level prompt template for a given format.
         """
-        self._prompt_templates[format] = PromptTemplate.from_template(template)
+        self.prompt_templates[format] = PromptTemplate.from_template(template)
 
     def get_prompt_template(self, format) -> PromptTemplate:
         """
@@ -189,10 +190,10 @@ class BaseProvider(BaseModel):
         produce output in a desired format.
         """
 
-        if format in self._prompt_templates:
-            return self._prompt_templates[format]
+        if format in self.prompt_templates:
+            return self.prompt_templates[format]
         else:
-            return self._prompt_templates["text"]  # Default to plain format
+            return self.prompt_templates["text"]  # Default to plain format
 
 
 class AI21Provider(BaseProvider, AI21):

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -153,7 +153,7 @@ class BaseProvider(BaseModel):
             "{prompt}\n\nProduce output in markdown format only."
         )
 
-        basicTemplate = PromptTemplate.from_template("{prompt}") # No customization
+        basicTemplate = PromptTemplate.from_template("{prompt}")  # No customization
 
         # These are defaults, which can be overridden by model providers,
         # including at the model level
@@ -183,7 +183,7 @@ class BaseProvider(BaseModel):
             "text": basicTemplate,
         }
 
-        if (format in promptTemplates):
+        if format in promptTemplates:
             return promptTemplates[format]
         else:
             return basicTemplate

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -167,7 +167,6 @@ class BaseProvider(BaseModel):
 
         super().__init__(*args, **kwargs, **model_kwargs)
 
-
     async def _call_in_executor(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
         """
         Calls self._call() asynchronously in a separate thread for providers

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -191,7 +191,7 @@ class BaseProvider(BaseModel):
         if format in self.prompt_templates:
             return self.prompt_templates[format]
         else:
-            return self.prompt_templates['text']  # Default to plain format
+            return self.prompt_templates["text"]  # Default to plain format
 
 
 class AI21Provider(BaseProvider, AI21):

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -183,7 +183,7 @@ class BaseProvider(BaseModel):
         """
         self.prompt_templates[format] = PromptTemplate.from_template(template)
 
-    def prompt_template(self, format) -> PromptTemplate:
+    def get_prompt_template(self, format) -> PromptTemplate:
         """
         Produce a prompt template suitable for use with a particular model, to
         produce output in a desired format.

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -114,6 +114,39 @@ class BaseProvider(BaseModel):
     """User inputs expected by this provider when initializing it. Each `Field` `f`
     should be passed in the constructor as a keyword argument, keyed by `f.key`."""
 
+    prompt_templates: ClassVar[Dict[str, PromptTemplate]] = {
+        "code": PromptTemplate.from_template(
+            "{prompt}\n\nProduce output as source code only, "
+            "with no text or explanation before or after it."
+        ),
+        "html": PromptTemplate.from_template(
+            "{prompt}\n\nProduce output in HTML format only, "
+            "with no markup before or afterward."
+        ),
+        "image": PromptTemplate.from_template(
+            "{prompt}\n\nProduce output as an image only, "
+            "with no text before or after it."
+        ),
+        "markdown": PromptTemplate.from_template(
+            "{prompt}\n\nProduce output in markdown format only."
+        ),
+        "md": PromptTemplate.from_template(
+            "{prompt}\n\nProduce output in markdown format only."
+        ),
+        "math": PromptTemplate.from_template(
+            "{prompt}\n\nProduce output in LaTeX format only, "
+            "with $$ at the beginning and end."
+        ),
+        "json": PromptTemplate.from_template(
+            "{prompt}\n\nProduce output in JSON format only, "
+            "with nothing before or after it."
+        ),
+        "text": PromptTemplate.from_template("{prompt}"),  # No customization
+    }
+    """Default prompt templates for each output type. Can be overridden with
+    `update_prompt_template`. The function `prompt_template`, by default,
+    refers to this."""
+
     #
     # instance attrs
     #
@@ -143,50 +176,16 @@ class BaseProvider(BaseModel):
         _call_with_args = functools.partial(self._call, *args, **kwargs)
         return await loop.run_in_executor(executor, _call_with_args)
 
-    def prompt_template(format, model_id) -> PromptTemplate:
+    def prompt_template(self, format) -> PromptTemplate:
         """
         Produce a prompt template suitable for use with a particular model, to
         produce output in a desired format.
         """
 
-        markdownTemplate = PromptTemplate.from_template(
-            "{prompt}\n\nProduce output in markdown format only."
-        )
-
-        basicTemplate = PromptTemplate.from_template("{prompt}")  # No customization
-
-        # These are defaults, which can be overridden by model providers,
-        # including at the model level
-        promptTemplates = {
-            "code": PromptTemplate.from_template(
-                "{prompt}\n\nProduce output as source code only, "
-                "with no text or explanation before or after it."
-            ),
-            "html": PromptTemplate.from_template(
-                "{prompt}\n\nProduce output in HTML format only, "
-                "with no markup before or afterward."
-            ),
-            "image": PromptTemplate.from_template(
-                "{prompt}\n\nProduce output as an image only, "
-                "with no text before or after it."
-            ),
-            "markdown": markdownTemplate,
-            "md": markdownTemplate,
-            "math": PromptTemplate.from_template(
-                "{prompt}\n\nProduce output in LaTeX format only, "
-                "with $$ at the beginning and end."
-            ),
-            "json": PromptTemplate.from_template(
-                "{prompt}\n\nProduce output in JSON format only, "
-                "with nothing before or after it."
-            ),
-            "text": basicTemplate,
-        }
-
-        if format in promptTemplates:
-            return promptTemplates[format]
+        if format in self.prompt_templates:
+            return self.prompt_templates[format]
         else:
-            return basicTemplate
+            return self.prompt_templates['text']  # Default to plain format
 
 
 class AI21Provider(BaseProvider, AI21):


### PR DESCRIPTION
Fix for #226: allows instances of `BaseProvider` to declare a custom `prompt_template` function that sets a prompt template. These templates may vary by format and local model ID.