### PR TITLE
Fixes custom model parameter overrides in config

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -43,8 +43,7 @@ class AskChatHandler(BaseChatHandler):
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]
     ):
-        model_parameters = self.get_model_parameters(provider, provider_params)
-        self.llm = provider(**provider_params, **model_parameters)
+        self.llm = provider(**provider_params)
         memory = ConversationBufferWindowMemory(
             memory_key="chat_history", return_messages=True, k=2
         )

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -23,8 +23,7 @@ class DefaultChatHandler(BaseChatHandler):
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]
     ):
-        model_parameters = self.get_model_parameters(provider, provider_params)
-        llm = provider(**provider_params, **model_parameters)
+        llm = provider(**provider_params)
 
         prompt_template = llm.get_chat_prompt_template()
         self.memory = ConversationBufferWindowMemory(

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
@@ -236,8 +236,7 @@ class GenerateChatHandler(BaseChatHandler):
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]
     ):
-        model_parameters = self.get_model_parameters(provider, provider_params)
-        llm = provider(**provider_params, **model_parameters)
+        llm = provider(**provider_params)
 
         self.llm = llm
         return llm

--- a/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
@@ -28,8 +28,7 @@ class DefaultInlineCompletionHandler(BaseInlineCompletionHandler):
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]
     ):
-        model_parameters = self.get_model_parameters(provider, provider_params)
-        llm = provider(**provider_params, **model_parameters)
+        llm = provider(**provider_params)
 
         prompt_template = llm.get_completion_prompt_template()
 


### PR DESCRIPTION
Removes model_parameters, which were redundant with provider_params, from chat and completion code. Fixes #624.

Tested by passing a custom model parameter in my JupyterLab config:

`jupyter lab --AiExtension.model_parameters openai-chat:gpt-4-1106-preview='{"max_tokens": 4095}'`

In the chat UI and the completion interface, this model now works. Temporarily added log statements confirm that the custom parameter is included in the `llm` object exactly once.

`model_parameters` was _not_ redundant with `provider_params` in the magic command handler, so it is not modified. Magic commands with a model with custom model config continue to work.