### PR TITLE
Don't run check-release on release

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -4,8 +4,6 @@ on:
     branches: ["*"]
   pull_request:
     branches: ["*"]
-  release:
-    types: [published]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -25,8 +25,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: minor
-        env:
-          DEBUG: true  #The additional debugging output produced in this GitHub Actions workflow includes:The version of Node.js ,NPM ,jlpm ,Yarn ,Python installed on the runner.
 
 
       - name: Runner debug info

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -26,7 +26,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: minor
         env:
-          DEBUG: true  # Add this line to enable debugging output
+          DEBUG: true  #The additional debugging output produced in this GitHub Actions workflow includes:The version of Node.js ,NPM ,jlpm ,Yarn ,Python installed on the runner.
+
 
       - name: Runner debug info
         if: always()

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,4 +1,5 @@
 name: Check Release
+
 on:
   push:
     branches: ["*"]
@@ -11,15 +12,22 @@ jobs:
   check_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup environment
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           python_version: "3.11.x"
+
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: minor
+        env:
+          DEBUG: true  # Add this line to enable debugging output
+
       - name: Runner debug info
         if: always()
         run: |


### PR DESCRIPTION
This pull request removes the unnecessary check-release step when running a release. This will improve the release process by reducing the time it takes to complete.

Fixes #404 