### PR TITLE
Add Kaggle to supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and powerful way to explore generative AI models in notebooks and improve your p
 in JupyterLab and the Jupyter Notebook. More specifically, Jupyter AI offers:
 
 * An `%%ai` magic that turns the Jupyter notebook into a reproducible generative AI playground.
-  This works anywhere the IPython kernel runs (JupyterLab, Jupyter Notebook, Google Colab, VSCode, etc.).
+  This works anywhere the IPython kernel runs (JupyterLab, Jupyter Notebook, Google Colab, Kaggle, VSCode, etc.).
 * A native chat UI in JupyterLab that enables you to work with generative AI as a conversational assistant.
 * Support for a wide range of generative model providers, including AI21, Anthropic, AWS, Cohere,
   Hugging Face, and OpenAI.


### PR DESCRIPTION
# :grey_question: About

I discovered your tool thanks to a tweet and wanted to give it a try before to use it for some data-story-tellings. I use Kaggle for my blogs, and gave a (succcessful try.
Si I thought it could be interesting to mention Kaggle as a supported platform.

:point_right: This PR adds Kaggle as a supported platform.

# :bookmark: Resources

- [A dummy notebook that does the job w/openai](https://www.kaggle.com/adriensales/jupyter-ai)

