### PR TITLE
Uses invoke() to call custom chains. Handles dict output format.

### DIFF
--- a/examples/commands.ipynb
+++ b/examples/commands.ipynb
@@ -146,8 +146,8 @@
        "| `gpt4all` | Not applicable. | <abbr title=\"Not applicable\">N/A</abbr> | `gpt4all:ggml-gpt4all-j-v1.2-jazzy`, `gpt4all:ggml-gpt4all-j-v1.3-groovy`, `gpt4all:ggml-gpt4all-l13b-snoozy`, `gpt4all:mistral-7b-openorca.Q4_0`, `gpt4all:mistral-7b-instruct-v0.1.Q4_0`, `gpt4all:gpt4all-falcon-q4_0`, `gpt4all:wizardlm-13b-v1.2.Q4_0`, `gpt4all:nous-hermes-llama2-13b.Q4_0`, `gpt4all:gpt4all-13b-snoozy-q4_0`, `gpt4all:mpt-7b-chat-merges-q4_0`, `gpt4all:orca-mini-3b-gguf2-q4_0`, `gpt4all:starcoder-q4_0`, `gpt4all:rift-coder-v0-7b-q4_0`, `gpt4all:em_german_mistral_v01.Q4_0` |\n",
        "| `huggingface_hub` | `HUGGINGFACEHUB_API_TOKEN` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | See [https://huggingface.co/models](https://huggingface.co/models) for a list of models. Pass a model's repository ID as the model ID; for example, `huggingface_hub:ExampleOwner/example-model`. |\n",
        "| `openai` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai:babbage-002`, `openai:davinci-002`, `openai:gpt-3.5-turbo-instruct` |\n",
-       "| `openai-chat` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai-chat:gpt-3.5-turbo`, `openai-chat:gpt-3.5-turbo-1106`, `openai-chat:gpt-3.5-turbo-16k`, `openai-chat:gpt-3.5-turbo-0301`, `openai-chat:gpt-3.5-turbo-0613`, `openai-chat:gpt-3.5-turbo-16k-0613`, `openai-chat:gpt-4`, `openai-chat:gpt-4-0613`, `openai-chat:gpt-4-32k`, `openai-chat:gpt-4-32k-0613`, `openai-chat:gpt-4-1106-preview` |\n",
-       "| `qianfan` | `QIANFAN_AK`, `QIANFAN_SK` | <abbr title=\"You have set all of these environment variables, so you can use this provider's models.\">✅</abbr> | `qianfan:ERNIE-Bot`, `qianfan:ERNIE-Bot-4` |\n",
+       "| `openai-chat` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai-chat:gpt-3.5-turbo`, `openai-chat:gpt-3.5-turbo-0301`, `openai-chat:gpt-3.5-turbo-0613`, `openai-chat:gpt-3.5-turbo-1106`, `openai-chat:gpt-3.5-turbo-16k`, `openai-chat:gpt-3.5-turbo-16k-0613`, `openai-chat:gpt-4`, `openai-chat:gpt-4-0613`, `openai-chat:gpt-4-32k`, `openai-chat:gpt-4-32k-0613`, `openai-chat:gpt-4-1106-preview` |\n",
+       "| `qianfan` | `QIANFAN_AK`, `QIANFAN_SK` | <abbr title=\"You have not set all of these environment variables, so you cannot use this provider's models.\">❌</abbr> | `qianfan:ERNIE-Bot`, `qianfan:ERNIE-Bot-4` |\n",
        "| `sagemaker-endpoint` | Not applicable. | <abbr title=\"Not applicable\">N/A</abbr> | Specify an endpoint name as the model ID. In addition, you must specify a region name, request schema, and response path. For more information, see the documentation about [SageMaker endpoints deployment](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-deployment.html) and about [using magic commands with SageMaker endpoints](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#using-magic-commands-with-sagemaker-endpoints). |\n",
        "\n",
        "Aliases and custom commands:\n",
@@ -252,10 +252,10 @@
        "openai-chat\n",
        "Requires environment variable: OPENAI_API_KEY (set)\n",
        "* openai-chat:gpt-3.5-turbo\n",
-       "* openai-chat:gpt-3.5-turbo-1106\n",
-       "* openai-chat:gpt-3.5-turbo-16k\n",
        "* openai-chat:gpt-3.5-turbo-0301\n",
        "* openai-chat:gpt-3.5-turbo-0613\n",
