### PR TITLE
If model_provider_id or embeddings_provider_id is not associated with models, set it to None

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/config_manager.py
@@ -169,6 +169,25 @@ class ConfigManager(Configurable):
                     )
                     config.embeddings_provider_id = None
 
+                # if the currently selected language or embedding model ids are
+                # not associated with models, set them to `None` and log a warning.
+                if (
+                    lm_id is not None
+                    and not get_lm_provider(lm_id, self._lm_providers)[1]
+                ):
+                    self.log.warning(
+                        f"No language model is associated with '{lm_id}'. Setting to None."
+                    )
+                    config.model_provider_id = None
+                if (
+                    em_id is not None
+                    and not get_em_provider(em_id, self._em_providers)[1]
+                ):
+                    self.log.warning(
+                        f"No embedding model is associated with '{em_id}'. Setting to None."
+                    )
+                    config.embeddings_provider_id = None
+
                 # re-write to the file to validate the config and apply any
                 # updates to the config file immediately
                 self._write_config(config)

--- a/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
@@ -1,9 +1,9 @@
 import json
 import logging
 import os
+from unittest.mock import mock_open, patch
 
 import pytest
-from unittest.mock import mock_open, patch
 from jupyter_ai.config_manager import (
     AuthError,
     ConfigManager,

--- a/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
@@ -86,7 +86,7 @@ def reset(config_path, schema_path):
 
 @pytest.fixture
 def config_with_bad_provider_ids(tmp_path):
-    """Fixture that creates a `config.json` with model_provider_id and  embeddings_provider_id values that would not associate with models. File is created in `tmp_path` folder. Function returns path to the file."""
+    """Fixture that creates a `config.json` with `model_provider_id` and  `embeddings_provider_id` values that would not associate with models. File is created in `tmp_path` folder. Function returns path to the file."""
     config_data = {
         "model_provider_id:": "foo:bar",
         "embeddings_provider_id": "buzz:fizz",
@@ -102,7 +102,7 @@ def config_with_bad_provider_ids(tmp_path):
 
 @pytest.fixture
 def cm_with_bad_provider_ids(common_cm_kwargs, config_with_bad_provider_ids):
-    """Config manager instance created with `config_path` set to mocked `config.json` with model_provider_id and embeddings_provider_id values that would not associate with models."""
+    """Config manager instance created with `config_path` set to mocked `config.json` with `model_provider_id` and `embeddings_provider_id` values that would not associate with models."""
     common_cm_kwargs["config_path"] = config_with_bad_provider_ids
     return ConfigManager(**common_cm_kwargs)
 

--- a/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
@@ -86,7 +86,7 @@ def reset(config_path, schema_path):
 
 @pytest.fixture
 def config_with_bad_provider_ids(tmp_path):
-    """Fixture that creates a `config.json` file with bad provider ids in `tmp_path` folder and returns path to the file."""
+    """Fixture that creates a `config.json` with model_provider_id and  embeddings_provider_id values that would not associate with models. File is created in `tmp_path` folder. Function returns path to the file."""
     config_data = {
         "model_provider_id:": "foo:bar",
         "embeddings_provider_id": "buzz:fizz",
@@ -102,6 +102,7 @@ def config_with_bad_provider_ids(tmp_path):
 
 @pytest.fixture
 def cm_with_bad_provider_ids(common_cm_kwargs, config_with_bad_provider_ids):
+    """Config manager instance created with `config_path` set to mocked `config.json` with model_provider_id and embeddings_provider_id values that would not associate with models."""
     common_cm_kwargs["config_path"] = config_with_bad_provider_ids
     return ConfigManager(**common_cm_kwargs)
 


### PR DESCRIPTION
If `model_provider_id` or `embeddings_provider_id` is not associated with available models, set it to `None`. 


- Fixes #409. Now user is redirected to settings instead of an error widget.
- Adds a relevant Pytest test and it passes locally

To test:
1. get you data dir path by running `echo "$(jupyter --data-dir)/jupyter_ai/config.json"`
2. open `config.json` in your data dir and change `model_provider_id` and/or `embeddings_provider_id` to one not provided by the server