### PR TITLE
Use regex in TeX replace function to catch repeating symbol occurrences

### DIFF
--- a/packages/jupyter-ai/src/components/rendermime-markdown.tsx
+++ b/packages/jupyter-ai/src/components/rendermime-markdown.tsx
@@ -17,10 +17,10 @@ type RendermimeMarkdownProps = {
  */
 function escapeLatexDelimiters(text: string) {
   return text
-    .replace('\\(', '\\\\(')
-    .replace('\\)', '\\\\)')
-    .replace('\\[', '\\\\[')
-    .replace('\\]', '\\\\]');
+    .replace(/\\\(/g, '\\\\(')
+    .replace(/\\\)/g, '\\\\)')
+    .replace(/\\\[/g, '\\\\[')
+    .replace(/\\\]/g, '\\\\]');
 }
 
 function RendermimeMarkdownBase(props: RendermimeMarkdownProps): JSX.Element {


### PR DESCRIPTION
Use regex in TeX replace function to catch repeating symbol occurrences. 
- Fixes #670 

Before:
<img width="648" alt="Screenshot 2024-03-05 at 1 29 57 PM" src="https://github.com/jupyterlab/jupyter-ai/assets/26686070/9a422f3a-bac5-41a3-bb0a-d41ff747cd08">

After:
<img width="514" alt="Screenshot 2024-03-05 at 1 33 06 PM" src="https://github.com/jupyterlab/jupyter-ai/assets/26686070/c0fd7cd8-404b-4393-a89d-07b57bed5a37">

