### PR TITLE
Keep version of magics package consistent in future releases

### DIFF
--- a/.jupyter-releaser.toml
+++ b/.jupyter-releaser.toml
@@ -2,15 +2,17 @@
 before-build-npm = [
     "python -m pip install jupyterlab~=4.0",
     "jlpm",
-    "jlpm build:prod"
+    "jlpm build:prod",
 ]
-before-build-python = [
-    "jlpm clean:all"
-]
+before-build-python = ["jlpm clean:all"]
 
 [options]
 version-cmd = "../../scripts/bump-version.sh"
 python_packages = [
     "packages/jupyter-ai:jupyter-ai",
-    "packages/jupyter-ai-magics:jupyter-ai-magics"
+    "packages/jupyter-ai-magics:jupyter-ai-magics",
 ]
+
+# this is set to skip validation of pyproject.toml by default
+# otherwise, check-release fails because the bumped dependency on `jupyter-ai-magics` does not exist in PyPI
+pydist_extra_check_cmds = []

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -17,6 +17,8 @@
 if [[ "$PWD" == *packages/jupyter-ai ]]; then
     # bump dependency in jupyter-ai to rely on current version of jupyter-ai-magics
     # -E : use extended regex to allow usage of `+` symbol
-    # -i '' : modify file in-place
-    sed -E -i '' "s/jupyter_ai_magics.=[0-9]+\.[0-9]+\.[0-9]+/jupyter_ai_magics==$1/" pyproject.toml
+    # -i.bak : edit file in-place, generating a backup file ending in `.bak`, which we delete on success
+    #          while confusing, this unfortunately is the only way to edit in-place on both macOS and Linux
+    #          reference: https://stackoverflow.com/a/44864004
+    sed -E -i.bak "s/jupyter_ai_magics.=[0-9]+\.[0-9]+\.[0-9]+/jupyter_ai_magics==$1/" pyproject.toml && rm pyproject.toml.bak
 fi

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-# script that bumps version for all projects regardless of whether they were
-# changed since last release. needed because `lerna version` only bumps versions for projects
-# listed by `lerna changed` by default.
+# Script used by Jupyter Releaser that bumps the version of all packages to the
+# one provided in `$1`. This script requires `jq` to be installed.
 #
-# see: https://github.com/lerna/lerna/issues/2369
+# This script is necessary because a) `lerna version` only bumps versions for
+# projects listed by `lerna changed` by default [1], and b) the version in
+# `packages/jupyter-ai/pyproject.toml` needs to be bumped as well.
+#
+# [1]: https://github.com/lerna/lerna/issues/2369
 
 (npx -p lerna@6.4.1 -y lerna version \
     --no-git-tag-version \
@@ -15,10 +18,11 @@
 ) || exit 1
 
 if [[ "$PWD" == *packages/jupyter-ai ]]; then
+    version=$(cat package.json | jq -r '.version')
     # bump dependency in jupyter-ai to rely on current version of jupyter-ai-magics
     # -E : use extended regex to allow usage of `+` symbol
     # -i.bak : edit file in-place, generating a backup file ending in `.bak`, which we delete on success
     #          while confusing, this unfortunately is the only way to edit in-place on both macOS and Linux
     #          reference: https://stackoverflow.com/a/44864004
-    sed -E -i.bak "s/jupyter_ai_magics.=[0-9]+\.[0-9]+\.[0-9]+/jupyter_ai_magics==$1/" pyproject.toml && rm pyproject.toml.bak
+    sed -E -i.bak "s/jupyter_ai_magics.=[0-9]+\.[0-9]+\.[0-9]+/jupyter_ai_magics==$version/" pyproject.toml && rm pyproject.toml.bak
 fi

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -14,7 +14,9 @@
     "$1" \
 ) || exit 1
 
