### PR TITLE
Clarify/fix conda instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ If you are not using JupyterLab and you only want to install the Jupyter AI `%%a
 
 ### With conda
 
-As an alternative to using `pip`, you can install jupyter-ai using
-[conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
-from the conda-forge channel:
+As an alternative to using `pip`, you can install `jupyter-ai` using
+[Conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
+from the `conda-forge` channel:
 
     $ conda install -c conda-forge jupyter_ai
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ If you are not using JupyterLab and you only want to install the Jupyter AI `%%a
 
 ### With conda
 
-First, install
-[conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).
+As an alternative to using `pip`, you can install jupyter-ai using
+[conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
+from the conda-forge channel:
 
-    $ conda install jupyter_ai
+    $ conda install -c conda-forge jupyter_ai
 
 ## The `%%ai` magic command
 


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-ai/issues/542

Users here and elsewhere (e.g. gitter channel) complained that the short instructions in readme are not working and not friendly for a newbie. Two issues were mentioned:
- copy-pasting conda instructions does not work because conda-forge channel is not mentioned
- for users new to Python ecosystem it is not obvious that they should either use the `pip` or `conda` route (despite the headings suggesting that indirectly)

This PR attempts to address both issues.