### PR TITLE
Pin langchain-community version to <0.0.8

### DIFF
--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "ipython",
     "importlib_metadata>=5.2.0",
     "langchain==0.0.350",
+    "langchain-community<0.0.8",
     "langchain-core>=0.1.0,<0.1.4",
     "typing_extensions>=4.5.0",
     "click~=8.0",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "aiosqlite>=0.18",
     "importlib_metadata>=5.2.0",
     "langchain==0.0.350",
+    "langchain-community<0.0.8",
     "langchain-core>=0.1.0,<0.1.4",
     "tiktoken",                  # required for OpenAIEmbeddings
     "jupyter_ai_magics",


### PR DESCRIPTION
This is a follow up to #558 by @dlqqq. 

The newest version of `langchain-community`, 0.0.8, includes a line:

```
    from langchain_core.runnables.config import run_in_executor
```

With `langchain-core>=0.1.0,<0.1.4` as the version that Jupyter AI uses, this `import` statement fails, because `run_in_executor` was introduced in a newer version of `langhain_core`.

This dependency is already included in our conda-forge feedstocks, having been added in https://github.com/conda-forge/jupyter-ai-magics-feedstock/pull/12 and https://github.com/conda-forge/jupyter-ai-feedstock/pull/11.