### PR TITLE
/learn skips hidden files/dirs by default, unless "-a" is specified

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -495,7 +495,7 @@ use the `-c` or `--chunk-size` option and the `-o` or `--chunk-overlap` option.
 By default, `/learn` will not read directories named `node_modules`, `lib`, or `build`,
 and will not read hidden files or hidden directories, where the file or directory name
 starts with a `.`. To force `/learn` to read all supported file types in all directories,
-use the `-a` or `--all` option.
+use the `-a` or `--all-files` option.
 
 ```
 # do not learn from hidden files, hidden directories, or node_modules, lib, or build directories

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -492,6 +492,19 @@ use the `-c` or `--chunk-size` option and the `-o` or `--chunk-overlap` option.
 /learn --chunk-size 1000 --chunk-overlap 200 <directory>
 ```
 
+By default, `/learn` will not read directories named `node_modules`, `lib`, or `build`,
+and will not read hidden files or hidden directories, where the file or directory name
+starts with a `.`. To force `/learn` to read all supported file types in all directories,
+use the `-a` or `--all` option.
+
+```
+# do not learn from hidden files, hidden directories, or node_modules, lib, or build directories
+/learn <directory>
+
+# learn from all supported files
+/learn -a <directory>
+```
+
 ### Additional chat commands
 
 To clear the chat panel, use the `/clear` command. This does not reset the AI model; the model may still remember previous messages that you sent it, and it may use them to inform its responses.

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -38,6 +38,7 @@ class LearnChatHandler(BaseChatHandler):
         self.root_dir = root_dir
         self.dask_client_future = dask_client_future
         self.parser.prog = "/learn"
+        self.parser.add_argument("-a", "--all", action="store_true")
         self.parser.add_argument("-v", "--verbose", action="store_true")
         self.parser.add_argument("-d", "--delete", action="store_true")
         self.parser.add_argument("-l", "--list", action="store_true")
@@ -115,7 +116,7 @@ class LearnChatHandler(BaseChatHandler):
         if args.verbose:
             self.reply(f"Loading and splitting files for {load_path}", message)
 
-        await self.learn_dir(load_path, args.chunk_size, args.chunk_overlap)
+        await self.learn_dir(load_path, args.chunk_size, args.chunk_overlap, args.all)
         self.save()
 
         response = f"""🎉 I have learned documents at **{load_path}** and I am ready to answer questions about them.
@@ -132,7 +133,7 @@ class LearnChatHandler(BaseChatHandler):
         {dir_list}"""
         return message
 
-    async def learn_dir(self, path: str, chunk_size: int, chunk_overlap: int):
+    async def learn_dir(self, path: str, chunk_size: int, chunk_overlap: int, all: bool):
         dask_client = await self.dask_client_future
         splitter_kwargs = {"chunk_size": chunk_size, "chunk_overlap": chunk_overlap}
         splitters = {
@@ -146,7 +147,7 @@ class LearnChatHandler(BaseChatHandler):
             default_splitter=RecursiveCharacterTextSplitter(**splitter_kwargs),
         )
 
-        delayed = split(path, splitter=splitter)
+        delayed = split(path, all, splitter=splitter)
         doc_chunks = await dask_client.compute(delayed)
 
         em_provider_cls, em_provider_args = self.get_embedding_provider()

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -116,7 +116,9 @@ class LearnChatHandler(BaseChatHandler):
         if args.verbose:
             self.reply(f"Loading and splitting files for {load_path}", message)
 
-        await self.learn_dir(load_path, args.chunk_size, args.chunk_overlap, args.all_files)
+        await self.learn_dir(
+            load_path, args.chunk_size, args.chunk_overlap, args.all_files
+        )
         self.save()
 
         response = f"""🎉 I have learned documents at **{load_path}** and I am ready to answer questions about them.

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -133,7 +133,9 @@ class LearnChatHandler(BaseChatHandler):
         {dir_list}"""
         return message
 
