### PR TITLE
replace c.ServerApp.root_dir by environment variable

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -1,5 +1,5 @@
 import time
-from os import environ, access, W_OK, getcwd
+import os
 
 from dask.distributed import Client as DaskClient
 from jupyter_ai_magics.utils import get_em_providers, get_lm_providers

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -73,11 +73,11 @@ class AiExtension(ExtensionApp):
         dask_client_future = loop.create_task(self._get_dask_client())
 
         # get root directory for read and writing
-        root_wdir = os.environ.get('JUPYTERAI_ROOTDIR')
-        if not root_wdir:
-            root_wdir = self.serverapp.root_dir
-            if not os.access(root_wdir, os.W_OK):
-                root_wdir = os.getcwd()
+        save_dir = os.environ.get('JUPYTERAI_SAVEDIR')
+        if not save_dir:
+            save_dir = self.serverapp.root_dir
+            if not os.access(save_dir, os.W_OK):
+                save_dir = os.getcwd()
 
         # initialize chat handlers
         chat_handler_kwargs = {
@@ -93,11 +93,11 @@ class AiExtension(ExtensionApp):
         )
         generate_chat_handler = GenerateChatHandler(
             **chat_handler_kwargs,
-            root_dir=root_wdir,
+            root_dir=save_dir,
         )
         learn_chat_handler = LearnChatHandler(
             **chat_handler_kwargs,
-            root_dir=root_wdir,
+            root_dir=save_dir,
             dask_client_future=dask_client_future,
         )
         help_chat_handler = HelpChatHandler(**chat_handler_kwargs)

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -1,5 +1,5 @@
-import time
 import os
+import time
 
 from dask.distributed import Client as DaskClient
 from jupyter_ai_magics.utils import get_em_providers, get_lm_providers
@@ -73,7 +73,7 @@ class AiExtension(ExtensionApp):
         dask_client_future = loop.create_task(self._get_dask_client())
 
         # get root directory for read and writing
-        save_dir = os.environ.get('JUPYTERAI_SAVEDIR')
+        save_dir = os.environ.get("JUPYTERAI_SAVEDIR")
         if not save_dir:
             save_dir = self.serverapp.root_dir
             if not os.access(save_dir, os.W_OK):


### PR DESCRIPTION
jupyter-ai generates files in the directory set by c.ServerApp.root_dir which might not be writable.
This MR adds the ability to overwrite this location with an environment variable called JUPYTERAI_SAVEDIR

If JUPYTERAI_SAVEDIR it will fall back to c.ServerApp.root_dir but checks if that directory is writeable.
If this is not the case it will take the current working directory without any further checks.

Possible fix for issue https://github.com/jupyterlab/jupyter-ai/issues/326