### PR TITLE
Add `nodejs=20` to the contributing docs

### DIFF
--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -35,7 +35,7 @@ Due to a compatibility issue with Webpack, Node.js 18.15.0 does not work with Ju
 After you have installed the prerequisites, create a new conda environment and activate it.
 
 ```
-conda create -n jupyter-ai python=3.11
+conda create -n jupyter-ai python=3.11 nodejs=20
 conda activate jupyter-ai
 ```
 


### PR DESCRIPTION
(Optional) Suggestion for installing `nodejs=20` with `conda`.

The docs mention Node.js as a requirements, but installing it with conda directly tends to be convenient.