### PR TITLE
Allow to define block and allow lists for providers

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -752,7 +752,7 @@ The `--response-path` option is a [JSONPath](https://goessner.net/articles/JsonP
 
 ## Configuration
 
-### Block-listing providers
+### Blocklisting providers
 This configuration allows for blocking specific providers in the settings panel. This list takes precedence over the allowlist in the next section.
 
 ```
@@ -765,14 +765,14 @@ To block more than one provider in the block-list, repeat the runtime configurat
 jupyter lab --Ai.blocked_providers=openai --Ai.blocked_providers=ai21
 ```
 
-### Allow-listing providers
-This configuration allows for filtering the list of providers in the settings panel to only an allow-listed set of providers.
+### Allowlisting providers
+This configuration allows for filtering the list of providers in the settings panel to only an allowlisted set of providers.
 
 ```
 jupyter lab --Ai.allowed_providers=openai
 ```
 
-To allow more than one provider in the allow-list, repeat the runtime configuration.
+To allow more than one provider in the allowlist, repeat the runtime configuration.
 
 ```
 jupyter lab --Ai.allowed_providers=openai --Ai.allowed_providers=ai21

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -752,30 +752,30 @@ The `--response-path` option is a [JSONPath](https://goessner.net/articles/JsonP
 
 ## Configuration
 
-You can specify an allowlist, to only allow a certain list of providers, or a blocklist, to block some providers.
+You can specify an allowlist, to only allow only a certain list of providers, or a blocklist, to block some providers.
 
 ### Blocklisting providers
 This configuration allows for blocking specific providers in the settings panel. This list takes precedence over the allowlist in the next section.
 
 ```
-jupyter lab --Ai.blocked_providers=openai
+jupyter lab --AiExtension.blocked_providers=openai
 ```
 
 To block more than one provider in the block-list, repeat the runtime configuration.
 
 ```
-jupyter lab --Ai.blocked_providers=openai --Ai.blocked_providers=ai21
+jupyter lab --AiExtension.blocked_providers=openai --AiExtension.blocked_providers=ai21
 ```
 
 ### Allowlisting providers
 This configuration allows for filtering the list of providers in the settings panel to only an allowlisted set of providers.
 
 ```
-jupyter lab --Ai.allowed_providers=openai
+jupyter lab --AiExtension.allowed_providers=openai
 ```
 
 To allow more than one provider in the allowlist, repeat the runtime configuration.
 
 ```
-jupyter lab --Ai.allowed_providers=openai --Ai.allowed_providers=ai21
+jupyter lab --AiExtension.allowed_providers=openai --AiExtension.allowed_providers=ai21
 ```

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -752,6 +752,8 @@ The `--response-path` option is a [JSONPath](https://goessner.net/articles/JsonP
 
 ## Configuration
 
+You can specify an allowlist, to only allow a certain list of providers, or a blocklist, to block some providers.
+
 ### Blocklisting providers
 This configuration allows for blocking specific providers in the settings panel. This list takes precedence over the allowlist in the next section.
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -748,3 +748,32 @@ The `--region-name` parameter is set to the [AWS region code](https://docs.aws.a
 The `--request-schema` parameter is the JSON object the endpoint expects as input, with the prompt being substituted into any value that matches the string literal `"<prompt>"`. For example, the request schema `{"text_inputs":"<prompt>"}` will submit a JSON object with the prompt stored under the `text_inputs` key.
 
 The `--response-path` option is a [JSONPath](https://goessner.net/articles/JsonPath/index.html) string that retrieves the language model's output from the endpoint's JSON response. For example, if your endpoint returns an object with the schema `{"generated_texts":["<output>"]}`, its response path is `generated_texts.[0]`.
+
+
+## Configuration
+
+### Block-listing providers
+This configuration allows for blocking specific providers in the settings panel. This list takes precedence over the allowlist in the next section.
+
+```
+jupyter lab --Ai.blocked_providers=openai
+```
+
+To block more than one provider in the block-list, repeat the runtime configuration.
+
+```
+jupyter lab --Ai.blocked_providers=openai --Ai.blocked_providers=ai21
+```
+
+### Allow-listing providers
+This configuration allows for filtering the list of providers in the settings panel to only an allow-listed set of providers.
+
+```
+jupyter lab --Ai.allowed_providers=openai
+```
+
+To allow more than one provider in the allow-list, repeat the runtime configuration.
+
+```
+jupyter lab --Ai.allowed_providers=openai --Ai.allowed_providers=ai21
+```

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_utils.py
@@ -1,0 +1,34 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import pytest
+from jupyter_ai_magics.utils import get_lm_providers
+
+KNOWN_LM_A = "openai"
+KNOWN_LM_B = "huggingface_hub"
+
+
+@pytest.mark.parametrize(
+    "restrictions",
+    [
+        {"allowed_providers": None, "blocked_providers": None},
+        {"allowed_providers": [], "blocked_providers": []},
+        {"allowed_providers": [], "blocked_providers": [KNOWN_LM_B]},
+        {"allowed_providers": [KNOWN_LM_A], "blocked_providers": []},
+    ],
+)
+def test_get_lm_providers_not_restricted(restrictions):
+    a_not_restricted = get_lm_providers(None, restrictions)
+    assert KNOWN_LM_A in a_not_restricted
+
+
+@pytest.mark.parametrize(
+    "restrictions",
+    [
+        {"allowed_providers": [], "blocked_providers": [KNOWN_LM_A]},
+        {"allowed_providers": [KNOWN_LM_B], "blocked_providers": []},
+    ],
+)
+def test_get_lm_providers_restricted(restrictions):
+    a_not_restricted = get_lm_providers(None, restrictions)
+    assert KNOWN_LM_A not in a_not_restricted

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -73,6 +73,7 @@ class AiExtension(ExtensionApp):
             log=self.log,
             lm_providers=self.settings["lm_providers"],
             em_providers=self.settings["em_providers"],
+            restrictions=restrictions,
         )
 
         self.log.info("Registered providers.")

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -4,6 +4,7 @@ from dask.distributed import Client as DaskClient
 from jupyter_ai.chat_handlers.learn import Retriever
 from jupyter_ai_magics.utils import get_em_providers, get_lm_providers
 from jupyter_server.extension.application import ExtensionApp
+from traitlets import List, Unicode
 
 from .chat_handlers import (
     AskChatHandler,
@@ -36,11 +37,35 @@ class AiExtension(ExtensionApp):
         (r"api/ai/providers/embeddings?", EmbeddingsModelProviderHandler),
     ]
 
+    allowed_providers = List(
+        Unicode(),
+        default_value=None,
+        help="Identifiers of allow-listed providers. If `None`, all are allowed.",
+        allow_none=True,
+        config=True,
+    )
+
+    blocked_providers = List(
+        Unicode(),
+        default_value=None,
+        help="Identifiers of block-listed providers. If `None`, none are blocked.",
+        allow_none=True,
+        config=True,
+    )
+
     def initialize_settings(self):
         start = time.time()
+        restrictions = {
+            "allowed_providers": self.allowed_providers,
+            "blocked_providers": self.blocked_providers,
+        }
 
-        self.settings["lm_providers"] = get_lm_providers(log=self.log)
-        self.settings["em_providers"] = get_em_providers(log=self.log)
+        self.settings["lm_providers"] = get_lm_providers(
+            log=self.log, restrictions=restrictions
+        )
+        self.settings["em_providers"] = get_em_providers(
+            log=self.log, restrictions=restrictions
+        )
 
         self.settings["jai_config_manager"] = ConfigManager(
             # traitlets configuration, not JAI configuration.

--- a/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
@@ -36,6 +36,7 @@ def common_cm_kwargs(config_path, schema_path):
         "em_providers": em_providers,
         "config_path": config_path,
         "schema_path": schema_path,
+        "restrictions": {"allowed_providers": None, "blocked_providers": None},
     }
 
 
@@ -112,6 +113,7 @@ def test_init_with_existing_config(
         em_providers=em_providers,
         config_path=config_path,
         schema_path=schema_path,
+        restrictions={"allowed_providers": None, "blocked_providers": None},
     )
 
 

--- a/packages/jupyter-ai/jupyter_ai/tests/test_extension.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_extension.py
@@ -1,0 +1,39 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import pytest
+from jupyter_ai.extension import AiExtension
+
+pytest_plugins = ["pytest_jupyter.jupyter_server"]
+
+KNOWN_LM_A = "openai"
+KNOWN_LM_B = "huggingface_hub"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--AiExtension.blocked_providers", KNOWN_LM_B],
+        ["--AiExtension.allowed_providers", KNOWN_LM_A],
+    ],
+)
+def test_allows_providers(argv, jp_configurable_serverapp):
+    server = jp_configurable_serverapp(argv=argv)
+    ai = AiExtension()
+    ai._link_jupyter_server_extension(server)
+    ai.initialize_settings()
+    assert KNOWN_LM_A in ai.settings["lm_providers"]
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--AiExtension.blocked_providers", KNOWN_LM_A],
+        ["--AiExtension.allowed_providers", KNOWN_LM_B],
+    ],
+)
+def test_blocks_providers(argv, jp_configurable_serverapp):
+    server = jp_configurable_serverapp(argv=argv)
+    ai = AiExtension()
+    ai._link_jupyter_server_extension(server)
+    ai.initialize_settings()
+    assert KNOWN_LM_A not in ai.settings["lm_providers"]

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -51,6 +51,7 @@ test = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-tornasync",
+    "pytest-jupyter",
     "syrupy~=4.0.8"
 ]
 


### PR DESCRIPTION
Closes https://github.com/jupyterlab/jupyter-ai/issues/313

The major limitation here is that it has no effect on ipython magics, which do not share the application (`AIExtension`) codebase (are independent of the server) and where the user would anyways be able to change the settings. I think that if one has strict requirements of not allowing certain models, they would need to block ipython magics from loading and rely on GUI interactions (which may need further work).