### PR TITLE
Modifiy post processing in chat

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
@@ -134,25 +134,25 @@ class DefaultInlineCompletionHandler(BaseInlineCompletionHandler):
 
         While most models (especially instruct and infill models do not require
         any pre-processing), some models such as gpt-4 which only have chat APIs
-        may require removing spurious fragments (such as backticks). 
-        This function uses heuristics and request data to remove such fragments. 
-        It comments out all lines that are not code, irrespective of programming language. 
+        may require removing spurious fragments (such as backticks).
+        This function uses heuristics and request data to remove such fragments.
+        It comments out all lines that are not code, irrespective of programming language.
         """
         suggestion = "\n\n" + suggestion.strip()
-        segments = suggestion.split('\n')
+        segments = suggestion.split("\n")
         is_code = False
         suggestion = []
         for s in segments:
-            if is_code==False:
-                if s.startswith('```'):
+            if is_code == False:
+                if s.startswith("```"):
                     is_code = True
                 else:
-                    if len(s)>0:
+                    if len(s) > 0:
                         suggestion.append("# " + s)
                     else:
                         suggestion.append(s)
             else:
-                if s.startswith('```'):
+                if s.startswith("```"):
                     is_code = False
                 else:
                     suggestion.append(s)


### PR DESCRIPTION
Fixes #686 

Removed spurious fragments from the suggestion, like backticks

        While most models (especially instruct and infill models do not require
        any pre-processing), some models such as gpt-4 which only have chat APIs
        may require removing spurious fragments (such as backticks).
        This function uses heuristics and request data to remove such fragments.
        It comments out all lines that are not code, irrespective of programming language.

Changes made to [packages/jupyter-ai/jupyter_ai/tests/completions/test_handlers.py](https://github.com/jupyterlab/jupyter-ai/blob/b18b7d077119fb9f7063b0fb04f8dd28d4bc91e4/packages/jupyter-ai/jupyter_ai/tests/completions/test_handlers.py#L77)

1. All lines with backticks have been removed. 
2. All text outside code blocks is commented out. 

Result looks like the following: 
<img width="1097" alt="backticks example" src="https://github.com/jupyterlab/jupyter-ai/assets/29005/8b7ddcec-6229-42df-af32-519d428ca819">
