### PR TITLE
Upgrades cohere dependency, model list

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -80,7 +80,15 @@ class OpenAIEmbeddingsProvider(BaseEmbeddingsProvider, OpenAIEmbeddings):
 class CohereEmbeddingsProvider(BaseEmbeddingsProvider, CohereEmbeddings):
     id = "cohere"
     name = "Cohere"
-    models = ["large", "multilingual-22-12", "small"]
+    models = [
+        "embed-english-v2.0",
+        "embed-english-light-v2.0",
+        "embed-multilingual-v2.0",
+        "embed-english-v3.0",
+        "embed-english-light-v3.0",
+        "embed-multilingual-v3.0",
+        "embed-multilingual-light-v3.0",
+    ]
     model_id_key = "model"
     pypi_package_deps = ["cohere"]
     auth_strategy = EnvAuthStrategy(name="COHERE_API_KEY")

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -37,7 +37,7 @@ test = ["coverage", "pytest", "pytest-asyncio", "pytest-cov"]
 all = [
     "ai21",
     "anthropic~=0.3.0",
-    "cohere",
+    "cohere>4.40,<5",
     "gpt4all",
     "huggingface_hub",
     "ipywidgets",


### PR DESCRIPTION
Fixes #589. Updates the Cohere embedding model list to match the [current embedding models for Cohere](https://docs.cohere.com/docs/models#embed). Forces us to use a version of the `cohere` Python package that supports the `input_type` parameter, i.e., one released around the same time as LangChain 0.1.0 (dependency introduced in #572).

Tested with all supported Cohere embedding models.