### PR TITLE
Load persisted vector store by default

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -76,7 +76,7 @@ class LearnChatHandler(BaseChatHandler):
                 return
 
             self.index = FAISS.load_local(
-                INDEX_SAVE_DIR, embeddings, index_name=self.index_name
+                INDEX_SAVE_DIR, embeddings, index_name=self.index_name, allow_dangerous_deserialization=True
             )
             self.load_metadata()
         except Exception as e:

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -76,7 +76,10 @@ class LearnChatHandler(BaseChatHandler):
                 return
 
             self.index = FAISS.load_local(
-                INDEX_SAVE_DIR, embeddings, index_name=self.index_name, allow_dangerous_deserialization=True
+                INDEX_SAVE_DIR,
+                embeddings,
+                index_name=self.index_name,
+                allow_dangerous_deserialization=True,
             )
             self.load_metadata()
         except Exception as e:


### PR DESCRIPTION
Closes #701 

This change is being made to restore the default behavior of `/learn`, where it should reload an existing vector store from disk after the server restarts.

In the next major release, we will likely make this behavior configurable while defaulting to `False` for security. Alternatively, we can explore other ways of loading the vector store that do not rely on de-pickling.