### PR TITLE
Handle single files, pdfs, errors from missing loader dependencies in `/learn`

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -123,7 +123,7 @@ class LearnChatHandler(BaseChatHandler):
                 load_path, args.chunk_size, args.chunk_overlap, args.all_files
             )
         except Exception as e:
-            response = f"""Learn documents in **{load_path}** failed. Additional packages needed: {str(e)}."""
+            response = f"""Learn documents in **{load_path}** failed. {str(e)}."""
         else:
             self.save()
             response = f"""🎉 I have learned documents at **{load_path}** and I am ready to answer questions about them.

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -59,7 +59,6 @@ class LearnChatHandler(BaseChatHandler):
         self.index = None
         self.metadata = IndexMetadata(dirs=[])
         self.prev_em_id = None
-        self.missing_dependency_error = None
 
         if not os.path.exists(INDEX_SAVE_DIR):
             os.makedirs(INDEX_SAVE_DIR)
@@ -119,15 +118,14 @@ class LearnChatHandler(BaseChatHandler):
         if args.verbose:
             self.reply(f"Loading and splitting files for {load_path}", message)
 
-        await self.learn_dir(
-            load_path, args.chunk_size, args.chunk_overlap, args.all_files
-        )
-        self.save()
-
-        if self.missing_dependency_error != None:
-            response = f"""Learn documents in **{load_path}** failed. Additional 
-                packages needed: {self.missing_dependency_error}."""
+        try:
+            await self.learn_dir(
+                load_path, args.chunk_size, args.chunk_overlap, args.all_files
+            )
+        except Exception as e:
+            response = f"""Learn documents in **{load_path}** failed. Additional packages needed: {str(e)}."""
         else:
+            self.save()
             response = f"""🎉 I have learned documents at **{load_path}** and I am ready to answer questions about them.
                 You can ask questions about these docs by prefixing your message with **/ask**."""
         self.reply(response, message)
@@ -158,22 +156,18 @@ class LearnChatHandler(BaseChatHandler):
             default_splitter=RecursiveCharacterTextSplitter(**splitter_kwargs),
         )
 
-        try:
-            delayed = split(path, all_files, splitter=splitter)
-            doc_chunks = await dask_client.compute(delayed)
-            em_provider_cls, em_provider_args = self.get_embedding_provider()
-            delayed = get_embeddings(doc_chunks, em_provider_cls, em_provider_args)
-            embedding_records = await dask_client.compute(delayed)
-            if self.index:
-                self.index.add_embeddings(*embedding_records)
-            else:
-                self.create(*embedding_records)
+        delayed = split(path, all_files, splitter=splitter)
+        doc_chunks = await dask_client.compute(delayed)
+        em_provider_cls, em_provider_args = self.get_embedding_provider()
+        delayed = get_embeddings(doc_chunks, em_provider_cls, em_provider_args)
+        embedding_records = await dask_client.compute(delayed)
+        if self.index:
+            self.index.add_embeddings(*embedding_records)
+        else:
+            self.create(*embedding_records)
 
-            self._add_dir_to_metadata(path, chunk_size, chunk_overlap)
-            self.prev_em_id = em_provider_cls.id + ":" + em_provider_args["model_id"]
-        except Exception as e:
-            self.missing_dependency_error = str(e)
-            return
+        self._add_dir_to_metadata(path, chunk_size, chunk_overlap)
+        self.prev_em_id = em_provider_cls.id + ":" + em_provider_args["model_id"]
 
     def _add_dir_to_metadata(self, path: str, chunk_size: int, chunk_overlap: int):
         dirs = self.metadata.dirs

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -8,13 +8,12 @@ import dask
 from langchain.document_loaders import PyPDFLoader
 from langchain.schema import Document
 from langchain.text_splitter import TextSplitter
-from pypdf import PdfReader
 
 
 # Uses pypdf which is used by PyPDFLoader from langchain
 def pdf_to_text(path):
-    reader = PdfReader(path)
-    text = "\n \n".join([page.extract_text() for page in reader.pages])
+    pages = PyPDFLoader(path)
+    text = "\n \n".join([page.page_content for page in pages.load_and_split()])
     return text
 
 

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -54,7 +54,7 @@ test = [
 
 dev = ["jupyter_ai_magics[dev]"]
 
-all = ["jupyter_ai_magics[all]"]
+all = ["jupyter_ai_magics[all]", pypdf]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -54,7 +54,7 @@ test = [
 
 dev = ["jupyter_ai_magics[dev]"]
 
-all = ["jupyter_ai_magics[all]", pypdf]
+all = ["jupyter_ai_magics[all]", "pypdf"]
 
 [tool.hatch.version]
 source = "nodejs"


### PR DESCRIPTION
Improves on PR #712 

This PR makes the following enhancements:

1. Enables handling single files, not just directories. 
2. Learns PDFs with Langchain's `PyPDFLoader`. In PR #712, the `pypdf` package was directly used instead of `PyPDFLoader`, which also depends on `pypdf`. 
3. In the earlier PR, `pypdf` was added as a required dependency, this has been changed to make it an optional dependency in [all]. 
4. If `pypdf` is not installed, the full missing package error with traceback is displayed, which is poor UX. Modified `learn.py` to return a clean error with the missing package name, w/o traceback. The error handling for a missing dependency is generic and does not depend on specific packages, and is displayed when the file type that is being handled needs additional packages. 

Here is an example of the error when `pypdf` is not installed. 
![image](https://github.com/jupyterlab/jupyter-ai/assets/29005/ed1fb48f-f774-40bd-a73f-75ac6f913e50)

Here is an example of handling a single PDF file after `pypdf` is installed. 
![image](https://github.com/jupyterlab/jupyter-ai/assets/29005/3081d5e0-3d47-47a0-a811-b619a2da2ed5)