-# bump dependency in jupyter-ai to rely on current version of jupyter-ai-magics
-# -E : use extended regex to allow usage of `+` symbol
-# -i '' : modify file in-place
-sed -E -i '' "s/jupyter_ai_magics.=[0-9]+\.[0-9]+\.[0-9]+/jupyter_ai_magics==$1/" packages/jupyter-ai/pyproject.toml
+if [[ "$PWD" == *packages/jupyter-ai ]]; then
+    # bump dependency in jupyter-ai to rely on current version of jupyter-ai-magics
+    # -E : use extended regex to allow usage of `+` symbol
+    # -i '' : modify file in-place
+    sed -E -i '' "s/jupyter_ai_magics.=[0-9]+\.[0-9]+\.[0-9]+/jupyter_ai_magics==$1/" pyproject.toml
+fi

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -11,5 +11,10 @@
     --no-push \
     --force-publish \
     -y \
-    $1 \
+    "$1" \
 ) || exit 1
+
+# bump dependency in jupyter-ai to rely on current version of jupyter-ai-magics
+# -E : use extended regex to allow usage of `+` symbol
+# -i '' : modify file in-place
+sed -E -i '' "s/jupyter_ai_magics.=[0-9]+\.[0-9]+\.[0-9]+/jupyter_ai_magics==$1/" packages/jupyter-ai/pyproject.toml

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -9,6 +9,14 @@
 #
 # [1]: https://github.com/lerna/lerna/issues/2369
 
+# Jupyter Releaser runs this script once per package in the monorepo, but we
+# should only run this script once in `packages/jupyter-ai`.
+if [[ "$PWD" != *packages/jupyter-ai ]]; then
+    echo "Skipping this dir as this script should only be run from 'packages/jupyter-ai'."
+    echo "CWD: $PWD"
+    exit 0
+fi
+
 (npx -p lerna@6.4.1 -y lerna version \
     --no-git-tag-version \
     --no-push \
@@ -17,12 +25,10 @@
     "$1" \
 ) || exit 1
 
-if [[ "$PWD" == *packages/jupyter-ai ]]; then
-    version=$(cat package.json | jq -r '.version')
-    # bump dependency in jupyter-ai to rely on current version of jupyter-ai-magics
-    # -E : use extended regex to allow usage of `+` symbol
-    # -i.bak : edit file in-place, generating a backup file ending in `.bak`, which we delete on success
-    #          while confusing, this unfortunately is the only way to edit in-place on both macOS and Linux
-    #          reference: https://stackoverflow.com/a/44864004
-    sed -E -i.bak "s/jupyter_ai_magics.=[0-9]+\.[0-9]+\.[0-9]+/jupyter_ai_magics==$version/" pyproject.toml && rm pyproject.toml.bak
-fi
+version=$(cat package.json | jq -r '.version')
+# bump dependency in jupyter-ai to rely on current version of jupyter-ai-magics
+# -E : use extended regex to allow usage of `+` symbol
+# -i.bak : edit file in-place, generating a backup file ending in `.bak`, which we delete on success
+#          while confusing, this unfortunately is the only way to edit in-place on both macOS and Linux
+#          reference: https://stackoverflow.com/a/44864004
+sed -E -i.bak "s/jupyter_ai_magics.=[0-9]+\.[0-9]+\.[0-9]+/jupyter_ai_magics==$version/" pyproject.toml && rm pyproject.toml.bak


### PR DESCRIPTION
This PR updates the `scripts/bump-version.sh` script to automatically update the dependency on `jupyter-ai-magics` to be equal to the current version of `jupyter-ai` in future releases.

After this change, when a user upgrades `jupyter-ai`, `jupyter-ai-magics` will be upgraded automatically. This will prevent issues like #730 from arising in the future, caused by having different versions of `jupyter-ai` and `jupyter-ai-magics` in the same environment.

We are already synchronizing the versions of `jupyter-ai` and `jupyter-ai-magics` when manually releasing to Conda Forge, so we should be doing the same for PyPI releases.