### PR TITLE
Pin `langchain-core` dependency to prevent Settings UI crash

### DIFF
--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "ipython",
     "importlib_metadata>=5.2.0",
     "langchain==0.0.350",
+    "langchain-core>=0.1.0,<0.1.4",
     "typing_extensions>=4.5.0",
     "click~=8.0",
     "jsonpath-ng>=1.5.3,<2",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "aiosqlite>=0.18",
     "importlib_metadata>=5.2.0",
     "langchain==0.0.350",
+    "langchain-core>=0.1.0,<0.1.4",
     "tiktoken",                  # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "dask[distributed]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,6 @@ name = "Forbidden import of `pydantic` package. Please import from `langchain.py
 type = "forbidden"
 source_modules = ["jupyter_ai", "jupyter_ai_magics"]
 forbidden_modules = ["pydantic"]
+
+[tool.pytest.ini_options]
+addopts = "--ignore packages/jupyter-ai-module-cookiecutter"


### PR DESCRIPTION
## Description

- Fixes #555

This PR is to be merged & released ASAP, as the latest releases are currently broken.

## Context

LangChain [now defines `name` as an instance field on the `BaseLLM` class we inherit from](https://github.com/langchain-ai/langchain/pull/15226). This causes an unfortunate interaction with our `name` class attribute, where it causes `Class.name` to somehow always resolve to `...` instead of the one stated in our class definition, which in turn is causing #555.

Even though the PR was only merged roughly a week ago, this affects Jupyter AI users because the change was made to the `langchain-core` package, and was released in `langchain-core==0.1.4`. `langchain==0.0.350` (the current version of LangChain we use) used a [loose version specifier](https://github.com/langchain-ai/langchain/pull/14612/files#diff-3b3fdfbc7c450ad0c643a8ce9dd0c360ae72c117d413f4df63db21ef4e674413R15) that allowed this problematic version to be installed, despite our existing version lock on `langchain`.

You can reproduce this bug with Pydantic in Python like so:

```py
from pydantic.v1 import BaseModel
from typing import ClassVar, Optional

class A(BaseModel):
    x: ClassVar[str] = "asdf"

class B(BaseModel):
    x: Optional[str] = None

class C(B):
    x: ClassVar[str] = "asdf"

assert A.x == "asdf"
assert C.x == "asdf" # <= this throws an exception
```

## Root cause

After doing a bit of digging, I found the root cause of this bug in [Pydantic's `ModelMetaclass` definition](https://github.com/pydantic/pydantic/blob/1.10.X-fixes/pydantic/main.py#L251-L280). The metaclass excludes any keys from showing up in `cls.__dict__` if it's listed in `cls.__dict__['__fields__']` (which only contains instance fields):

```py
exclude_from_namespace = fields | private_attributes.keys() | {'__slots__'}
new_namespace = {
    ...
    **{n: v for n, v in namespace.items() if n not in exclude_from_namespace},
}
```

Tentatively, our next step is to rename this field in the LangChain source, as it seems to only be used for testing anyways. Then once that's released, we can revert this PR and bump our `langchain` version.
