### PR TITLE
Update docs to mention `langchain_community.llms`

### DIFF
--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -64,7 +64,7 @@ keyword argument.
 ```python
 # my_package/my_provider.py
 from jupyter_ai_magics import BaseProvider
-from langchain.llms import FakeListLLM
+from langchain_community.llms import FakeListLLM
 
 
 class MyProvider(BaseProvider, FakeListLLM):


### PR DESCRIPTION
Importing from `langchain.llm` would otherwise give the following warning:

```
LangChainDeprecationWarning: Importing LLMs from langchain is deprecated. Importing from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:

`from langchain_community.llms import FakeListLLM`.

To install langchain-community run `pip install -U langchain-community`.
  warnings.warn(
```