### PR TITLE
fix to conda install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ As an alternative to using `pip`, you can install `jupyter-ai` using
 [Conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
 from the `conda-forge` channel:
 
-    $ conda install -c conda-forge jupyter_ai
+    $ conda install conda-forge::jupyter-ai
 
 ## The `%%ai` magic command
 


### PR DESCRIPTION
The current instructions for installing jupyter-ai with conda/mamba are wrong.

This is a simple change to the readme to bring it inline with instructions found on [conda-forge](https://anaconda.org/conda-forge/jupyter-ai)

