### PR TITLE
Together.ai provider added

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
@@ -29,6 +29,7 @@ from .providers import (
     OpenAIProvider,
     QianfanProvider,
     SmEndpointProvider,
+    TogetherAIProvider,
 )
 
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -31,13 +31,13 @@ from langchain_community.chat_models import (
 from langchain_community.llms import (
     AI21,
     Anthropic,
-    Together,
     Bedrock,
     Cohere,
     GPT4All,
     HuggingFaceHub,
     OpenAI,
     SagemakerEndpoint,
+    Together,
 )
 
 # this is necessary because `langchain.pydantic_v1.main` does not include
@@ -858,17 +858,18 @@ class TogetherAIProvider(BaseProvider, Together):
     id = "togetherai"
     name = "Together AI"
     model_id_key = "model"
-    models = ['Austism/chronos-hermes-13b',
-              'DiscoResearch/DiscoLM-mixtral-8x7b-v2',
-              'EleutherAI/llemma_7b',
-              'Gryphe/MythoMax-L2-13b',
-              'Meta-Llama/Llama-Guard-7b',
-              'Nexusflow/NexusRaven-V2-13B',
-              'NousResearch/Nous-Capybara-7B-V1p9',
-              'NousResearch/Nous-Hermes-2-Yi-34B',
-              'NousResearch/Nous-Hermes-Llama2-13b',
-              'NousResearch/Nous-Hermes-Llama2-70b'
-              ]
+    models = [
+        "Austism/chronos-hermes-13b",
+        "DiscoResearch/DiscoLM-mixtral-8x7b-v2",
+        "EleutherAI/llemma_7b",
+        "Gryphe/MythoMax-L2-13b",
+        "Meta-Llama/Llama-Guard-7b",
+        "Nexusflow/NexusRaven-V2-13B",
+        "NousResearch/Nous-Capybara-7B-V1p9",
+        "NousResearch/Nous-Hermes-2-Yi-34B",
+        "NousResearch/Nous-Hermes-Llama2-13b",
+        "NousResearch/Nous-Hermes-Llama2-70b",
+    ]
     pypi_package_deps = ["together"]
     auth_strategy = EnvAuthStrategy(name="TOGETHER_API_KEY")
 
@@ -876,7 +877,9 @@ class TogetherAIProvider(BaseProvider, Together):
         model = kwargs.get("model_id")
 
         if model not in self.models:
-            kwargs["responses"] = ["Model not supported! Please check model list with %ai list"]
+            kwargs["responses"] = [
+                "Model not supported! Please check model list with %ai list"
+            ]
 
         super().__init__(**kwargs)
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -31,6 +31,7 @@ from langchain_community.chat_models import (
 from langchain_community.llms import (
     AI21,
     Anthropic,
+    Together,
     Bedrock,
     Cohere,
     GPT4All,
@@ -851,6 +852,41 @@ class BedrockChatProvider(BaseProvider, BedrockChat):
     @property
     def allows_concurrency(self):
         return not "anthropic" in self.model_id
+
+
+class TogetherAIProvider(BaseProvider, Together):
+    id = "togetherai"
+    name = "Together AI"
+    model_id_key = "model"
+    models = ['Austism/chronos-hermes-13b',
+              'DiscoResearch/DiscoLM-mixtral-8x7b-v2',
+              'EleutherAI/llemma_7b',
+              'Gryphe/MythoMax-L2-13b',
+              'Meta-Llama/Llama-Guard-7b',
+              'Nexusflow/NexusRaven-V2-13B',
+              'NousResearch/Nous-Capybara-7B-V1p9',
+              'NousResearch/Nous-Hermes-2-Yi-34B',
+              'NousResearch/Nous-Hermes-Llama2-13b',
+              'NousResearch/Nous-Hermes-Llama2-70b'
+              ]
+    pypi_package_deps = ["together"]
+    auth_strategy = EnvAuthStrategy(name="TOGETHER_API_KEY")
+
+    def __init__(self, **kwargs):
+        model = kwargs.get("model_id")
+
+        if model not in self.models:
+            kwargs["responses"] = ["Model not supported! Please check model list with %ai list"]
+
+        super().__init__(**kwargs)
+
+    def get_prompt_template(self, format) -> PromptTemplate:
+        if format == "code":
+            return PromptTemplate.from_template(
+                "{prompt}\n\nProduce output as source code only, "
+                "with no text or explanation before or after it."
+            )
+        return super().get_prompt_template(format)
 
 
 # Baidu QianfanChat provider. temporarily living as a separate class until

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -46,6 +46,8 @@ all = [
     "openai~=1.6.1",
     "boto3",
     "qianfan",
+    "together",
+
 ]
 
 [project.entry-points."jupyter_ai.model_providers"]
@@ -63,6 +65,7 @@ anthropic-chat = "jupyter_ai_magics:ChatAnthropicProvider"
 amazon-bedrock-chat = "jupyter_ai_magics:BedrockChatProvider"
 qianfan = "jupyter_ai_magics:QianfanProvider"
 nvidia-chat = "jupyter_ai_magics.partner_providers.nvidia:ChatNVIDIAProvider"
+together-ai = "jupyter_ai_magics:TogetherAIProvider"
 
 [project.entry-points."jupyter_ai.embeddings_model_providers"]
 bedrock = "jupyter_ai_magics:BedrockEmbeddingsProvider"


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-ai/issues/649

Together.ai is getting popular for running community open models on their cloud platform, and looks like it would be good to have in Jupyter AI by default.


- [x]  Add TogetherAIProvider
- [x] Expand the list of available models

- [ ]  Add TogetherAIEmbeddingsProvider
- [ ]  Add documentation
- [ ]  Mark as experimental, like for GPT4All?