### PR TITLE
Resolves chat panel initialization error

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -116,10 +116,14 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
         """Retrieves the current user. If `jupyter_collaboration` is not
         installed, one is synthesized from the server's current shell
         environment."""
-        collaborative = self.config.ServerApp.jpserver_extensions.get(
-            "jupyter_collaboration", False
+        # Get a dictionary of all loaded extensions. 
+        # (`serverapp` is a property on all `JupyterHandler` subclasses)
+        extensions = self.serverapp.extension_manager.extensions
+        collaborative = (
+            "jupyter_collaboration" in extensions
+            and extensions["jupyter_collaboration"].enabled
         )
-
+        
         if collaborative:
             names = self.current_user.name.split(" ", maxsplit=2)
             initials = getattr(self.current_user, "initials", None)

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -116,7 +116,7 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
         """Retrieves the current user. If `jupyter_collaboration` is not
         installed, one is synthesized from the server's current shell
         environment."""
-        collaborative = self.config.ServerApp.jpserver_extensions.get_value({}).get(
+        collaborative = self.config.ServerApp.jpserver_extensions.get(
             "jupyter_collaboration", False
         )
 

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -116,14 +116,14 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
         """Retrieves the current user. If `jupyter_collaboration` is not
         installed, one is synthesized from the server's current shell
         environment."""
-        # Get a dictionary of all loaded extensions. 
+        # Get a dictionary of all loaded extensions.
         # (`serverapp` is a property on all `JupyterHandler` subclasses)
         extensions = self.serverapp.extension_manager.extensions
         collaborative = (
             "jupyter_collaboration" in extensions
             and extensions["jupyter_collaboration"].enabled
         )
-        
+
         if collaborative:
             names = self.current_user.name.split(" ", maxsplit=2)
             initials = getattr(self.current_user, "initials", None)


### PR DESCRIPTION
Removes `get_value({})` inline of dictionary `get` method, unblocking chat panel initialization error:

> _“There seems to be a problem with the Chat backend, please look at the JupyterLab server logs or contact your administrator to correct this problem.”_ 

Tested against v2.10.0 in Jupyter Lab v4.1.2

Fixes #335 