### PR TITLE
add claude 2 to anthropic models

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -172,6 +172,7 @@ class AnthropicProvider(BaseProvider, Anthropic):
         "claude-v1",
         "claude-v1.0",
         "claude-v1.2",
+        "claude-2",
         "claude-instant-v1",
         "claude-instant-v1.0",
     ]
@@ -435,6 +436,7 @@ class BedrockProvider(BaseProvider, Bedrock):
         "amazon.titan-tg1-large",
         "anthropic.claude-v1",
         "anthropic.claude-instant-v1",
+        "anthropic.claude-v2",
         "ai21.j2-jumbo-instruct",
         "ai21.j2-grande-instruct",
     ]


### PR DESCRIPTION
Claude-2 is available through the API and AWS Bedrock with the provided names

`%%ai anthropic:claude-2` works already now.