-    async def learn_dir(self, path: str, chunk_size: int, chunk_overlap: int, all: bool):
+    async def learn_dir(
+        self, path: str, chunk_size: int, chunk_overlap: int, all: bool
+    ):
         dask_client = await self.dask_client_future
         splitter_kwargs = {"chunk_size": chunk_size, "chunk_overlap": chunk_overlap}
         splitters = {

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -38,7 +38,7 @@ class LearnChatHandler(BaseChatHandler):
         self.root_dir = root_dir
         self.dask_client_future = dask_client_future
         self.parser.prog = "/learn"
-        self.parser.add_argument("-a", "--all", action="store_true")
+        self.parser.add_argument("-a", "--all-files", action="store_true")
         self.parser.add_argument("-v", "--verbose", action="store_true")
         self.parser.add_argument("-d", "--delete", action="store_true")
         self.parser.add_argument("-l", "--list", action="store_true")
@@ -116,7 +116,7 @@ class LearnChatHandler(BaseChatHandler):
         if args.verbose:
             self.reply(f"Loading and splitting files for {load_path}", message)
 
-        await self.learn_dir(load_path, args.chunk_size, args.chunk_overlap, args.all)
+        await self.learn_dir(load_path, args.chunk_size, args.chunk_overlap, args.all_files)
         self.save()
 
         response = f"""🎉 I have learned documents at **{load_path}** and I am ready to answer questions about them.
@@ -134,7 +134,7 @@ class LearnChatHandler(BaseChatHandler):
         return message
 
     async def learn_dir(
-        self, path: str, chunk_size: int, chunk_overlap: int, all: bool
+        self, path: str, chunk_size: int, chunk_overlap: int, all_files: bool
     ):
         dask_client = await self.dask_client_future
         splitter_kwargs = {"chunk_size": chunk_size, "chunk_overlap": chunk_overlap}
@@ -149,7 +149,7 @@ class LearnChatHandler(BaseChatHandler):
             default_splitter=RecursiveCharacterTextSplitter(**splitter_kwargs),
         )
 
-        delayed = split(path, all, splitter=splitter)
+        delayed = split(path, all_files, splitter=splitter)
         doc_chunks = await dask_client.compute(delayed)
 
         em_provider_cls, em_provider_args = self.get_embedding_provider()

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -55,8 +55,8 @@ def split(path, all_files: bool, splitter):
         # Filter out hidden filenames, hidden directories, and excluded directories,
         # unless "all files" are requested
         if not all_files:
-            subdirs[:] = [d for d in subdirs if not (d[0] == '.' or d in EXCLUDE_DIRS)]
-            filenames = [f for f in filenames if not f[0] == '.']
+            subdirs[:] = [d for d in subdirs if not (d[0] == "." or d in EXCLUDE_DIRS)]
+            filenames = [f for f in filenames if not f[0] == "."]
 
         for filename in filenames:
             filepath = Path(os.path.join(dir, filename))

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -52,11 +52,7 @@ def split(path, all: bool, splitter):
     chunks = []
 
     for dir, _, filenames in os.walk(path):
-        if all is False and dir in EXCLUDE_DIRS:
-            continue
-
-        # Exclude hidden directories
-        if all is False and dir[0] == ".":
+        if not all and (dir.startswith(".") or dir in EXCLUDE_DIRS):
             continue
 
         for filename in filenames:

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -17,6 +17,7 @@ def path_to_doc(path):
         metadata = {"path": str(path), "sha256": m.digest(), "extension": path.suffix}
         return Document(page_content=text, metadata=metadata)
 
+
 # Unless /learn has the "all files" option passed in, files and directories beginning with '.' are excluded
 EXCLUDE_DIRS = {
     "node_modules",
@@ -55,7 +56,7 @@ def split(path, all: bool, splitter):
             continue
 
         # Exclude hidden directories
-        if all is False and dir[0] == '.':
+        if all is False and dir[0] == ".":
             continue
 
         for filename in filenames:
@@ -64,7 +65,7 @@ def split(path, all: bool, splitter):
                 continue
 
             # Unless we're learning "all" files, exclude hidden files
-            if all is False and filepath.name[0] == '.':
+            if all is False and filepath.name[0] == ".":
                 continue
 
             document = dask.delayed(path_to_doc)(filepath)

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -56,12 +56,11 @@ def split(path, all: bool, splitter):
             continue
 
         for filename in filenames:
-            filepath = Path(os.path.join(dir, filename))
-            if filepath.suffix not in SUPPORTED_EXTS:
+            if not all and filename.startswith("."):
                 continue
 
-            # Unless we're learning "all" files, exclude hidden files
-            if all is False and filepath.name[0] == ".":
+            filepath = Path(os.path.join(dir, filename))
+            if filepath.suffix not in SUPPORTED_EXTS:
                 continue
 
             document = dask.delayed(path_to_doc)(filepath)

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -51,14 +51,14 @@ def flatten(*chunk_lists):
 def split(path, all_files: bool, splitter):
     chunks = []
 
-    for dir, _, filenames in os.walk(path):
-        if not all_files and (dir.startswith(".") or dir in EXCLUDE_DIRS):
-            continue
+    for dir, subdirs, filenames in os.walk(path):
+        # Filter out hidden filenames, hidden directories, and excluded directories,
+        # unless "all files" are requested
+        if not all_files:
+            subdirs[:] = [d for d in subdirs if not (d[0] == '.' or d in EXCLUDE_DIRS)]
+            filenames = [f for f in filenames if not f[0] == '.']
 
         for filename in filenames:
-            if not all_files and filename.startswith("."):
-                continue
-
             filepath = Path(os.path.join(dir, filename))
             if filepath.suffix not in SUPPORTED_EXTS:
                 continue

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -48,15 +48,15 @@ def flatten(*chunk_lists):
     return list(itertools.chain(*chunk_lists))
 
 
-def split(path, all: bool, splitter):
+def split(path, all_files: bool, splitter):
     chunks = []
 
     for dir, _, filenames in os.walk(path):
-        if not all and (dir.startswith(".") or dir in EXCLUDE_DIRS):
+        if not all_files and (dir.startswith(".") or dir in EXCLUDE_DIRS):
             continue
 
         for filename in filenames:
-            if not all and filename.startswith("."):
+            if not all_files and filename.startswith("."):
                 continue
 
             filepath = Path(os.path.join(dir, filename))


### PR DESCRIPTION
Fixes #424.

Omits hidden files and directories by default when calling `/learn`, unless `-a` or `--all-files` is specified, in which all supported files under the given directory are parsed.

Created a directory `learnme` with a file `.secret.txt`, reading "The capital of Slobonia is Asterphase".

With `/learn -a learnme`, the information is learned.

<img width="437" alt="Screenshot 2023-11-01 at 3 54 59 PM" src="https://github.com/jupyterlab/jupyter-ai/assets/93281816/06d07ac4-4893-4b95-84bb-8d08c2a64c3d">
