### PR TITLE
Upgrade to LangChain 0.1.0

### DIFF
--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -97,7 +97,7 @@ from langchain.embeddings import FakeEmbeddings
 
 class MyEmbeddingsProvider(BaseEmbeddingsProvider, FakeEmbeddings):
     id = "my_embeddings_provider"
-    name = "My Embeddings Provider"
+    provider_name = "My Embeddings Provider"
     model_id_key = "model"
     models = ["my_model"]
 
@@ -154,7 +154,7 @@ Please note that this will only work with Jupyter AI magics (the `%ai` and `%%ai
 
 You can add a custom slash command to the chat interface by
 creating a new class that inherits from `BaseChatHandler`. Set
-its `id`, `name`, `help` message for display in the user interface,
+its `id`, `provider_name`, `help` message for display in the user interface,
 and `routing_type`. Each custom slash command must have a unique
 slash command. Slash commands can only contain ASCII letters, numerals,
 and underscores. Each slash command must be unique; custom slash
@@ -168,7 +168,7 @@ from jupyter_ai.models import HumanChatMessage
 
 class CustomChatHandler(BaseChatHandler):
     id = "custom"
-    name = "Custom"
+    provider_name = "Custom"
     help = "A chat handler that does something custom"
     routing_type = SlashCommandRoutingType(slash_id="custom")
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -8,7 +8,7 @@ from jupyter_ai_magics.providers import (
     Field,
     MultiEnvAuthStrategy,
 )
-from langchain.embeddings import (
+from langchain_community.embeddings import (
     BedrockEmbeddings,
     CohereEmbeddings,
     GPT4AllEmbeddings,

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -8,6 +8,7 @@ from jupyter_ai_magics.providers import (
     Field,
     MultiEnvAuthStrategy,
 )
+from langchain.pydantic_v1 import BaseModel, Extra
 from langchain_community.embeddings import (
     BedrockEmbeddings,
     CohereEmbeddings,
@@ -16,7 +17,6 @@ from langchain_community.embeddings import (
     OpenAIEmbeddings,
     QianfanEmbeddingsEndpoint,
 )
-from langchain.pydantic_v1 import BaseModel, Extra
 
 
 class BaseEmbeddingsProvider(BaseModel):

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -28,7 +28,7 @@ class BaseEmbeddingsProvider(BaseModel):
     id: ClassVar[str] = ...
     """ID for this provider class."""
 
-    name: ClassVar[str] = ...
+    provider_name: ClassVar[str] = ...
     """User-facing name of this provider."""
 
     models: ClassVar[List[str]] = ...
@@ -71,7 +71,7 @@ class BaseEmbeddingsProvider(BaseModel):
 
 class OpenAIEmbeddingsProvider(BaseEmbeddingsProvider, OpenAIEmbeddings):
     id = "openai"
-    name = "OpenAI"
+    provider_name = "OpenAI"
     models = ["text-embedding-ada-002"]
     model_id_key = "model"
     pypi_package_deps = ["openai"]
@@ -80,7 +80,7 @@ class OpenAIEmbeddingsProvider(BaseEmbeddingsProvider, OpenAIEmbeddings):
 
 class CohereEmbeddingsProvider(BaseEmbeddingsProvider, CohereEmbeddings):
     id = "cohere"
-    name = "Cohere"
+    provider_name = "Cohere"
     models = ["large", "multilingual-22-12", "small"]
     model_id_key = "model"
     pypi_package_deps = ["cohere"]
@@ -89,7 +89,7 @@ class CohereEmbeddingsProvider(BaseEmbeddingsProvider, CohereEmbeddings):
 
 class HfHubEmbeddingsProvider(BaseEmbeddingsProvider, HuggingFaceHubEmbeddings):
     id = "huggingface_hub"
-    name = "Hugging Face Hub"
+    provider_name = "Hugging Face Hub"
     models = ["*"]
     model_id_key = "repo_id"
     # ipywidgets needed to suppress tqdm warning
@@ -102,7 +102,7 @@ class HfHubEmbeddingsProvider(BaseEmbeddingsProvider, HuggingFaceHubEmbeddings):
 
 class BedrockEmbeddingsProvider(BaseEmbeddingsProvider, BedrockEmbeddings):
     id = "bedrock"
-    name = "Bedrock"
+    provider_name = "Bedrock"
     models = ["amazon.titan-embed-text-v1"]
     model_id_key = "model_id"
     pypi_package_deps = ["boto3"]
@@ -125,7 +125,7 @@ class GPT4AllEmbeddingsProvider(BaseEmbeddingsProvider, GPT4AllEmbeddings):
         super().__init__(**kwargs)
 
     id = "gpt4all"
-    name = "GPT4All Embeddings"
+    provider_name = "GPT4All Embeddings"
     models = ["all-MiniLM-L6-v2-f16"]
     model_id_key = "model_id"
     pypi_package_deps = ["gpt4all"]
@@ -135,7 +135,7 @@ class QianfanEmbeddingsEndpointProvider(
     BaseEmbeddingsProvider, QianfanEmbeddingsEndpoint
 ):
     id = "qianfan"
-    name = "ERNIE-Bot"
+    provider_name = "ERNIE-Bot"
     models = ["ERNIE-Bot", "ERNIE-Bot-4"]
     model_id_key = "model"
     pypi_package_deps = ["qianfan"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -112,7 +112,7 @@ class BaseProvider(BaseModel):
     id: ClassVar[str] = ...
     """ID for this provider class."""
 
-    name: ClassVar[str] = ...
+    provider_name: ClassVar[str] = ...
     """User-facing name of this provider."""
 
     models: ClassVar[List[str]] = ...
@@ -253,7 +253,7 @@ class BaseProvider(BaseModel):
 
 class AI21Provider(BaseProvider, AI21):
     id = "ai21"
-    name = "AI21"
+    provider_name = "AI21"
     models = [
         "j1-large",
         "j1-grande",
@@ -284,7 +284,7 @@ class AI21Provider(BaseProvider, AI21):
 
 class AnthropicProvider(BaseProvider, Anthropic):
     id = "anthropic"
-    name = "Anthropic"
+    provider_name = "Anthropic"
     models = [
         "claude-v1",
         "claude-v1.0",
@@ -317,7 +317,7 @@ class AnthropicProvider(BaseProvider, Anthropic):
 
 class ChatAnthropicProvider(BaseProvider, ChatAnthropic):
     id = "anthropic-chat"
-    name = "ChatAnthropic"
+    provider_name = "ChatAnthropic"
     models = [
         "claude-v1",
         "claude-v1.0",
@@ -339,7 +339,7 @@ class ChatAnthropicProvider(BaseProvider, ChatAnthropic):
 
 class CohereProvider(BaseProvider, Cohere):
     id = "cohere"
-    name = "Cohere"
+    provider_name = "Cohere"
     models = ["medium", "xlarge"]
     model_id_key = "model"
     pypi_package_deps = ["cohere"]
@@ -364,7 +364,7 @@ class GPT4AllProvider(BaseProvider, GPT4All):
         super().__init__(**kwargs)
 
     id = "gpt4all"
-    name = "GPT4All"
+    provider_name = "GPT4All"
     docs = "https://docs.gpt4all.io/gpt4all_python.html"
     models = [
         "ggml-gpt4all-j-v1.2-jazzy",
@@ -406,7 +406,7 @@ HUGGINGFACE_HUB_VALID_TASKS = (
 
 class HfHubProvider(BaseProvider, HuggingFaceHub):
     id = "huggingface_hub"
-    name = "Hugging Face Hub"
+    provider_name = "Hugging Face Hub"
     models = ["*"]
     model_id_key = "repo_id"
     help = (
@@ -511,7 +511,7 @@ class HfHubProvider(BaseProvider, HuggingFaceHub):
 
 class OpenAIProvider(BaseProvider, OpenAI):
     id = "openai"
-    name = "OpenAI"
+    provider_name = "OpenAI"
     models = [
         "text-davinci-003",
         "text-davinci-002",
@@ -542,7 +542,7 @@ class OpenAIProvider(BaseProvider, OpenAI):
 
 class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
     id = "openai-chat"
-    name = "OpenAI"
+    provider_name = "OpenAI"
     models = [
         "gpt-3.5-turbo",
         "gpt-3.5-turbo-16k",
@@ -586,7 +586,7 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
 
 class AzureChatOpenAIProvider(BaseProvider, AzureChatOpenAI):
     id = "azure-chat-openai"
-    name = "Azure OpenAI"
+    provider_name = "Azure OpenAI"
     models = ["*"]
     model_id_key = "deployment_name"
     model_id_label = "Deployment name"
@@ -641,7 +641,7 @@ class JsonContentHandler(LLMContentHandler):
 
 class SmEndpointProvider(BaseProvider, SagemakerEndpoint):
     id = "sagemaker-endpoint"
-    name = "SageMaker endpoint"
+    provider_name = "SageMaker endpoint"
     models = ["*"]
     model_id_key = "endpoint_name"
     model_id_label = "Endpoint name"
@@ -681,7 +681,7 @@ class SmEndpointProvider(BaseProvider, SagemakerEndpoint):
 
 class BedrockProvider(BaseProvider, Bedrock):
     id = "bedrock"
-    name = "Amazon Bedrock"
+    provider_name = "Amazon Bedrock"
     models = [
         "amazon.titan-text-express-v1",
         "ai21.j2-ultra-v1",
@@ -709,7 +709,7 @@ class BedrockProvider(BaseProvider, Bedrock):
 
 class BedrockChatProvider(BaseProvider, BedrockChat):
     id = "bedrock-chat"
-    name = "Amazon Bedrock Chat"
+    provider_name = "Amazon Bedrock Chat"
     models = [
         "anthropic.claude-v1",
         "anthropic.claude-v2",
@@ -742,7 +742,7 @@ class BedrockChatProvider(BaseProvider, BedrockChat):
 # Baidu QianfanChat provider. temporarily living as a separate class until
 class QianfanProvider(BaseProvider, QianfanChatEndpoint):
     id = "qianfan"
-    name = "ERNIE-Bot"
+    provider_name = "ERNIE-Bot"
     models = ["ERNIE-Bot", "ERNIE-Bot-4"]
     model_id_key = "model_name"
     pypi_package_deps = ["qianfan"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -18,14 +18,14 @@ from typing import (
 )
 
 from jsonpath_ng import parse
-from langchain.chat_models import (
+from langchain_community.chat_models import (
     AzureChatOpenAI,
     BedrockChat,
     ChatAnthropic,
     QianfanChatEndpoint,
 )
 from langchain.chat_models.base import BaseChatModel
-from langchain.llms import (
+from langchain_community.llms import (
     AI21,
     Anthropic,
     Bedrock,

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -18,13 +18,20 @@ from typing import (
 )
 
 from jsonpath_ng import parse
+from langchain.chat_models.base import BaseChatModel
+from langchain.llms.sagemaker_endpoint import LLMContentHandler
+from langchain.llms.utils import enforce_stop_tokens
+from langchain.prompts import PromptTemplate
+from langchain.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain.schema import LLMResult
+from langchain.utils import get_from_dict_or_env
 from langchain_community.chat_models import (
     AzureChatOpenAI,
     BedrockChat,
     ChatAnthropic,
+    ChatOpenAI,
     QianfanChatEndpoint,
 )
-from langchain.chat_models.base import BaseChatModel
 from langchain_community.llms import (
     AI21,
     Anthropic,
@@ -37,13 +44,6 @@ from langchain_community.llms import (
     QianfanLLMEndpoint,
     SagemakerEndpoint,
 )
-from langchain.llms.sagemaker_endpoint import LLMContentHandler
-from langchain.llms.utils import enforce_stop_tokens
-from langchain.prompts import PromptTemplate
-from langchain.pydantic_v1 import BaseModel, Extra, root_validator
-from langchain.schema import LLMResult
-from langchain.utils import get_from_dict_or_env
-from langchain_community.chat_models import ChatOpenAI
 
 
 class EnvAuthStrategy(BaseModel):

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -23,8 +23,8 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 dependencies = [
     "ipython",
     "importlib_metadata>=5.2.0",
-    "langchain==0.0.350",
-    "langchain-core>=0.1.0,<0.1.4",
+    "langchain>=0.1.0,<=0.2",
+    "langchain-core>=0.1.7,<0.2",
     "typing_extensions>=4.5.0",
     "click~=8.0",
     "jsonpath-ng>=1.5.3,<2",

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "importlib_metadata>=5.2.0",
     "langchain>=0.1.0,<=0.2",
     "langchain-core>=0.1.7,<0.2",
+    "langchain-community>=0.0.10,<0.1",
     "typing_extensions>=4.5.0",
     "click~=8.0",
     "jsonpath-ng>=1.5.3,<2",

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -53,7 +53,7 @@ class DefaultChatHandler(BaseChatHandler):
             prompt_template = ChatPromptTemplate.from_messages(
                 [
                     SystemMessagePromptTemplate.from_template(SYSTEM_PROMPT).format(
-                        provider_name=llm.name, local_model_id=llm.model_id
+                        provider_name=llm.provider_name, local_model_id=llm.model_id
                     ),
                     MessagesPlaceholder(variable_name="history"),
                     HumanMessagePromptTemplate.from_template("{input}"),
@@ -64,7 +64,7 @@ class DefaultChatHandler(BaseChatHandler):
             prompt_template = PromptTemplate(
                 input_variables=["history", "input"],
                 template=SYSTEM_PROMPT.format(
-                    provider_name=llm.name, local_model_id=llm.model_id
+                    provider_name=llm.provider_name, local_model_id=llm.model_id
                 )
                 + "\n\n"
                 + DEFAULT_TEMPLATE,

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -304,7 +304,7 @@ class ModelProviderHandler(ProviderHandler):
             providers.append(
                 ListProvidersEntry(
                     id=provider.id,
-                    name=provider.name,
+                    provider_name=provider.provider_name,
                     models=provider.models,
                     help=provider.help,
                     auth_strategy=provider.auth_strategy,
@@ -316,7 +316,7 @@ class ModelProviderHandler(ProviderHandler):
 
         # Step 2: sort & filter providers
         providers = self._filter_blocked_models(providers)
-        providers = sorted(providers, key=lambda p: p.name)
+        providers = sorted(providers, key=lambda p: p.provider_name)
 
         # Finally, yield response.
         response = ListProvidersResponse(providers=providers)
@@ -331,7 +331,7 @@ class EmbeddingsModelProviderHandler(ProviderHandler):
             providers.append(
                 ListProvidersEntry(
                     id=provider.id,
-                    name=provider.name,
+                    provider_name=provider.provider_name,
                     models=provider.models,
                     auth_strategy=provider.auth_strategy,
                     registry=provider.registry,
@@ -340,7 +340,7 @@ class EmbeddingsModelProviderHandler(ProviderHandler):
             )
 
         providers = self._filter_blocked_models(providers)
-        providers = sorted(providers, key=lambda p: p.name)
+        providers = sorted(providers, key=lambda p: p.provider_name)
 
         response = ListProvidersResponse(providers=providers)
         self.finish(response.json())

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -76,7 +76,7 @@ class ListProvidersEntry(BaseModel):
     """
 
     id: str
-    name: str
+    provider_name: str
     model_id_label: Optional[str]
     models: List[str]
     help: Optional[str]

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -26,8 +26,6 @@ dependencies = [
     "jupyterlab~=4.0",
     "aiosqlite>=0.18",
     "importlib_metadata>=5.2.0",
-    "langchain>=0.1.0,<=0.2",
-    "langchain-core>=0.1.7,<0.2",
     "tiktoken",                  # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "dask[distributed]",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
     "jupyterlab~=4.0",
     "aiosqlite>=0.18",
     "importlib_metadata>=5.2.0",
-    "langchain==0.0.350",
-    "langchain-core>=0.1.0,<0.1.4",
+    "langchain>=0.1.0,<=0.2",
+    "langchain-core>=0.1.7,<0.2",
     "tiktoken",                  # required for OpenAIEmbeddings
     "jupyter_ai_magics",
     "dask[distributed]",

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -273,7 +273,7 @@ export function ChatSettings(): JSX.Element {
         {server.lmProviders.providers.map(lmp =>
           lmp.models.map(lm => (
             <MenuItem value={`${lmp.id}:${lm}`}>
-              {lmp.name} :: {lm}
+              {lmp.provider_name} :: {lm}
             </MenuItem>
           ))
         )}
@@ -316,7 +316,7 @@ export function ChatSettings(): JSX.Element {
             .filter(em => em !== '*') // TODO: support registry providers
             .map(em => (
               <MenuItem value={`${emp.id}:${em}`}>
-                {emp.name} :: {em}
+                {emp.provider_name} :: {em}
               </MenuItem>
             ))
         )}

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -170,7 +170,7 @@ export namespace AiService {
 
   export type ListProvidersEntry = {
     id: string;
-    name: string;
+    provider_name: string;
     model_id_label?: string;
     models: string[];
     help?: string;


### PR DESCRIPTION
Fixes #569. Upgrades Jupyter AI to use LangChain 0.1.0, for compatibility with conda-forge package of LangChain with OpenAI 1.x support (#543). Renames `name` in `ListProvidersEntry` to `provider_name`, because `name` is now declared on the underlying `Runnable` class, and modifying our code is going to be a lot lower impact than modifying LangChain code is. (The LangChain code doesn't use `name` for much, so I'm willing to be flexible.)

Tested the magic commands and chat interface, including settings panel, locally.