### PR TITLE
Upgrades to langchain 0.0.350

### DIFF
--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 dependencies = [
     "ipython",
     "importlib_metadata>=5.2.0",
-    "langchain==0.0.346",
+    "langchain==0.0.350",
     "typing_extensions>=4.5.0",
     "click~=8.0",
     "jsonpath-ng>=1.5.3,<2",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "openai~=0.26",
     "aiosqlite>=0.18",
     "importlib_metadata>=5.2.0",
-    "langchain==0.0.346",
+    "langchain==0.0.350",
     "tiktoken", # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "dask[distributed]",


### PR DESCRIPTION
LangChain 0.0.346 is not available in conda-forge; see https://github.com/conda-forge/langchain-feedstock/pull/143, which is blocked due to langchain-0.0.10 being unavailable in conda-forge.

Upgrades LangChain to 0.0.350. Tested locally, successfully.