### PR TITLE
Catch embedding model validation errors on extension init

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -80,7 +80,9 @@ class LearnChatHandler(BaseChatHandler):
             )
             self.load_metadata()
         except Exception as e:
-            self.log.error("Could not load vector index from disk. Full exception details printed below.")
+            self.log.error(
+                "Could not load vector index from disk. Full exception details printed below."
+            )
             self.log.error(e)
 
     async def process_message(self, message: HumanChatMessage):

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -67,17 +67,21 @@ class LearnChatHandler(BaseChatHandler):
 
     def _load(self):
         """Loads the vector store."""
-        embeddings = self.get_embedding_model()
-        if not embeddings:
+        if self.index is not None:
             return
-        if self.index is None:
-            try:
-                self.index = FAISS.load_local(
-                    INDEX_SAVE_DIR, embeddings, index_name=self.index_name
-                )
-                self.load_metadata()
-            except Exception as e:
-                self.log.error("Could not load vector index from disk.")
+
+        try:
+            embeddings = self.get_embedding_model()
+            if not embeddings:
+                return
+
+            self.index = FAISS.load_local(
+                INDEX_SAVE_DIR, embeddings, index_name=self.index_name
+            )
+            self.load_metadata()
+        except Exception as e:
+            self.log.error("Could not load vector index from disk. Full exception details printed below.")
+            self.log.error(e)
 
     async def process_message(self, message: HumanChatMessage):
         # If no embedding provider has been selected


### PR DESCRIPTION
The embedding model sometimes raises an exception when instantiated, which causes the server extension to fail initializing and show the "There seems to be a problem with the chat backend" error to the user.

This PR catches the raised exception to allow for the server extension to finish initializing even if the embedding model raises an exception.