### PR TITLE
Mentions conda install instructions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,20 @@ for details on installing and using Jupyter AI.
 
 If you want to install both the `%%ai` magic and the JupyterLab extension, you can run:
 
-    $ pip install jupyter_ai
+    $ pip install jupyter-ai
 
 If you are not using JupyterLab and you only want to install the Jupyter AI `%%ai` magic, you can run:
 
-    $ pip install jupyter_ai_magics
+    $ pip install jupyter-ai-magics
 
 
 ### With conda
 
 As an alternative to using `pip`, you can install `jupyter-ai` using
 [Conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
-from the `conda-forge` channel:
+from the `conda-forge` channel, using one of the following two commands:
 
+    $ conda install -c conda-force jupyter-ai  # or,
     $ conda install conda-forge::jupyter-ai
 
 ## The `%%ai` magic command

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -62,24 +62,24 @@ classes in their code.
 To install the JupyterLab extension, you can run:
 
 ```
-pip install jupyter_ai
+pip install jupyter-ai
 ```
 
-The latest major version of `jupyter_ai`, v2, only supports JupyterLab 4. If you
-need support for JupyterLab 3, you should install `jupyter_ai` v1 instead:
+The latest major version of `jupyter-ai`, v2, only supports JupyterLab 4. If you
+need support for JupyterLab 3, you should install `jupyter-ai` v1 instead:
 
 ```
-pip install jupyter_ai~=1.0
+pip install jupyter-ai~=1.0
 ```
 
 If you are not using JupyterLab and you only want to install the Jupyter AI `%%ai` magic, you can run:
 
 ```
-$ pip install jupyter_ai_magics
+$ pip install jupyter-ai-magics
 ```
 
-`jupyter_ai` depends on `jupyter_ai_magics`, so installing `jupyter_ai`
-automatically installs `jupyter_ai_magics`.
+`jupyter-ai` depends on `jupyter-ai-magics`, so installing `jupyter-ai`
+automatically installs `jupyter-ai-magics`.
 
 ### Installation via `pip` or `conda` in a Conda environment (recommended)
 
@@ -97,12 +97,9 @@ and create an environment that uses Python 3.11:
 Then, use either `pip` or `conda` to install JupyterLab and Jupyter AI in this
 Conda environment.
 
-    $ pip install jupyter_ai                   # or,
+    $ pip install jupyter-ai                   # or,
     $ conda install -c conda-forge jupyter-ai  # or,
     $ conda install conda-forge::jupyter-ai
-
-Note that the `pip` package name is `jupyter_ai` with an underscore, and that
-the `conda` package name is `jupyter-ai` with a hyphen.
 
 When starting JupyterLab with Jupyter AI, make sure to activate the Conda
 environment first:
@@ -116,11 +113,11 @@ jupyter lab
 
 If you installed Jupyter AI using `pip`, to remove the extension, run:
 
-    $ pip uninstall jupyter_ai
+    $ pip uninstall jupyter-ai
 
 or
 
-    $ pip uninstall jupyter_ai_magics
+    $ pip uninstall jupyter-ai-magics
 
 If you installed Jupyter AI using `conda`, you can remove it by running:
 
@@ -129,9 +126,6 @@ If you installed Jupyter AI using `conda`, you can remove it by running:
 or
 
     $ conda remove jupyter-ai-magics
-
-Note that the `pip` package names use underscores, and the `conda` package
-names use hyphens.
 
 ## Model providers
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -94,10 +94,8 @@ and create an environment that uses Python 3.11:
     $ conda create -n jupyter-ai python=3.11
     $ conda activate jupyter-ai
 
-Then, use either `pip` or `conda` to install JupyterLab and Jupyter AI in this
-Conda environment.
+Then, use `conda` to install JupyterLab and Jupyter AI in this Conda environment.
 
-    $ pip install jupyter-ai                   # or,
     $ conda install -c conda-forge jupyter-ai  # or,
     $ conda install conda-forge::jupyter-ai
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -114,13 +114,24 @@ jupyter lab
 
 ## Uninstallation
 
-To remove the extension, run:
+If you installed Jupyter AI using `pip`, to remove the extension, run:
 
     $ pip uninstall jupyter_ai
 
 or
 
     $ pip uninstall jupyter_ai_magics
+
+If you installed Jupyter AI using `conda`, you can remove it by running:
+
+    $ conda remove jupyter-ai
+
+or
+
+    $ conda remove jupyter-ai-magics
+
+Note that the `pip` package names use underscores, and the `conda` package
+names use hyphens.
 
 ## Model providers
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -81,7 +81,7 @@ $ pip install jupyter_ai_magics
 `jupyter_ai` depends on `jupyter_ai_magics`, so installing `jupyter_ai`
 automatically installs `jupyter_ai_magics`.
 
-### Installation via `pip` within Conda environment (recommended)
+### Installation via `pip` or `conda` in a Conda environment (recommended)
 
 We highly recommend installing both JupyterLab and Jupyter AI within an isolated
 Conda environment to avoid clobbering Python packages in your existing Python
@@ -93,10 +93,16 @@ and create an environment that uses Python 3.11:
 
     $ conda create -n jupyter-ai python=3.11
     $ conda activate jupyter-ai
-    $ pip install jupyter_ai
 
-Then, follow the steps from "Requirements" and "Installation via `pip`" to
-install JupyterLab and Jupyter AI in this Conda environment.
+Then, use either `pip` or `conda` to install JupyterLab and Jupyter AI in this
+Conda environment.
+
+    $ pip install jupyter_ai                   # or,
+    $ conda install -c conda-forge jupyter-ai  # or,
+    $ conda install conda-forge::jupyter-ai
+
+Note that the `pip` package name is `jupyter_ai` with an underscore, and that
+the `conda` package name is `jupyter-ai` with a hyphen.
 
 When starting JupyterLab with Jupyter AI, make sure to activate the Conda
 environment first:


### PR DESCRIPTION
As a follow-up to #610, this modifies the main user docs to mention that users can install Jupyter AI using either `pip` or `conda`. We used to only include `pip` installation instructions.