### PR TITLE
DOC: Render hugging face url as link

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -135,7 +135,7 @@ To use Bedrock models, you will need to authenticate via
 
 You need the `pillow` Python package to use Hugging Face Hub's text-to-image models.
 
-You can find a list of Hugging Face's models at https://huggingface.co/models.
+You can find a list of Hugging Face's models at [https://huggingface.co/models](https://huggingface.co/models).
 
 SageMaker endpoint names are created when you deploy a model. For more information, see
 ["Create your endpoint and deploy your model"](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-deployment.html)


### PR DESCRIPTION
Currently renders as:

<img width="699" alt="Screenshot 2023-11-04 at 4 55 56 PM" src="https://github.com/jupyterlab/jupyter-ai/assets/118582/7e914169-eea7-4ccb-8e98-526813ab0978">
