### PR TITLE
Copy edits for Jupyternaut messages

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -82,7 +82,8 @@ class LearnChatHandler(BaseChatHandler):
         em_provider_cls, em_provider_args = self.get_embedding_provider()
         if not em_provider_cls:
             self.reply(
-                "Sorry, please select an embedding provider before using the `/learn` command."
+                "Please select an embedding provider in the chat settings, "
+                "then run your **/learn** command again."
             )
             return
 
@@ -121,17 +122,18 @@ class LearnChatHandler(BaseChatHandler):
         )
         self.save()
 
-        response = f"""🎉 I have learned documents at **{load_path}** and I am ready to answer questions about them.
-        You can ask questions about these docs by prefixing your message with **/ask**."""
+        response = f"""🎉 I have learned from documents at **{load_path}** and
+        I am ready to answer questions about them. You can ask questions about these
+        documents by starting your message with **/ask**."""
         self.reply(response, message)
 
     def _build_list_response(self):
         if not self.metadata.dirs:
-            return "There are no docs that have been learned yet."
+            return "I haven't learned from any documents yet."
 
         dirs = [dir.path for dir in self.metadata.dirs]
         dir_list = "\n- " + "\n- ".join(dirs) + "\n\n"
-        message = f"""I can answer questions from docs in these directories:
+        message = f"""I can answer questions about documents in these directories:
         {dir_list}"""
         return message
 
@@ -198,10 +200,10 @@ class LearnChatHandler(BaseChatHandler):
         self.log.info(
             f"Switching embedding provider from {prev_em_id} to {curr_em_id}."
         )
-        message = f"""🔔 Hi there, it seems like you have updated the embeddings
+        message = f"""🔔 Hi there! It seems like you have changed the embedding
         model from `{prev_em_id}` to `{curr_em_id}`. I have to re-learn the
-        documents you had previously submitted for learning. Please wait to use
-        the **/ask** command until I am done with this task."""
+        documents you had previously submitted for learning. Please wait
+        until I am done with this task before you use the **/ask** command."""
 
         self.reply(message)
 
@@ -236,9 +238,9 @@ class LearnChatHandler(BaseChatHandler):
         dir_list = (
             "\n- " + "\n- ".join([dir.path for dir in self.metadata.dirs]) + "\n\n"
         )
-        message = f"""🎉 I am done learning docs in these directories:
+        message = f"""🎉 I am done learning about documents in these directories:
         {dir_list} I am ready to answer questions about them.
-        You can ask questions about these docs by prefixing your message with **/ask**."""
+        You can ask me about these documents by starting your message with **/ask**."""
         self.reply(message)
 
     def create(


### PR DESCRIPTION
Manual backport of #349 to 1.x branch.

* Copy edits for Jupyternaut messages

* Revert "Copy edits for Jupyternaut messages"

This reverts commit f24bb76d8dfb1793b84fdb7b2bf734e958327af0.

* Revert "Revert "Copy edits for Jupyternaut messages""

This reverts commit 278e051a73e6037e1e829f165f893a2c9d8fea74.

* Update packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py



---------