### PR TITLE
Remove `pypdf` from required dependencies

### DIFF
--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "typing_extensions>=4.5.0",
     "traitlets>=5.0",
     "deepmerge>=1.0",
-    "pypdf==4.1.0",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]


### PR DESCRIPTION
`pypdf` was wrongly included in the required dependencies, meaning that `jupyter-ai==2.14.0` depends on an exact version of `pypdf`.

I will cut a patch release to include #747 after this is merged.