+       "* openai-chat:gpt-3.5-turbo-1106\n",
+       "* openai-chat:gpt-3.5-turbo-16k\n",
        "* openai-chat:gpt-3.5-turbo-16k-0613\n",
        "* openai-chat:gpt-4\n",
        "* openai-chat:gpt-4-0613\n",
@@ -264,7 +264,7 @@
        "* openai-chat:gpt-4-1106-preview\n",
        "\n",
        "qianfan\n",
-       "Requires environment variables: QIANFAN_AK (set), QIANFAN_SK (set)\n",
+       "Requires environment variables: QIANFAN_AK (not set), QIANFAN_SK (not set)\n",
        "* qianfan:ERNIE-Bot\n",
        "* qianfan:ERNIE-Bot-4\n",
        "\n",
@@ -379,8 +379,8 @@
        "| `gpt4all` | Not applicable. | <abbr title=\"Not applicable\">N/A</abbr> | `gpt4all:ggml-gpt4all-j-v1.2-jazzy`, `gpt4all:ggml-gpt4all-j-v1.3-groovy`, `gpt4all:ggml-gpt4all-l13b-snoozy`, `gpt4all:mistral-7b-openorca.Q4_0`, `gpt4all:mistral-7b-instruct-v0.1.Q4_0`, `gpt4all:gpt4all-falcon-q4_0`, `gpt4all:wizardlm-13b-v1.2.Q4_0`, `gpt4all:nous-hermes-llama2-13b.Q4_0`, `gpt4all:gpt4all-13b-snoozy-q4_0`, `gpt4all:mpt-7b-chat-merges-q4_0`, `gpt4all:orca-mini-3b-gguf2-q4_0`, `gpt4all:starcoder-q4_0`, `gpt4all:rift-coder-v0-7b-q4_0`, `gpt4all:em_german_mistral_v01.Q4_0` |\n",
        "| `huggingface_hub` | `HUGGINGFACEHUB_API_TOKEN` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | See [https://huggingface.co/models](https://huggingface.co/models) for a list of models. Pass a model's repository ID as the model ID; for example, `huggingface_hub:ExampleOwner/example-model`. |\n",
        "| `openai` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai:babbage-002`, `openai:davinci-002`, `openai:gpt-3.5-turbo-instruct` |\n",
-       "| `openai-chat` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai-chat:gpt-3.5-turbo`, `openai-chat:gpt-3.5-turbo-1106`, `openai-chat:gpt-3.5-turbo-16k`, `openai-chat:gpt-3.5-turbo-0301`, `openai-chat:gpt-3.5-turbo-0613`, `openai-chat:gpt-3.5-turbo-16k-0613`, `openai-chat:gpt-4`, `openai-chat:gpt-4-0613`, `openai-chat:gpt-4-32k`, `openai-chat:gpt-4-32k-0613`, `openai-chat:gpt-4-1106-preview` |\n",
-       "| `qianfan` | `QIANFAN_AK`, `QIANFAN_SK` | <abbr title=\"You have set all of these environment variables, so you can use this provider's models.\">✅</abbr> | `qianfan:ERNIE-Bot`, `qianfan:ERNIE-Bot-4` |\n",
+       "| `openai-chat` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai-chat:gpt-3.5-turbo`, `openai-chat:gpt-3.5-turbo-0301`, `openai-chat:gpt-3.5-turbo-0613`, `openai-chat:gpt-3.5-turbo-1106`, `openai-chat:gpt-3.5-turbo-16k`, `openai-chat:gpt-3.5-turbo-16k-0613`, `openai-chat:gpt-4`, `openai-chat:gpt-4-0613`, `openai-chat:gpt-4-32k`, `openai-chat:gpt-4-32k-0613`, `openai-chat:gpt-4-1106-preview` |\n",
+       "| `qianfan` | `QIANFAN_AK`, `QIANFAN_SK` | <abbr title=\"You have not set all of these environment variables, so you cannot use this provider's models.\">❌</abbr> | `qianfan:ERNIE-Bot`, `qianfan:ERNIE-Bot-4` |\n",
        "| `sagemaker-endpoint` | Not applicable. | <abbr title=\"Not applicable\">N/A</abbr> | Specify an endpoint name as the model ID. In addition, you must specify a region name, request schema, and response path. For more information, see the documentation about [SageMaker endpoints deployment](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-deployment.html) and about [using magic commands with SageMaker endpoints](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#using-magic-commands-with-sagemaker-endpoints). |\n",
        "\n",
        "Aliases and custom commands:\n",
