### PR TITLE
Main branch is compatible with Lab 4 only

### DIFF
--- a/packages/jupyter-ai/README.md
+++ b/packages/jupyter-ai/README.md
@@ -9,7 +9,7 @@ for the frontend extension.
 
 ## Requirements
 
-- JupyterLab >= 3.5 (not JupyterLab 4)
+- JupyterLab >= 4.0.0
 - Jupyter Server >= 2.0.0
 
 ## Installation


### PR DESCRIPTION
Updates README to say that the `main` branch is only compatible with JupyterLab 4.

**Please do not backport this branch to 1.x.** The `1.x` branch remains compatible with Lab 3 only, so its README is accurate.