### PR TITLE
Remove trailing Markdown code tags in completion suggestions

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
@@ -91,7 +91,7 @@ class DefaultInlineCompletionHandler(BaseInlineCompletionHandler):
                     continue
                 else:
                     suggestion = self._post_process_suggestion(suggestion, request)
-            elif suggestion.endswith("```"):
+            elif suggestion.rstrip().endswith("```"):
                 suggestion = self._post_process_suggestion(suggestion, request)
             self.write_message(
                 InlineCompletionStreamChunk(
@@ -155,7 +155,7 @@ class DefaultInlineCompletionHandler(BaseInlineCompletionHandler):
                 break
 
         # check if the suggestion ends with a closing markdown identifier and remove it
-        if suggestion.endswith("```"):
-            suggestion = suggestion[:-3].rstrip()
+        if suggestion.rstrip().endswith("```"):
+            suggestion = suggestion.rstrip()[:-3].rstrip()
 
         return suggestion

--- a/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/completions/handlers/default.py
@@ -91,6 +91,8 @@ class DefaultInlineCompletionHandler(BaseInlineCompletionHandler):
                     continue
                 else:
                     suggestion = self._post_process_suggestion(suggestion, request)
+            elif suggestion.endswith("```"):
+                suggestion = self._post_process_suggestion(suggestion, request)
             self.write_message(
                 InlineCompletionStreamChunk(
                     type="stream",
@@ -151,4 +153,9 @@ class DefaultInlineCompletionHandler(BaseInlineCompletionHandler):
                 if suggestion.startswith(request.prefix):
                     suggestion = suggestion[len(request.prefix) :]
                 break
+
+        # check if the suggestion ends with a closing markdown identifier and remove it
+        if suggestion.endswith("```"):
+            suggestion = suggestion[:-3].rstrip()
+
         return suggestion

--- a/packages/jupyter-ai/jupyter_ai/tests/completions/test_handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/completions/test_handlers.py
@@ -1,11 +1,11 @@
 import json
 from types import SimpleNamespace
 
+import pytest
 from jupyter_ai.completions.handlers.default import DefaultInlineCompletionHandler
 from jupyter_ai.completions.models import InlineCompletionRequest
 from jupyter_ai_magics import BaseProvider
 from langchain_community.llms import FakeListLLM
-import pytest
 from pytest import fixture
 from tornado.httputil import HTTPServerRequest
 from tornado.web import Application


### PR DESCRIPTION
This is my attempt at fixing #686
I have also added a unit test and adapted the `MockProvider` a little bit so that unit tests can test different responses. 
As a result I've also changed the assertions in the `test_handle_stream_request` test to what I _think_ are the intended responses.