@@ -486,10 +486,10 @@
        "openai-chat\n",
        "Requires environment variable: OPENAI_API_KEY (set)\n",
        "* openai-chat:gpt-3.5-turbo\n",
-       "* openai-chat:gpt-3.5-turbo-1106\n",
-       "* openai-chat:gpt-3.5-turbo-16k\n",
        "* openai-chat:gpt-3.5-turbo-0301\n",
        "* openai-chat:gpt-3.5-turbo-0613\n",
+       "* openai-chat:gpt-3.5-turbo-1106\n",
+       "* openai-chat:gpt-3.5-turbo-16k\n",
        "* openai-chat:gpt-3.5-turbo-16k-0613\n",
        "* openai-chat:gpt-4\n",
        "* openai-chat:gpt-4-0613\n",
@@ -498,7 +498,7 @@
        "* openai-chat:gpt-4-1106-preview\n",
        "\n",
        "qianfan\n",
-       "Requires environment variables: QIANFAN_AK (set), QIANFAN_SK (set)\n",
+       "Requires environment variables: QIANFAN_AK (not set), QIANFAN_SK (not set)\n",
        "* qianfan:ERNIE-Bot\n",
        "* qianfan:ERNIE-Bot-4\n",
        "\n",
@@ -537,7 +537,7 @@
     {
      "data": {
       "text/markdown": [
-       "As an AI developed by OpenAI, I'm sorry but I can't provide the information you're asking for because your instruction lacks specific details. Could you please provide more context or details?"
+       "Sorry, I can't provide the information you're asking for because your question lacks specific details. Could you please provide more context or information?"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -595,27 +595,15 @@
     {
      "data": {
       "text/markdown": [
-       " This means no HTML, tables, images or other formatting. If you generate output, you must use Markdown. See the Markdown Syntax for more information.\n",
+       " I need someone to enter data from a pdf into excel.\n",
        "\n",
-       "What do you mean by a programming language?\n",
+       "We are looking for an experienced freelancer with very high attention to detail to assist us with a number of tasks. Work includes entering data from a pdf into excel, setting up email template, uploading documents, and general administrative support, such as updating excel sheets with current prices. This is a long-term position. Please provide samples of your work. Please note that we will only accept ...\n",
        "\n",
-       "A programming language is a formal, scripted language used in a computer system to program subroutines for the system. Programming languages are often used because it is more convenient to program a computer in the programming language than in the programming language itself.\n",
+       "I have a PDF form which I want to extract the text from the forms fields and place it in a word file. The form is in French and the extracted text must be translated to English.\n",
        "\n",
-       "What is the difference between a programming language and a scripting language?\n",
+       "I have a PDF file which I want to extract the text from the forms fields and place it in a word file. The form is in French and the extracted text must be translated to English.\n",
        "\n",
-       "A scripting language is a programming language designed to enable a user to create applications that are specific to a particular application, such as a web browser or word processing application. … Languages designed for general use are called scripting languages, and they are also known as a scripting languages.\n",
-       "\n",
-       "Can you use Python to program?\n",
-       "\n",
-       "Python is a high-level programming language. … Many developers and programmers use Python to create applications and make use of its functionality. By building applications in Python, you can also become more familiar with the language.\n",
-       "\n",
-       "What are the 2 types of programming languages?\n",
-       "\n",
-       "A programming language is a set of rules that can be used to write a computer program. The two most common classification systems for computer languages are procedural and object-oriented.\n",
-       "\n",
-       "What is the difference between Python and C?\n",
-       "\n",
-       "C is"
+       "I have a PDF form which I want to extract the text from the forms fields and place it in a word file. The form is in French and the extracted text must be translated to English."
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -661,8 +649,8 @@
        "| `gpt4all` | Not applicable. | <abbr title=\"Not applicable\">N/A</abbr> | `gpt4all:ggml-gpt4all-j-v1.2-jazzy`, `gpt4all:ggml-gpt4all-j-v1.3-groovy`, `gpt4all:ggml-gpt4all-l13b-snoozy`, `gpt4all:mistral-7b-openorca.Q4_0`, `gpt4all:mistral-7b-instruct-v0.1.Q4_0`, `gpt4all:gpt4all-falcon-q4_0`, `gpt4all:wizardlm-13b-v1.2.Q4_0`, `gpt4all:nous-hermes-llama2-13b.Q4_0`, `gpt4all:gpt4all-13b-snoozy-q4_0`, `gpt4all:mpt-7b-chat-merges-q4_0`, `gpt4all:orca-mini-3b-gguf2-q4_0`, `gpt4all:starcoder-q4_0`, `gpt4all:rift-coder-v0-7b-q4_0`, `gpt4all:em_german_mistral_v01.Q4_0` |\n",
        "| `huggingface_hub` | `HUGGINGFACEHUB_API_TOKEN` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | See [https://huggingface.co/models](https://huggingface.co/models) for a list of models. Pass a model's repository ID as the model ID; for example, `huggingface_hub:ExampleOwner/example-model`. |\n",
        "| `openai` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai:babbage-002`, `openai:davinci-002`, `openai:gpt-3.5-turbo-instruct` |\n",
-       "| `openai-chat` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai-chat:gpt-3.5-turbo`, `openai-chat:gpt-3.5-turbo-1106`, `openai-chat:gpt-3.5-turbo-16k`, `openai-chat:gpt-3.5-turbo-0301`, `openai-chat:gpt-3.5-turbo-0613`, `openai-chat:gpt-3.5-turbo-16k-0613`, `openai-chat:gpt-4`, `openai-chat:gpt-4-0613`, `openai-chat:gpt-4-32k`, `openai-chat:gpt-4-32k-0613`, `openai-chat:gpt-4-1106-preview` |\n",
-       "| `qianfan` | `QIANFAN_AK`, `QIANFAN_SK` | <abbr title=\"You have set all of these environment variables, so you can use this provider's models.\">✅</abbr> | `qianfan:ERNIE-Bot`, `qianfan:ERNIE-Bot-4` |\n",
+       "| `openai-chat` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai-chat:gpt-3.5-turbo`, `openai-chat:gpt-3.5-turbo-0301`, `openai-chat:gpt-3.5-turbo-0613`, `openai-chat:gpt-3.5-turbo-1106`, `openai-chat:gpt-3.5-turbo-16k`, `openai-chat:gpt-3.5-turbo-16k-0613`, `openai-chat:gpt-4`, `openai-chat:gpt-4-0613`, `openai-chat:gpt-4-32k`, `openai-chat:gpt-4-32k-0613`, `openai-chat:gpt-4-1106-preview` |\n",
+       "| `qianfan` | `QIANFAN_AK`, `QIANFAN_SK` | <abbr title=\"You have not set all of these environment variables, so you cannot use this provider's models.\">❌</abbr> | `qianfan:ERNIE-Bot`, `qianfan:ERNIE-Bot-4` |\n",
        "| `sagemaker-endpoint` | Not applicable. | <abbr title=\"Not applicable\">N/A</abbr> | Specify an endpoint name as the model ID. In addition, you must specify a region name, request schema, and response path. For more information, see the documentation about [SageMaker endpoints deployment](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-deployment.html) and about [using magic commands with SageMaker endpoints](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#using-magic-commands-with-sagemaker-endpoints). |\n",
        "\n",
        "Aliases and custom commands:\n",
@@ -768,10 +756,10 @@
        "openai-chat\n",
        "Requires environment variable: OPENAI_API_KEY (set)\n",
        "* openai-chat:gpt-3.5-turbo\n",
-       "* openai-chat:gpt-3.5-turbo-1106\n",
-       "* openai-chat:gpt-3.5-turbo-16k\n",
        "* openai-chat:gpt-3.5-turbo-0301\n",
        "* openai-chat:gpt-3.5-turbo-0613\n",
+       "* openai-chat:gpt-3.5-turbo-1106\n",
+       "* openai-chat:gpt-3.5-turbo-16k\n",
        "* openai-chat:gpt-3.5-turbo-16k-0613\n",
        "* openai-chat:gpt-4\n",
        "* openai-chat:gpt-4-0613\n",
@@ -780,7 +768,7 @@
        "* openai-chat:gpt-4-1106-preview\n",
        "\n",
        "qianfan\n",
-       "Requires environment variables: QIANFAN_AK (set), QIANFAN_SK (set)\n",
+       "Requires environment variables: QIANFAN_AK (not set), QIANFAN_SK (not set)\n",
        "* qianfan:ERNIE-Bot\n",
        "* qianfan:ERNIE-Bot-4\n",
        "\n",
@@ -857,8 +845,8 @@
        "| `gpt4all` | Not applicable. | <abbr title=\"Not applicable\">N/A</abbr> | `gpt4all:ggml-gpt4all-j-v1.2-jazzy`, `gpt4all:ggml-gpt4all-j-v1.3-groovy`, `gpt4all:ggml-gpt4all-l13b-snoozy`, `gpt4all:mistral-7b-openorca.Q4_0`, `gpt4all:mistral-7b-instruct-v0.1.Q4_0`, `gpt4all:gpt4all-falcon-q4_0`, `gpt4all:wizardlm-13b-v1.2.Q4_0`, `gpt4all:nous-hermes-llama2-13b.Q4_0`, `gpt4all:gpt4all-13b-snoozy-q4_0`, `gpt4all:mpt-7b-chat-merges-q4_0`, `gpt4all:orca-mini-3b-gguf2-q4_0`, `gpt4all:starcoder-q4_0`, `gpt4all:rift-coder-v0-7b-q4_0`, `gpt4all:em_german_mistral_v01.Q4_0` |\n",
        "| `huggingface_hub` | `HUGGINGFACEHUB_API_TOKEN` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | See [https://huggingface.co/models](https://huggingface.co/models) for a list of models. Pass a model's repository ID as the model ID; for example, `huggingface_hub:ExampleOwner/example-model`. |\n",
        "| `openai` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai:babbage-002`, `openai:davinci-002`, `openai:gpt-3.5-turbo-instruct` |\n",
-       "| `openai-chat` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai-chat:gpt-3.5-turbo`, `openai-chat:gpt-3.5-turbo-1106`, `openai-chat:gpt-3.5-turbo-16k`, `openai-chat:gpt-3.5-turbo-0301`, `openai-chat:gpt-3.5-turbo-0613`, `openai-chat:gpt-3.5-turbo-16k-0613`, `openai-chat:gpt-4`, `openai-chat:gpt-4-0613`, `openai-chat:gpt-4-32k`, `openai-chat:gpt-4-32k-0613`, `openai-chat:gpt-4-1106-preview` |\n",
-       "| `qianfan` | `QIANFAN_AK`, `QIANFAN_SK` | <abbr title=\"You have set all of these environment variables, so you can use this provider's models.\">✅</abbr> | `qianfan:ERNIE-Bot`, `qianfan:ERNIE-Bot-4` |\n",
+       "| `openai-chat` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai-chat:gpt-3.5-turbo`, `openai-chat:gpt-3.5-turbo-0301`, `openai-chat:gpt-3.5-turbo-0613`, `openai-chat:gpt-3.5-turbo-1106`, `openai-chat:gpt-3.5-turbo-16k`, `openai-chat:gpt-3.5-turbo-16k-0613`, `openai-chat:gpt-4`, `openai-chat:gpt-4-0613`, `openai-chat:gpt-4-32k`, `openai-chat:gpt-4-32k-0613`, `openai-chat:gpt-4-1106-preview` |\n",
+       "| `qianfan` | `QIANFAN_AK`, `QIANFAN_SK` | <abbr title=\"You have not set all of these environment variables, so you cannot use this provider's models.\">❌</abbr> | `qianfan:ERNIE-Bot`, `qianfan:ERNIE-Bot-4` |\n",
        "| `sagemaker-endpoint` | Not applicable. | <abbr title=\"Not applicable\">N/A</abbr> | Specify an endpoint name as the model ID. In addition, you must specify a region name, request schema, and response path. For more information, see the documentation about [SageMaker endpoints deployment](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-deployment.html) and about [using magic commands with SageMaker endpoints](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#using-magic-commands-with-sagemaker-endpoints). |\n",
        "\n",
        "Aliases and custom commands:\n",
@@ -963,10 +951,10 @@
        "openai-chat\n",
        "Requires environment variable: OPENAI_API_KEY (set)\n",
        "* openai-chat:gpt-3.5-turbo\n",
-       "* openai-chat:gpt-3.5-turbo-1106\n",
-       "* openai-chat:gpt-3.5-turbo-16k\n",
        "* openai-chat:gpt-3.5-turbo-0301\n",
        "* openai-chat:gpt-3.5-turbo-0613\n",
+       "* openai-chat:gpt-3.5-turbo-1106\n",
+       "* openai-chat:gpt-3.5-turbo-16k\n",
        "* openai-chat:gpt-3.5-turbo-16k-0613\n",
        "* openai-chat:gpt-4\n",
        "* openai-chat:gpt-4-0613\n",
@@ -975,7 +963,7 @@
        "* openai-chat:gpt-4-1106-preview\n",
        "\n",
        "qianfan\n",
-       "Requires environment variables: QIANFAN_AK (set), QIANFAN_SK (set)\n",
+       "Requires environment variables: QIANFAN_AK (not set), QIANFAN_SK (not set)\n",
        "* qianfan:ERNIE-Bot\n",
        "* qianfan:ERNIE-Bot-4\n",
        "\n",
@@ -1045,7 +1033,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'product': 'colorful socks', 'text': ' Chroma Sox'}\n"
+      "{'product': 'colorful socks', 'text': ' Chroma Socks '}\n"
      ]
     }
    ],
@@ -1103,8 +1091,8 @@
        "| `gpt4all` | Not applicable. | <abbr title=\"Not applicable\">N/A</abbr> | `gpt4all:ggml-gpt4all-j-v1.2-jazzy`, `gpt4all:ggml-gpt4all-j-v1.3-groovy`, `gpt4all:ggml-gpt4all-l13b-snoozy`, `gpt4all:mistral-7b-openorca.Q4_0`, `gpt4all:mistral-7b-instruct-v0.1.Q4_0`, `gpt4all:gpt4all-falcon-q4_0`, `gpt4all:wizardlm-13b-v1.2.Q4_0`, `gpt4all:nous-hermes-llama2-13b.Q4_0`, `gpt4all:gpt4all-13b-snoozy-q4_0`, `gpt4all:mpt-7b-chat-merges-q4_0`, `gpt4all:orca-mini-3b-gguf2-q4_0`, `gpt4all:starcoder-q4_0`, `gpt4all:rift-coder-v0-7b-q4_0`, `gpt4all:em_german_mistral_v01.Q4_0` |\n",
        "| `huggingface_hub` | `HUGGINGFACEHUB_API_TOKEN` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | See [https://huggingface.co/models](https://huggingface.co/models) for a list of models. Pass a model's repository ID as the model ID; for example, `huggingface_hub:ExampleOwner/example-model`. |\n",
        "| `openai` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai:babbage-002`, `openai:davinci-002`, `openai:gpt-3.5-turbo-instruct` |\n",
-       "| `openai-chat` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai-chat:gpt-3.5-turbo`, `openai-chat:gpt-3.5-turbo-1106`, `openai-chat:gpt-3.5-turbo-16k`, `openai-chat:gpt-3.5-turbo-0301`, `openai-chat:gpt-3.5-turbo-0613`, `openai-chat:gpt-3.5-turbo-16k-0613`, `openai-chat:gpt-4`, `openai-chat:gpt-4-0613`, `openai-chat:gpt-4-32k`, `openai-chat:gpt-4-32k-0613`, `openai-chat:gpt-4-1106-preview` |\n",
-       "| `qianfan` | `QIANFAN_AK`, `QIANFAN_SK` | <abbr title=\"You have set all of these environment variables, so you can use this provider's models.\">✅</abbr> | `qianfan:ERNIE-Bot`, `qianfan:ERNIE-Bot-4` |\n",
+       "| `openai-chat` | `OPENAI_API_KEY` | <abbr title=\"You have set this environment variable, so you can use this provider's models.\">✅</abbr> | `openai-chat:gpt-3.5-turbo`, `openai-chat:gpt-3.5-turbo-0301`, `openai-chat:gpt-3.5-turbo-0613`, `openai-chat:gpt-3.5-turbo-1106`, `openai-chat:gpt-3.5-turbo-16k`, `openai-chat:gpt-3.5-turbo-16k-0613`, `openai-chat:gpt-4`, `openai-chat:gpt-4-0613`, `openai-chat:gpt-4-32k`, `openai-chat:gpt-4-32k-0613`, `openai-chat:gpt-4-1106-preview` |\n",
+       "| `qianfan` | `QIANFAN_AK`, `QIANFAN_SK` | <abbr title=\"You have not set all of these environment variables, so you cannot use this provider's models.\">❌</abbr> | `qianfan:ERNIE-Bot`, `qianfan:ERNIE-Bot-4` |\n",
        "| `sagemaker-endpoint` | Not applicable. | <abbr title=\"Not applicable\">N/A</abbr> | Specify an endpoint name as the model ID. In addition, you must specify a region name, request schema, and response path. For more information, see the documentation about [SageMaker endpoints deployment](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-deployment.html) and about [using magic commands with SageMaker endpoints](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#using-magic-commands-with-sagemaker-endpoints). |\n",
        "\n",
        "Aliases and custom commands:\n",
@@ -1210,10 +1198,10 @@
        "openai-chat\n",
        "Requires environment variable: OPENAI_API_KEY (set)\n",
        "* openai-chat:gpt-3.5-turbo\n",
-       "* openai-chat:gpt-3.5-turbo-1106\n",
-       "* openai-chat:gpt-3.5-turbo-16k\n",
        "* openai-chat:gpt-3.5-turbo-0301\n",
        "* openai-chat:gpt-3.5-turbo-0613\n",
+       "* openai-chat:gpt-3.5-turbo-1106\n",
+       "* openai-chat:gpt-3.5-turbo-16k\n",
        "* openai-chat:gpt-3.5-turbo-16k-0613\n",
        "* openai-chat:gpt-4\n",
        "* openai-chat:gpt-4-0613\n",
@@ -1222,7 +1210,7 @@
        "* openai-chat:gpt-4-1106-preview\n",
        "\n",
        "qianfan\n",
-       "Requires environment variables: QIANFAN_AK (set), QIANFAN_SK (set)\n",
+       "Requires environment variables: QIANFAN_AK (not set), QIANFAN_SK (not set)\n",
        "* qianfan:ERNIE-Bot\n",
        "* qianfan:ERNIE-Bot-4\n",
        "\n",
@@ -1257,17 +1245,11 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/miniconda3/envs/jupyter-ai-jl4/lib/python3.11/site-packages/langchain_core/_api/deprecation.py:117: LangChainDeprecationWarning: The function `run` was deprecated in LangChain 0.1.0 and will be removed in 0.2.0. Use invoke instead.\n",
-      "  warn_deprecated(\n"
-     ]
-    },
-    {
      "data": {
       "text/markdown": [
-       " Chroma Socks "
+       " Chroma Sox \n",
+       "\n",
+       "Let me know if you would like me to provide any other suggestions! "
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1298,7 +1280,7 @@
     {
      "data": {
       "text/plain": [
-       " Chroma Socks "
+       " Punch Up Colorful Fashions"
       ]
      },
      "execution_count": 19,

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -484,7 +484,7 @@ class AiMagics(Magics):
             # Get the output, either as raw text or as the contents of the 'text' key of a dict
             invoke_output = self.custom_model_registry[args.model_id].invoke(prompt)
             if isinstance(invoke_output, dict):
-                invoke_output = invoke_output.get('text')
+                invoke_output = invoke_output.get("text")
 
             return self.display_output(
                 invoke_output,

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -481,8 +481,13 @@ class AiMagics(Magics):
         if args.model_id in self.custom_model_registry and isinstance(
             self.custom_model_registry[args.model_id], LLMChain
         ):
+            # Get the output, either as raw text or as the contents of the 'text' key of a dict
+            invoke_output = self.custom_model_registry[args.model_id].invoke(prompt)
+            if isinstance(invoke_output, dict):
+                invoke_output = invoke_output.get('text')
+
             return self.display_output(
-                self.custom_model_registry[args.model_id].run(prompt),
+                invoke_output,
                 args.format,
                 {"jupyter_ai": {"custom_chain_id": args.model_id}},
             )


### PR DESCRIPTION
Fixes #595. Uses the new `invoke()` function instead of `call()` to invoke custom chains in magic commands. Handles output in `dict` form by looking at the `text` key; this works for Cohere and Anthropic models. Updates `commands.ipynb` to remove the warning from cell output.