### PR TITLE
Rename Bedrock and Bedrock chat providers in docs

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -117,8 +117,8 @@ Jupyter AI supports the following model providers:
 | AI21                | `ai21`               | `AI21_API_KEY`             | `ai21`                          |
 | Anthropic           | `anthropic`          | `ANTHROPIC_API_KEY`        | `anthropic`                     |
 | Anthropic (chat)    | `anthropic-chat`     | `ANTHROPIC_API_KEY`        | `anthropic`                     |
-| Bedrock             | `amazon-bedrock`     | N/A                        | `boto3`                         |
-| Bedrock (chat)      | `amazon-bedrock-chat`| N/A                        | `boto3`                         |
+| Bedrock             | `bedrock`            | N/A                        | `boto3`                         |
+| Bedrock (chat)      | `bedrock-chat`       | N/A                        | `boto3`                         |
 | Cohere              | `cohere`             | `COHERE_API_KEY`           | `cohere`                        |
 | Hugging Face Hub    | `huggingface_hub`    | `HUGGINGFACEHUB_API_TOKEN` | `huggingface_hub`, `ipywidgets`, `pillow` |
 | OpenAI              | `openai`             | `OPENAI_API_KEY`           | `openai`                        |


### PR DESCRIPTION
The `bedrock` and `bedrock-chat` providers were incorrectly labeled `amazon-bedrock` and `amazon-bedrock-chat` in our user docs. Fixes this.