### PR TITLE
Add OpenAI text-embedding-3-small, -large models

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -71,7 +71,7 @@ class BaseEmbeddingsProvider(BaseModel):
 class OpenAIEmbeddingsProvider(BaseEmbeddingsProvider, OpenAIEmbeddings):
     id = "openai"
     name = "OpenAI"
-    models = ["text-embedding-ada-002"]
+    models = ["text-embedding-ada-002", "text-embedding-3-small", "text-embedding-3-large"]
     model_id_key = "model"
     pypi_package_deps = ["openai"]
     auth_strategy = EnvAuthStrategy(name="OPENAI_API_KEY")

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -71,7 +71,11 @@ class BaseEmbeddingsProvider(BaseModel):
 class OpenAIEmbeddingsProvider(BaseEmbeddingsProvider, OpenAIEmbeddings):
     id = "openai"
     name = "OpenAI"
-    models = ["text-embedding-ada-002", "text-embedding-3-small", "text-embedding-3-large"]
+    models = [
+        "text-embedding-ada-002",
+        "text-embedding-3-small",
+        "text-embedding-3-large",
+    ]
     model_id_key = "model"
     pypi_package_deps = ["openai"]
     auth_strategy = EnvAuthStrategy(name="OPENAI_API_KEY")


### PR DESCRIPTION
Adds two new 3rd-generation (gen-3) embedding models for OpenAI embeddings: `text-embedding-3-small` and `text-embedding-3-large`.

When I try to select and use one of the new models, it works, but I get a warning: `Warning: model not found. Using cl100k_base encoding`. This comes from `tiktoken` and is fixed by https://github.com/openai/tiktoken/pull/247, which uses the same `cl100k_base` encoding as mentioned in the warning.