### PR TITLE
relax pinning on importlib_metadata, typing_extensions

### DIFF
--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -23,16 +23,16 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 dependencies = [
     "ipython",
     "pydantic",
-    "importlib_metadata~=5.2.0",
+    "importlib_metadata>=5.2.0",
     "langchain==0.0.223",
-    "typing_extensions==4.5.0",
+    "typing_extensions>=4.5.0",
     "click~=8.0",
-    "jsonpath-ng~=1.5.3",
+    "jsonpath-ng>=1.5.3,<2",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pre-commit~=3.3.3"
+    "pre-commit>=3.3.3,<4"
 ]
 
 test = [

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -26,14 +26,14 @@ dependencies = [
     "jupyterlab~=4.0",
     "pydantic",
     "openai~=0.26",
-    "aiosqlite~=0.18",
-    "importlib_metadata~=5.2.0",
+    "aiosqlite>=0.18",
+    "importlib_metadata>=5.2.0",
     "langchain==0.0.223",
     "tiktoken", # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "dask[distributed]",
     "faiss-cpu", # Not distributed by official repo
-    "typing_extensions==4.5.0"
+    "typing_extensions>=4.5.0",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]


### PR DESCRIPTION
`==` pinning is ~always to be avoided in exported package dependencies, and tight pinning on backports like importlib_metadata is extremely unlikely to be desirable, since these prohibit users from installing later, _compatible_ versions of these dependencies for their own use alongside jupyter-ai.

I've replaced some very stable dependencies with strict pinnings (which cause many installation conflicts without any actual compatibility issues) to lower bounds, and replaced some strict `~=x.y.z` with semantic `>=x.y.z,<x+1`, where `~=x.y.z` produces `>=x.y.z,<x.y+1`. 

I didn't update strict pinnings on dependencies like `langchain`, which I strongly suspect should also be relaxed, but I can't speak to that one.

In general, I'd encourage upper bounds to be on the major version _at most_, if upper bounds should be used at all (usually the answer is no unless compatibility breakage is likely, e.g. jupyterlab).