### PR TITLE
Unifies parameters to instantiate llm while incorporating model params

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -43,8 +43,11 @@ class AskChatHandler(BaseChatHandler):
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]
     ):
-        model_parameters = self.get_model_parameters(provider, provider_params)
-        self.llm = provider(**provider_params, **model_parameters)
+        unified_parameters = {
+            **provider_params,
+            **(self.get_model_parameters(provider, provider_params))
+        }
+        self.llm = provider(**unified_parameters)
         memory = ConversationBufferWindowMemory(
             memory_key="chat_history", return_messages=True, k=2
         )

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -45,7 +45,7 @@ class AskChatHandler(BaseChatHandler):
     ):
         unified_parameters = {
             **provider_params,
-            **(self.get_model_parameters(provider, provider_params))
+            **(self.get_model_parameters(provider, provider_params)),
         }
         self.llm = provider(**unified_parameters)
         memory = ConversationBufferWindowMemory(

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -25,7 +25,7 @@ class DefaultChatHandler(BaseChatHandler):
     ):
         unified_parameters = {
             **provider_params,
-            **(self.get_model_parameters(provider, provider_params))
+            **(self.get_model_parameters(provider, provider_params)),
         }
         llm = provider(**unified_parameters)
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -23,8 +23,11 @@ class DefaultChatHandler(BaseChatHandler):
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]
     ):
-        model_parameters = self.get_model_parameters(provider, provider_params)
-        llm = provider(**provider_params, **model_parameters)
+        unified_parameters = {
+            **provider_params,
+            **(self.get_model_parameters(provider, provider_params))
+        }
+        llm = provider(**unified_parameters)
 
         prompt_template = llm.get_chat_prompt_template()
         self.memory = ConversationBufferWindowMemory(

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
@@ -236,8 +236,11 @@ class GenerateChatHandler(BaseChatHandler):
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]
     ):
-        model_parameters = self.get_model_parameters(provider, provider_params)
-        llm = provider(**provider_params, **model_parameters)
+        unified_parameters = {
+            **provider_params,
+            **(self.get_model_parameters(provider, provider_params))
+        }
+        llm = provider(**unified_parameters)
 
         self.llm = llm
         return llm

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
@@ -238,7 +238,7 @@ class GenerateChatHandler(BaseChatHandler):
     ):
         unified_parameters = {
             **provider_params,
-            **(self.get_model_parameters(provider, provider_params))
+            **(self.get_model_parameters(provider, provider_params)),
         }
         llm = provider(**unified_parameters)
 

--- a/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
@@ -28,8 +28,11 @@ class DefaultInlineCompletionHandler(BaseInlineCompletionHandler):
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]
     ):
-        model_parameters = self.get_model_parameters(provider, provider_params)
-        llm = provider(**provider_params, **model_parameters)
+        unified_parameters = {
+            **provider_params,
+            **(self.get_model_parameters(provider, provider_params))
+        }
+        llm = provider(**unified_parameters)
 
         prompt_template = llm.get_completion_prompt_template()
 

--- a/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
@@ -30,7 +30,7 @@ class DefaultInlineCompletionHandler(BaseInlineCompletionHandler):
     ):
         unified_parameters = {
             **provider_params,
-            **(self.get_model_parameters(provider, provider_params))
+            **(self.get_model_parameters(provider, provider_params)),
         }
         llm = provider(**unified_parameters)
 


### PR DESCRIPTION
Fixes #624. Alternative to #630.

Deduplicates parameters to `provider` constructor while still incorporating the results of `get_model_parameters`, as suggested by @dlqqq.