### PR TITLE
Allow usage without NVIDIA partner package

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
@@ -22,7 +22,6 @@ from .providers import (
     BedrockChatProvider,
     BedrockProvider,
     ChatAnthropicProvider,
-    ChatNVIDIAProvider,
     ChatOpenAIProvider,
     CohereProvider,
     GPT4AllProvider,

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/nvidia.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/nvidia.py
@@ -1,0 +1,23 @@
+from jupyter_ai_magics.providers import BaseProvider, EnvAuthStrategy
+from langchain_nvidia_ai_endpoints import ChatNVIDIA
+
+
+class ChatNVIDIAProvider(BaseProvider, ChatNVIDIA):
+    id = "nvidia-chat"
+    name = "NVIDIA"
+    models = [
+        "playground_llama2_70b",
+        "playground_nemotron_steerlm_8b",
+        "playground_mistral_7b",
+        "playground_nv_llama2_rlhf_70b",
+        "playground_llama2_13b",
+        "playground_steerlm_llama_70b",
+        "playground_llama2_code_13b",
+        "playground_yi_34b",
+        "playground_mixtral_8x7b",
+        "playground_neva_22b",
+        "playground_llama2_code_34b",
+    ]
+    model_id_key = "model"
+    auth_strategy = EnvAuthStrategy(name="NVIDIA_API_KEY")
+    pypi_package_deps = ["langchain_nvidia_ai_endpoints"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -38,7 +38,6 @@ from langchain_community.llms import (
     OpenAI,
     SagemakerEndpoint,
 )
-from langchain_nvidia_ai_endpoints import ChatNVIDIA
 
 # this is necessary because `langchain.pydantic_v1.main` does not include
 # `ModelMetaclass`, as it is not listed in `__all__` by the `pydantic.main`
@@ -859,23 +858,3 @@ class QianfanProvider(BaseProvider, QianfanChatEndpoint):
     model_id_key = "model_name"
     pypi_package_deps = ["qianfan"]
     auth_strategy = MultiEnvAuthStrategy(names=["QIANFAN_AK", "QIANFAN_SK"])
-
-
-class ChatNVIDIAProvider(BaseProvider, ChatNVIDIA):
-    id = "nvidia-chat"
-    name = "NVIDIA"
-    models = [
-        "playground_llama2_70b",
-        "playground_nemotron_steerlm_8b",
-        "playground_mistral_7b",
-        "playground_nv_llama2_rlhf_70b",
-        "playground_llama2_13b",
-        "playground_steerlm_llama_70b",
-        "playground_llama2_code_13b",
-        "playground_yi_34b",
-        "playground_mixtral_8x7b",
-        "playground_neva_22b",
-        "playground_llama2_code_34b",
-    ]
-    model_id_key = "model"
-    auth_strategy = EnvAuthStrategy(name="NVIDIA_API_KEY")

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
@@ -26,16 +26,22 @@ def get_lm_providers(
         restrictions = {"allowed_providers": None, "blocked_providers": None}
     providers = {}
     eps = entry_points()
-    model_provider_eps = eps.select(group="jupyter_ai.model_providers")
-    for model_provider_ep in model_provider_eps:
+    provider_ep_group = eps.select(group="jupyter_ai.model_providers")
+    for provider_ep in provider_ep_group:
         try:
-            provider = model_provider_ep.load()
-        except Exception as e:
-            log.error(
-                f"Unable to load model provider class from entry point `{model_provider_ep.name}`: %s.",
-                e,
+            provider = provider_ep.load()
+        except ImportError as e:
+            log.warning(
+                f"Unable to load model provider `{provider_ep.name}`. Please install the `{e.name}` package."
             )
             continue
+        except Exception as e:
+            log.error(
+                f"Unable to load model provider `{provider_ep.name}`. Printing full exception below."
+            )
+            log.exception(e)
+            continue
+
         if not is_provider_allowed(provider.id, restrictions):
             log.info(f"Skipping blocked provider `{provider.id}`.")
             continue

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -62,7 +62,7 @@ amazon-bedrock = "jupyter_ai_magics:BedrockProvider"
 anthropic-chat = "jupyter_ai_magics:ChatAnthropicProvider"
 amazon-bedrock-chat = "jupyter_ai_magics:BedrockChatProvider"
 qianfan = "jupyter_ai_magics:QianfanProvider"
-nvidia-chat = "jupyter_ai_magics:ChatNVIDIAProvider"
+nvidia-chat = "jupyter_ai_magics.partner_providers.nvidia:ChatNVIDIAProvider"
 
 [project.entry-points."jupyter_ai.embeddings_model_providers"]
 bedrock = "jupyter_ai_magics:BedrockEmbeddingsProvider"


### PR DESCRIPTION
### Issue

#579 added a change that imports the partner package `langchain_nvidia_ai_endpoints` directly, which causes an `ImportError` to be raised when importing `jupyter_ai` without the partner package installed in the same environment.

```
[W 2024-02-06 06:22:34.590 ServerApp] jupyter_ai | error adding extension (enabled: True): The module 'jupyter_ai' could not be found (No module named 'langchain_nvidia_ai_endpoints'). Are you sure the extension is installed?
    Traceback (most recent call last):
      File "/Users/dlq/micromamba/envs/jai/lib/python3.11/site-packages/jupyter_server/extension/manager.py", line 322, in add_extension
        extpkg = ExtensionPackage(name=extension_name, enabled=enabled)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/dlq/micromamba/envs/jai/lib/python3.11/site-packages/jupyter_server/extension/manager.py", line 186, in __init__
        self._load_metadata()
      File "/Users/dlq/micromamba/envs/jai/lib/python3.11/site-packages/jupyter_server/extension/manager.py", line 201, in _load_metadata
        raise ExtensionModuleNotFound(msg) from None
    jupyter_server.extension.utils.ExtensionModuleNotFound: The module 'jupyter_ai' could not be found (No module named 'langchain_nvidia_ai_endpoints'). Are you sure the extension is installed?
```

### PR description

This PR fixes that issue by defining the NVIDIA provider in an isolated module that is not imported by anything else in `jupyter_ai_magics`. This allows that module to import from `langchain_nvidia_ai_endpoints` directly. This branch also catches any `ImportError` raised while loading the entry points and prints a short helpful warning to the terminal:

```
[W 2024-02-06 07:16:40.368 AiExtension] Unable to load model provider `nvidia-chat`. Please install the `langchain_nvidia_ai_endpoints` package.
```

### Reviewing this PR

You will need to re-install the package, then test both cases:

```sh
jlpm dev-uninstall && jlpm dev-install
jupyter lab # test case with partner package installed
pip uninstall langchain_nvidia_ai_endpoints
jupyter lab # test case with partner package uninstalled
```

### Callout for future work

One issue with this PR is that it breaks our provider convention where everything is re-exposed at the top-level package. That is, the statement

```
from jupyter_ai_magics import <provider>
```

works for `AI21Provider`, but fails for `ChatNVIDIAProvider`.

In the future, I actually would like to revert our convention of exposing all the providers at the package root. We only do so now because I thought that entry points could only be exposed from the package root, which is untrue. This effort would require first removing all of these imports from `packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py`:

```
# expose model providers on the package root
from .providers import (
    AI21Provider,
    AnthropicProvider,
    AzureChatOpenAIProvider,
    ...
)
```

Then, editing each entry point definition from:

```
ai21 = "jupyter_ai_magics:AI21Provider"
```

To a definition that specifies the source module directly:

```
ai21 = "jupyter_ai_magics.providers:AI21Provider"
```