### PR TITLE
Add Anthropic Claude 3 models to providers

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -441,14 +441,11 @@ class ChatAnthropicProvider(BaseProvider, ChatAnthropic):
     id = "anthropic-chat"
     name = "ChatAnthropic"
     models = [
-        "claude-v1",
-        "claude-v1.0",
-        "claude-v1.2",
-        "claude-2",
         "claude-2.0",
-        "claude-instant-v1",
-        "claude-instant-v1.0",
-        "claude-instant-v1.2",
+        "claude-2.1",
+        "claude-instant-1.2",
+        "claude-3-opus-20240229",
+        "claude-3-sonnet-20240229"
     ]
     model_id_key = "model"
     pypi_package_deps = ["anthropic"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -793,7 +793,7 @@ class SmEndpointProvider(BaseProvider, SagemakerEndpoint):
     async def _acall(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
         return await self._call_in_executor(*args, **kwargs)
 
-
+# See model ID list here: https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
 class BedrockProvider(BaseProvider, Bedrock):
     id = "bedrock"
     name = "Amazon Bedrock"
@@ -821,15 +821,15 @@ class BedrockProvider(BaseProvider, Bedrock):
     async def _acall(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
         return await self._call_in_executor(*args, **kwargs)
 
-
+# See model ID list here: https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
 class BedrockChatProvider(BaseProvider, BedrockChat):
     id = "bedrock-chat"
     name = "Amazon Bedrock Chat"
     models = [
-        "anthropic.claude-v1",
         "anthropic.claude-v2",
         "anthropic.claude-v2:1",
         "anthropic.claude-instant-v1",
+        "anthropic.claude-3-sonnet-20240229-v1:0"
     ]
     model_id_key = "model_id"
     pypi_package_deps = ["boto3"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -445,7 +445,7 @@ class ChatAnthropicProvider(BaseProvider, ChatAnthropic):
         "claude-2.1",
         "claude-instant-1.2",
         "claude-3-opus-20240229",
-        "claude-3-sonnet-20240229"
+        "claude-3-sonnet-20240229",
     ]
     model_id_key = "model"
     pypi_package_deps = ["anthropic"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -793,6 +793,7 @@ class SmEndpointProvider(BaseProvider, SagemakerEndpoint):
     async def _acall(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
         return await self._call_in_executor(*args, **kwargs)
 
+
 # See model ID list here: https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
 class BedrockProvider(BaseProvider, Bedrock):
     id = "bedrock"
@@ -821,6 +822,7 @@ class BedrockProvider(BaseProvider, Bedrock):
     async def _acall(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
         return await self._call_in_executor(*args, **kwargs)
 
+
 # See model ID list here: https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
 class BedrockChatProvider(BaseProvider, BedrockChat):
     id = "bedrock-chat"
@@ -829,7 +831,7 @@ class BedrockChatProvider(BaseProvider, BedrockChat):
         "anthropic.claude-v2",
         "anthropic.claude-v2:1",
         "anthropic.claude-instant-v1",
-        "anthropic.claude-3-sonnet-20240229-v1:0"
+        "anthropic.claude-3-sonnet-20240229-v1:0",
     ]
     model_id_key = "model_id"
     pypi_package_deps = ["boto3"]


### PR DESCRIPTION
- Closes #668.
- Closes #671.

Modified the `Bedrock` and `BedrockChat` models in providers.py to remove all v1 models and added the `Claude-3-Sonnet` model. 

Added comments directing developers to the Amazon Docs where provider model ids are listed. 