### PR TITLE
Remove front end unit tests from code and README.md

### DIFF
--- a/packages/jupyter-ai/README.md
+++ b/packages/jupyter-ai/README.md
@@ -122,17 +122,6 @@ To execute them, run:
 pytest -vv -r ap --cov jupyter_ai
 ```
 
-#### Frontend tests
-
-This extension is using [Jest](https://jestjs.io/) for JavaScript code testing.
-
-To execute them, execute:
-
-```sh
-jlpm
-jlpm test
-```
-
 #### Integration tests
 
 This extension uses [Playwright](https://playwright.dev/docs/intro/) for the integration tests (aka user level tests).

--- a/packages/jupyter-ai/src/__tests__/jupyter_gai.spec.ts
+++ b/packages/jupyter-ai/src/__tests__/jupyter_gai.spec.ts
@@ -1,9 +1,0 @@
-/**
- * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
- */
-
-describe('jupyter_ai', () => {
-  it('should be tested', () => {
-    expect(1 + 1).toEqual(2);
-  });
-});


### PR DESCRIPTION
As mentioned in https://github.com/jupyterlab/jupyter-ai/issues/211, [packages/jupyter-ai/README.md](https://github.com/jupyterlab/jupyter-ai/blob/dd123857cd8875b2b9b31c4179c98c1d7565c4dd/packages/jupyter-ai/README.md) says "Frontend tests. This extension is using Jest for JavaScript code testing." but there are no meaningful Jest tests. We also don't plan to implement JS unit tests, plan to cover our needs with snapshot-based E2E testing. 

This PR removes front end unit tests from code and README.md. This will remove confusion and create correct expectations. If need would arise, adding js unit tests back would be trivial. 