### PR TITLE
WIP: Gather shared Python dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupyter-ai/monorepo",
   "version": "2.7.1",
-  "description": "A generative AI extension for JupyterLab",
+  "description": "The top-level monorepo package. Should only be locally installed by developers.",
   "private": true,
   "keywords": [
     "jupyter",
@@ -29,7 +29,7 @@
     "clean": "lerna run clean",
     "clean:all": "lerna run clean:all",
     "dev": "jupyter lab --config playground/config.py",
-    "dev-install": "lerna run dev-install --stream",
+    "dev-install": "pip install \".[dev-shared,test-shared]\" && lerna run dev-install --stream",
     "dev-uninstall": "lerna run dev-uninstall --stream",
     "lint": "jlpm && lerna run prettier && lerna run eslint",
     "lint:check": "lerna run prettier:check && lerna run eslint:check",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupyter-ai/monorepo",
-  "version": "2.7.1",
-  "description": "The top-level monorepo package. Should only be locally installed by developers.",
+  "version": "0.0.0",
+  "description": "The top-level monorepo JS package. Never released or installed.",
   "private": true,
   "keywords": [
     "jupyter",

--- a/packages/jupyter-ai-magics/package.json
+++ b/packages/jupyter-ai-magics/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/jupyterlab/jupyter-ai.git"
   },
   "scripts": {
-    "dev-install": "pip install -e \".[dev,all]\"",
+    "dev-install": "pip install -e \".[all]\"",
     "dev-uninstall": "pip uninstall jupyter_ai_magics -y"
   }
 }

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -30,17 +30,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
-    "pre-commit>=3.3.3,<4"
-]
-
-test = [
-    "coverage",
-    "pytest",
-    "pytest-asyncio",
-    "pytest-cov"
-]
-
 all = [
     "ai21",
     "anthropic~=0.3.0",
@@ -51,7 +40,7 @@ all = [
     "pillow",
     "openai",
     "boto3",
-    "qianfan"
+    "qianfan",
 ]
 
 [project.entry-points."jupyter_ai.model_providers"]

--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -54,7 +54,7 @@
     "watch": "run-p watch:src watch:labextension",
     "watch:src": "tsc -w",
     "watch:labextension": "jupyter labextension watch .",
-    "dev-install": "pip install -e \".[dev,all,test]\" && jupyter labextension develop . --overwrite && jupyter server extension enable jupyter_ai",
+    "dev-install": "pip install -e \".[all]\" && jupyter labextension develop . --overwrite && jupyter server extension enable jupyter_ai",
     "dev-uninstall": "pip uninstall jupyter_ai -y"
   },
   "dependencies": {

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -28,13 +28,13 @@ dependencies = [
     "aiosqlite>=0.18",
     "importlib_metadata>=5.2.0",
     "langchain==0.0.350",
-    "tiktoken", # required for OpenAIEmbeddings
+    "tiktoken",                  # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "dask[distributed]",
-    "faiss-cpu", # Not distributed by official repo
+    "faiss-cpu",                 # Not distributed by official repo
     "typing_extensions>=4.5.0",
     "traitlets>=5.0",
-    "deepmerge>=1.0"
+    "deepmerge>=1.0",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]
@@ -43,24 +43,7 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 core_default_tasks = "jupyter_ai:tasks"
 
 [project.optional-dependencies]
-test = [
-    "jupyter-server[test]>=1.6,<3",
-    "coverage",
-    "pytest",
-    "pytest-asyncio",
-    "pytest-cov",
-    "pytest-tornasync",
-    "pytest-jupyter",
-    "syrupy~=4.0.8"
-]
-
-dev = [
-    "jupyter_ai_magics[dev]"
-]
-
-all = [
-    "jupyter_ai_magics[all]"
-]
+all = ["jupyter_ai_magics[all]"]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,40 @@
+# This is a top-level monorepo package that is never installed by users. This
+# file, along with the root `package.json` file, exist mainly for build tools
+# which need extra configuration to work with monorepo projects like ours.
+
+# We use setuptools instead of hatch here for simplicity. We only install this
+# package to install the shared dev and test dependencies declared here.
 [build-system]
-requires = ["hatchling>=1.4.0", "jupyterlab~=4.0", "hatch-nodejs-version"]
-build-backend = "hatchling.build"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "jupyter_ai_monorepo"
-dynamic = ["version", "description", "authors", "urls", "keywords"]
+description = "The top-level monorepo package. Should only be locally installed by developers."
 requires-python = ">=3.8"
 dependencies = []
 
+# The version declared in `package.json` is used by Jupyter Releaser to build
+# the changelogs. That version (not this) is bumped by `scripts/bump-version.sh`
+# every release.
+version = "0.0.0"
+
 [project.optional-dependencies]
-build = []
+# dev dependencies shared by all packages. should be installed by developers
+# working on Jupyter AI via `jlpm dev-install`.
+dev-shared = ["import-linter", "pre-commit>=3.3.3,<4"]
+
+# test dependencies shared by all packages, ditto above.
+test-shared = [
+    "jupyter-server[test]>=1.6,<3",
+    "coverage",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "pytest-tornasync",
+    "pytest-jupyter",
+    "syrupy~=4.0.8",
+]
 
 [project.readme]
 file = "README.md"
@@ -18,12 +43,13 @@ content-type = "text/markdown"
 [project.license]
 text = "BSD 3-Clause License"
 
-[tool.hatch.version]
-source = "nodejs"
-path = "package.json"
-
 [tool.check-manifest]
 ignore = [".*"]
 
 [tool.check-wheel-contents]
 ignore = ["W002"]
+
+# minimal configuration to allow this package to be installed
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["README.md"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jupyter_ai_monorepo"
-description = "The top-level monorepo package. Should only be locally installed by developers."
+description = "The top-level monorepo PY package. Never released, but is installed by developers."
 requires-python = ">=3.8"
 dependencies = []
 
-# The version declared in `package.json` is used by Jupyter Releaser to build
-# the changelogs. That version (not this) is bumped by `scripts/bump-version.sh`
-# every release.
-version = "0.0.0"
+# Automatically bumped by `scripts/bump-version.sh`.
+version = "2.7.1"
 
 [project.optional-dependencies]
 # dev dependencies shared by all packages. should be installed by developers

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
 # script that bumps version for all projects regardless of whether they were
-# changed since last release. needed because `lerna version` only bumps versions for projects
-# listed by `lerna changed` by default.
+# changed since last release.
+
+set -euxo pipefail
+target_version="$1"
+
+# bump version in pyproject.toml
+# TODO
+
+# we specify `--force-publish` because otherwise, `lerna version` only bumps
+# versions for projects listed by `lerna changed`.
 #
 # see: https://github.com/lerna/lerna/issues/2369
-
 (npx -p lerna@6.4.1 -y lerna version \
     --no-git-tag-version \
     --no-push \
     --force-publish \
     -y \
-    $1 \
+    "$target_version" \
 ) || exit 1


### PR DESCRIPTION
Gathers dev & test dependencies shared by all Jupyter AI packages into the root `pyproject.toml`. This helps make the codebase less confusing, as developers do not need to re-declare dependencies in each package `pyproject.toml`.

I've switched to the default setuptools build backend for the monorepo root package for simplicity (since we don't need a sophisticated build for a dummy package that is never released). I still need to update `bump-version.sh` to bump the root `pyproject.toml`.