### PR TITLE
Add step to create a GPT4All cache folder to the docs

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -378,7 +378,7 @@ Note that each model comes with its own license, and that users are themselves
 responsible for verifying that their usage complies with the license. You can
 find licensing details on the [GPT4All official site](https://gpt4all.io/index.html).
 
-First, create a cache folder
+First, create a folder to store the model files.
 
 ```
 mkdir ~/.cache/gpt4all

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -378,6 +378,12 @@ Note that each model comes with its own license, and that users are themselves
 responsible for verifying that their usage complies with the license. You can
 find licensing details on the [GPT4All official site](https://gpt4all.io/index.html).
 
+First, create a cache folder
+
+```
+mkdir ~/.cache/gpt4all
+```
+
 For each model you use, you will have to run the command
 
 ```


### PR DESCRIPTION
### Problem

[GPT4All usage](http://gpt4all.io/models/ggml-gpt4all-l13b-snoozy.bin) section of the docs has instructions on how to install gpt4all models

> For each model you use, you will have to run the command
> ```
> curl -LO --output-dir ~/.cache/gpt4all "<model-bin-url>"
> ```

if `.cache` or `gpt4all` folder does not exist, command will fail with error

```
Warning: /Users/.../.cache/gpt4all/ggml-gpt4all-l13b-snoozy.bin: No such
Warning: file or directory
  0 7759M    0 46864    0     0  92400      0 24:27:40 --:--:-- 24:27:40 93168
curl: (23) Failure writing output to destination
```

### Solution

Add step to create a GPT4All cache folder to the docs