### PR TITLE
Update nodejs installation

### DIFF
--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -35,7 +35,7 @@ Due to a compatibility issue with Webpack, Node.js 18.15.0 does not work with Ju
 After you have installed the prerequisites, create a new conda environment and activate it.
 
 ```
-conda create -n jupyter-ai python=3.11 nodejs=20
+conda create -n jupyter-ai python=3.11 conda-forge::nodejs=20
 conda activate jupyter-ai
 ```
 


### PR DESCRIPTION
The [installation instruction](https://jupyter-ai.readthedocs.io/en/latest/contributors/index.html#development-install) with `nodejs=20` does not work on my linux machine. Removing the version pin installs nodejs v18.18.2, which works fine with jupyter-ai. The reason is that the latest version of nodejs on the [anaconda channel](https://anaconda.org/anaconda/nodejs/files) is v18.18.2, while the latest version on the [conda-forge channel](https://anaconda.org/conda-forge/nodejs/files) is v0.20.9. So we either have to remove the nodejs version pin or force it to install from the conda-forge channel. Nodejs on the anaconda channel only has 70K downloads, while it has 7.4M downloads. I would recommend installing nodejs from the conda-forge channel. 

```bash
conda create -n jupyter-ai python=3.11 nodejs=20
```
![image](https://github.com/jupyterlab/jupyter-ai/assets/5016453/1146540b-502b-4a4f-b59a-7747d0a8dd34)

```bash
conda create -n jupyter-ai python=3.11 nodejs
```
![image](https://github.com/jupyterlab/jupyter-ai/assets/5016453/efc2b8c8-e740-4b46-820e-bdafe0bcbdcf)

```bash
conda create -n jupyter-ai python=3.11 conda-forge::nodejs
```
![image](https://github.com/jupyterlab/jupyter-ai/assets/5016453/6b52f709-9b94-4dff-8b01-cde92e04a8cd)
