### PR TITLE
Add new OpenAI models

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -668,8 +668,7 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
         "gpt-4-0613",
         "gpt-4-32k",
         "gpt-4-32k-0613",
-        "gpt-4-0125-preview"
-        "gpt-4-1106-preview",
+        "gpt-4-0125-preview" "gpt-4-1106-preview",
     ]
     model_id_key = "model_name"
     pypi_package_deps = ["openai"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -657,15 +657,18 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
     name = "OpenAI"
     models = [
         "gpt-3.5-turbo",
+        "gpt-3.5-turbo-0125",
         "gpt-3.5-turbo-0301",  # Deprecated as of 2024-06-13
         "gpt-3.5-turbo-0613",  # Deprecated as of 2024-06-13
         "gpt-3.5-turbo-1106",
         "gpt-3.5-turbo-16k",
         "gpt-3.5-turbo-16k-0613",  # Deprecated as of 2024-06-13
         "gpt-4",
+        "gpt-4-turbo-preview",
         "gpt-4-0613",
         "gpt-4-32k",
         "gpt-4-32k-0613",
+        "gpt-4-0125-preview"
         "gpt-4-1106-preview",
     ]
     model_id_key = "model_name"

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -668,7 +668,8 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
         "gpt-4-0613",
         "gpt-4-32k",
         "gpt-4-32k-0613",
-        "gpt-4-0125-preview" "gpt-4-1106-preview",
+        "gpt-4-0125-preview",
+        "gpt-4-1106-preview",
     ]
     model_id_key = "model_name"
     pypi_package_deps = ["openai"]


### PR DESCRIPTION
Added new OpenAI models gpt-3.5-turbo-0125, gpt-4-0125-preview, and gpt-4-turbo-preview (currently points to 0125-preview)