### PR TITLE
Use `AZURE_OPENAI_API_KEY` for Azure OpenAI provider

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -706,7 +706,7 @@ class AzureChatOpenAIProvider(BaseProvider, AzureChatOpenAI):
     model_id_key = "deployment_name"
     model_id_label = "Deployment name"
     pypi_package_deps = ["openai"]
-    auth_strategy = EnvAuthStrategy(name="OPENAI_API_KEY")
+    auth_strategy = EnvAuthStrategy(name="AZURE_OPENAI_API_KEY")
     registry = True
 
     fields = [


### PR DESCRIPTION
Addresses #690 - changes variable in azure auth to comply with openai>1.0