### PR TITLE
Add gpt-4-1106-preview model from openai

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -555,6 +555,7 @@ class ChatOpenAIProvider(BaseProvider, OpenAIChat):
         "gpt-4-32k",
         "gpt-4-32k-0314",
         "gpt-4-32k-0613",
+        "gpt-4-1106-preview",
     ]
     model_id_key = "model_name"
     pypi_package_deps = ["openai"]
@@ -596,6 +597,7 @@ class ChatOpenAINewProvider(BaseProvider, ChatOpenAI):
         "gpt-4-32k",
         "gpt-4-32k-0314",
         "gpt-4-32k-0613",
+        "gpt-4-1106-preview",
     ]
     model_id_key = "model_name"
     pypi_package_deps = ["openai"]


### PR DESCRIPTION
Added OpenAI's "gpt-4-1106-preview" model to ChatOpenAIProvider.models and ChatOpenAINewProvider.models.