### PR TITLE
Make links from Jupyter AI chat open in new tab (vs in the same tab currently)

### DIFF
--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -22,6 +22,11 @@ type ChatMessageHeaderProps = {
   sx?: SxProps<Theme>;
 };
 
+type NewTabLinkProps = {
+  children: React.ReactNode;
+  href?: string;
+};
+
 export function ChatMessageHeader(props: ChatMessageHeaderProps): JSX.Element {
   const collaborators = useCollaboratorsContext();
 
@@ -128,6 +133,14 @@ export function ChatMessages(props: ChatMessagesProps): JSX.Element {
     }
   }, [props.messages]);
 
+  function NewTabLink(props: NewTabLinkProps) {
+    return (
+      <a href={props.href ?? '#'} target="_blank" rel="noopener noreferrer">
+        {props.children}
+      </a>
+    );
+  }
+
   return (
     <Box
       sx={{
@@ -149,6 +162,7 @@ export function ChatMessages(props: ChatMessagesProps): JSX.Element {
             // markdown styling and then overriding any CSS to make it more compact.
             className="jp-RenderedHTMLCommon jp-ai-react-markdown"
             components={{
+              a: NewTabLink,
               code: ChatCodeView
             }}
             remarkPlugins={[remarkMath]}


### PR DESCRIPTION
### Problem

Links in Jupyter AI chat are opening in the current window effectively closing the JupyterLab application when clicked. This is confusing and not optimal UX as people usually don't want to close the JupyterLab when clicking a help/documentation link.

### Proposed solution

Open links from Jupyter Ai chat in new tab.

This PR introduces a `NewTabLink` subcomponent to open links in new tabs. This component applies target="_blank" for opening in new tabs and rel="noopener noreferrer" for security and privacy. 

Before:
![Before](https://github.com/jupyterlab/jupyter-ai/assets/26686070/e4afbfba-bcca-43c6-a386-d85c56e5b09e)

After:
![After](https://github.com/jupyterlab/jupyter-ai/assets/26686070/6681d785-1f83-4314-950d-9fecec940596)
