### PR TITLE
Switch to langchain_community

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import List
 
 import dask
-from langchain.document_loaders import PyPDFLoader
+from langchain_community.document_loaders import PyPDFLoader
 from langchain.schema import Document
 from langchain.text_splitter import TextSplitter
 

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from typing import List
 
 import dask
-from langchain_community.document_loaders import PyPDFLoader
 from langchain.schema import Document
 from langchain.text_splitter import TextSplitter
+from langchain_community.document_loaders import PyPDFLoader
 
 
 # Uses pypdf which is used by PyPDFLoader from langchain


### PR DESCRIPTION
Fixes #727 

PyPDFLoader was still using `langchain` instead of `langchain_community`, this has been replaced.
Tested that the error/warning does not occur. 