### PR TITLE
Removes non-open-source products from example use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and powerful way to explore generative AI models in notebooks and improve your p
 in JupyterLab and the Jupyter Notebook. More specifically, Jupyter AI offers:
 
 * An `%%ai` magic that turns the Jupyter notebook into a reproducible generative AI playground.
-  This works anywhere the IPython kernel runs (JupyterLab, Jupyter Notebook, Google Colab, VSCode, etc.).
+  This works anywhere the IPython kernel runs, including JupyterLab and Jupyter Notebook.
 * A native chat UI in JupyterLab that enables you to work with generative AI as a conversational assistant.
 * Support for a wide range of generative model providers, including AI21, Anthropic, AWS, Cohere,
   Hugging Face, and OpenAI.


### PR DESCRIPTION
Reduces the number of examples of applications where magic commands can run, to only include open source applications JupyterLab and Jupyter Notebook.

The README still refers to companies that provide large language models, but these providers are also mentioned in our source code and user interface, so those can't be avoided.

Alternative to #577.