### PR TITLE
jupyter_ai and jupyter_ai_magics version match

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -42,6 +42,8 @@ conda install jupyterlab~=4.0
 The `jupyter_ai_magics` package, which provides exclusively the IPython magics,
 does not depend on JupyterLab or `jupyter_ai`. You can install
 `jupyter_ai_magics` without installing `jupyterlab` or `jupyter_ai`.
+If you have both `jupyter_ai_magics` and `jupyter_ai` installed, you should
+have the same version of each, to avoid errors.
 
 ## Installation
 


### PR DESCRIPTION
Fixes #329 by updating the documentation to note that the same version of `jupyter_ai` and `jupyter_ai_magics` should be installed, per @michaelchia's suggestion.