### PR TITLE
Update Azure OpenAI fields

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
@@ -75,23 +75,17 @@ class AzureChatOpenAIProvider(BaseProvider, AzureChatOpenAI):
     id = "azure-chat-openai"
     name = "Azure OpenAI"
     models = ["*"]
-    model_id_key = "deployment_name"
+    model_id_key = "azure_deployment"
     model_id_label = "Deployment name"
     pypi_package_deps = ["langchain_openai"]
+    # Confusingly, langchain uses both OPENAI_API_KEY and AZURE_OPENAI_API_KEY for azure
+    # https://github.com/langchain-ai/langchain/blob/f2579096993ae460516a0aae1d3e09f3eb5c1772/libs/partners/openai/langchain_openai/llms/azure.py#L85
     auth_strategy = EnvAuthStrategy(name="AZURE_OPENAI_API_KEY")
     registry = True
 
     fields = [
-        TextField(
-            key="openai_api_base", label="Base API URL (required)", format="text"
-        ),
-        TextField(
-            key="openai_api_version", label="API version (required)", format="text"
-        ),
-        TextField(
-            key="openai_organization", label="Organization (optional)", format="text"
-        ),
-        TextField(key="openai_proxy", label="Proxy (optional)", format="text"),
+        TextField(key="azure_endpoint", label="Base API URL (required)", format="text"),
+        TextField(key="api_version", label="API version (required)", format="text"),
     ]
 
 


### PR DESCRIPTION
## Description

I noticed Azure OpenAI wasn't working in our jupyterhub after an update, and I traced it to us having upgraded to openai 1.x.

I made [the changes recommanded by the microsoft doc](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/migration?tabs=python-new%2Cdalle-fix) and I noticed there was also a regression regarding the env var. Unfortunately langchain uses the same env var for both azure and regular openai ([sample code](https://github.com/azure-samples/function-python-ai-langchain/blob/main/function_app.py)) which means people can't use both azure and openai at the same time with jupyter ai, although I think that is a very niche use case.

I have tested my patch in my org and it works now with these changes. 

## Related issues

- Closes #734 