### PR TITLE
Add Titan embedding model v2

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -98,10 +98,14 @@ class HfHubEmbeddingsProvider(BaseEmbeddingsProvider, HuggingFaceHubEmbeddings):
     registry = True
 
 
+# See model ID list here: https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
 class BedrockEmbeddingsProvider(BaseEmbeddingsProvider, BedrockEmbeddings):
     id = "bedrock"
     name = "Bedrock"
-    models = ["amazon.titan-embed-text-v1"]
+    models = [
+        "amazon.titan-embed-text-v1",
+        "amazon.titan-embed-text-v2:0"
+        ]
     model_id_key = "model_id"
     pypi_package_deps = ["boto3"]
     auth_strategy = AwsAuthStrategy()

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -102,10 +102,7 @@ class HfHubEmbeddingsProvider(BaseEmbeddingsProvider, HuggingFaceHubEmbeddings):
 class BedrockEmbeddingsProvider(BaseEmbeddingsProvider, BedrockEmbeddings):
     id = "bedrock"
     name = "Bedrock"
-    models = [
-        "amazon.titan-embed-text-v1",
-        "amazon.titan-embed-text-v2:0"
-        ]
+    models = ["amazon.titan-embed-text-v1", "amazon.titan-embed-text-v2:0"]
     model_id_key = "model_id"
     pypi_package_deps = ["boto3"]
     auth_strategy = AwsAuthStrategy()


### PR DESCRIPTION
Fixes #776 

Included the new embedding model, released recently on Amazon Bedrock.

 See: https://aws.amazon.com/about-aws/whats-new/2024/04/amazon-titan-text-embeddings-v2-amazon-bedrock/