### PR TITLE
Autocomplete UI for slash commands

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -11,6 +11,7 @@ from typing import (
     Literal,
     Optional,
     Type,
+    Union,
 )
 from uuid import uuid4
 
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 
 # Chat handler type, with specific attributes for each
 class HandlerRoutingType(BaseModel):
-    routing_method: ClassVar[str] = Literal["slash_command"]
+    routing_method: ClassVar[Union[Literal["slash_command"]]] = ...
     """The routing method that sends commands to this handler."""
 
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
@@ -10,8 +10,8 @@ from .base import BaseChatHandler, SlashCommandRoutingType
 
 class ExportChatHandler(BaseChatHandler):
     id = "export"
-    name = "Export chat messages"
-    help = "Export the chat messages in markdown format with timestamps"
+    name = "Export chat history"
+    help = "Export chat history to a Markdown file"
     routing_type = SlashCommandRoutingType(slash_id="export")
 
     uses_llm = False

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -30,6 +30,7 @@ from .handlers import (
     GlobalConfigHandler,
     ModelProviderHandler,
     RootChatHandler,
+    SlashCommandsInfoHandler,
 )
 
 JUPYTERNAUT_AVATAR_ROUTE = JupyternautPersona.avatar_route
@@ -45,6 +46,7 @@ class AiExtension(ExtensionApp):
         (r"api/ai/config/?", GlobalConfigHandler),
         (r"api/ai/chats/?", RootChatHandler),
         (r"api/ai/chats/history?", ChatHistoryHandler),
+        (r"api/ai/chats/slash_commands?", SlashCommandsInfoHandler),
         (r"api/ai/providers?", ModelProviderHandler),
         (r"api/ai/providers/embeddings?", EmbeddingsModelProviderHandler),
         (r"api/ai/completion/inline/?", DefaultInlineCompletionHandler),

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -407,6 +407,7 @@ class ApiKeysHandler(BaseAPIHandler):
         except Exception as e:
             raise HTTPError(500, str(e))
 
+
 class SlashCommandsInfoHandler(BaseAPIHandler):
     """List slash commands that are currently available to the user."""
 
@@ -417,7 +418,7 @@ class SlashCommandsInfoHandler(BaseAPIHandler):
     @property
     def chat_handlers(self) -> Dict[str, "BaseChatHandler"]:
         return self.settings["jai_chat_handlers"]
-    
+
     @web.authenticated
     def get(self):
         response = ListSlashCommandsResponse()
@@ -429,20 +430,25 @@ class SlashCommandsInfoHandler(BaseAPIHandler):
 
         for id, chat_handler in self.chat_handlers.items():
             # filter out any chat handler that is not a slash command
-            if id == "default" or chat_handler.routing_type.routing_method != "slash_command":
+            if (
+                id == "default"
+                or chat_handler.routing_type.routing_method != "slash_command"
+            ):
                 continue
 
             # hint the type of this attribute
             routing_type: SlashCommandRoutingType = chat_handler.routing_type
 
             # filter out any chat handler that is unsupported by the current LLM
-            if "/" + routing_type.slash_id in self.config_manager.lm_provider.unsupported_slash_commands:
+            if (
+                "/" + routing_type.slash_id
+                in self.config_manager.lm_provider.unsupported_slash_commands
+            ):
                 continue
 
             response.slash_commands.append(
                 ListSlashCommandsEntry(
-                    slash_id=routing_type.slash_id,
-                    description=chat_handler.help
+                    slash_id=routing_type.slash_id, description=chat_handler.help
                 )
             )
 

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -163,9 +163,11 @@ class GlobalConfig(BaseModel):
     completions_model_provider_id: Optional[str]
     completions_fields: Dict[str, Dict[str, Any]]
 
+
 class ListSlashCommandsEntry(BaseModel):
     slash_id: str
     description: str
+
 
 class ListSlashCommandsResponse(BaseModel):
     slash_commands: List[ListSlashCommandsEntry] = []

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -162,3 +162,10 @@ class GlobalConfig(BaseModel):
     api_keys: Dict[str, str]
     completions_model_provider_id: Optional[str]
     completions_fields: Dict[str, Dict[str, Any]]
+
+class ListSlashCommandsEntry(BaseModel):
+    slash_id: str
+    description: str
+
+class ListSlashCommandsResponse(BaseModel):
+    slash_commands: List[ListSlashCommandsEntry] = []

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
+  Autocomplete,
   Box,
   SxProps,
   TextField,
@@ -9,9 +10,21 @@ import {
   FormControlLabel,
   Checkbox,
   IconButton,
-  InputAdornment
+  InputAdornment,
+  Typography
 } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
+import {
+  Download,
+  FindInPage,
+  Help,
+  MoreHoriz,
+  MenuBook,
+  School,
+  HideSource
+} from '@mui/icons-material';
+
+import { AiService } from '../handler';
 
 type ChatInputProps = {
   value: string;
@@ -26,8 +39,122 @@ type ChatInputProps = {
   sx?: SxProps<Theme>;
 };
 
+type SlashCommandOption = {
+  id: string;
+  label: string;
+  description: string;
+};
+
+/**
+ * List of icons per slash command, shown in the autocomplete popup.
+ *
+ * This list of icons should eventually be made configurable. However, it is
+ * unclear whether custom icons should be defined within a Lumino plugin (in the
+ * frontend) or served from a static server route (in the backend).
+ */
+const DEFAULT_SLASH_COMMAND_ICONS: Record<string, JSX.Element> = {
+  ask: <FindInPage />,
+  clear: <HideSource />,
+  export: <Download />,
+  generate: <MenuBook />,
+  help: <Help />,
+  learn: <School />,
+  unknown: <MoreHoriz />
+};
+
+/**
+ * Renders an option shown in the slash command autocomplete.
+ */
+function renderSlashCommandOption(
+  optionProps: React.HTMLAttributes<HTMLLIElement>,
+  option: SlashCommandOption
+): JSX.Element {
+  const icon =
+    option.id in DEFAULT_SLASH_COMMAND_ICONS
+      ? DEFAULT_SLASH_COMMAND_ICONS[option.id]
+      : DEFAULT_SLASH_COMMAND_ICONS.unknown;
+
+  return (
+    <li {...optionProps}>
+      <Box sx={{ lineHeight: 0, marginRight: 2, opacity: 0.618 }}>{icon}</Box>
+      <Box sx={{ flexGrow: 1 }}>
+        <Typography
+          component="span"
+          sx={{
+            fontSize: 'var(--jp-ui-font-size1)'
+          }}
+        >
+          {option.label + ' - '}
+        </Typography>
+        <Typography
+          component="span"
+          sx={{ opacity: 0.618, fontSize: 'var(--jp-ui-font-size0)' }}
+        >
+          {option.description}
+        </Typography>
+      </Box>
+    </li>
+  );
+}
+
 export function ChatInput(props: ChatInputProps): JSX.Element {
-  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+  const [slashCommandOptions, setSlashCommandOptions] = useState<
+    SlashCommandOption[]
+  >([]);
+
+  /**
+   * Effect: fetch the list of available slash commands from the backend on
+   * initial mount to populate the slash command autocomplete.
+   */
+  useEffect(() => {
+    async function getSlashCommands() {
+      const slashCommands = (await AiService.listSlashCommands())
+        .slash_commands;
+      setSlashCommandOptions(
+        slashCommands.map<SlashCommandOption>(slashCommand => ({
+          id: slashCommand.slash_id,
+          label: '/' + slashCommand.slash_id,
+          description: slashCommand.description
+        }))
+      );
+    }
+    getSlashCommands();
+  }, []);
+
+  // whether any option is highlighted in the slash command autocomplete
+  const [highlighted, setHighlighted] = useState<boolean>(false);
+
+  // controls whether the slash command autocomplete is open
+  const [open, setOpen] = useState<boolean>(false);
+
+  /**
+   * Effect: Open the autocomplete when the user types a slash into an empty
+   * chat input. Close the autocomplete and reset the last selected value when
+   * the user clears the chat input.
+   */
+  useEffect(() => {
+    if (props.value === '/') {
+      setOpen(true);
+      return;
+    }
+
+    if (props.value === '') {
+      setOpen(false);
+      return;
+    }
+  }, [props.value]);
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== 'Enter') {
+      return;
+    }
+
+    // do not send the message if the user was just trying to select a suggested
+    // slash command from the Autocomplete component.
+    if (highlighted) {
+      return;
+    }
+
     if (
       event.key === 'Enter' &&
       ((props.sendWithShiftEnter && event.shiftKey) ||
@@ -52,36 +179,91 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
 
   return (
     <Box sx={props.sx}>
-      <Box sx={{ display: 'flex' }}>
-        <TextField
-          value={props.value}
-          onChange={e => props.onChange(e.target.value)}
-          fullWidth
-          variant="outlined"
-          multiline
-          onKeyDown={handleKeyDown}
-          placeholder="Ask Jupyternaut"
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                <IconButton
-                  size="small"
-                  color="primary"
-                  onClick={props.onSend}
-                  disabled={!props.value.trim().length}
-                  title="Send message (SHIFT+ENTER)"
-                >
-                  <SendIcon />
-                </IconButton>
-              </InputAdornment>
-            )
-          }}
-          FormHelperTextProps={{
-            sx: { marginLeft: 'auto', marginRight: 0 }
-          }}
-          helperText={props.value.length > 2 ? helperText : ' '}
-        />
-      </Box>
+      <Autocomplete
+        autoHighlight
+        freeSolo
+        inputValue={props.value}
+        onInputChange={(_, newValue: string) => {
+          props.onChange(newValue);
+        }}
+        onHighlightChange={
+          /**
+           * On highlight change: set `highlighted` to whether an option is
+           * highlighted by the user.
+           *
+           * This isn't called when an option is selected for some reason, so we
+           * need to call `setHighlighted(false)` in `onClose()`.
+           */
+          (_, highlightedOption) => {
+            setHighlighted(!!highlightedOption);
+          }
+        }
+        onClose={
+          /**
+           * On close: set `highlighted` to `false` and close the popup by
+           * setting `open` to `false`.
+           */
+          () => {
+            setHighlighted(false);
+            setOpen(false);
+          }
+        }
+        // set this to an empty string to prevent the last selected slash
+        // command from being shown in blue
+        value=""
+        open={open}
+        options={slashCommandOptions}
+        // hide default extra right padding in the text field
+        disableClearable
+        // ensure the autocomplete popup always renders on top
+        componentsProps={{
+          popper: {
+            placement: 'top'
+          }
+        }}
+        renderOption={renderSlashCommandOption}
+        ListboxProps={{
+          sx: {
+            '& .MuiAutocomplete-option': {
+              padding: 2
+            }
+          }
+        }}
+        renderInput={params => (
+          <TextField
+            {...params}
+            fullWidth
+            variant="outlined"
+            multiline
+            placeholder="Ask Jupyternaut"
+            onKeyDown={handleKeyDown}
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    size="small"
+                    color="primary"
+                    onClick={props.onSend}
+                    disabled={!props.value.trim().length}
+                    title={
+                      props.sendWithShiftEnter
+                        ? 'Send message (SHIFT+ENTER)'
+                        : 'Send message (ENTER)'
+                    }
+                  >
+                    <SendIcon />
+                  </IconButton>
+                </InputAdornment>
+              )
+            }}
+            FormHelperTextProps={{
+              sx: { marginLeft: 'auto', marginRight: 0 }
+            }}
+            helperText={props.value.length > 2 ? helperText : ' '}
+          />
+        )}
+      />
       {props.hasSelection && (
         <FormGroup sx={{ display: 'flex', flexDirection: 'row' }}>
           <FormControlLabel

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -113,7 +113,7 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
       setSlashCommandOptions(
         slashCommands.map<SlashCommandOption>(slashCommand => ({
           id: slashCommand.slash_id,
-          label: '/' + slashCommand.slash_id,
+          label: '/' + slashCommand.slash_id + ' ',
           description: slashCommand.description
         }))
       );

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -76,7 +76,7 @@ function renderSlashCommandOption(
 
   return (
     <li {...optionProps}>
-      <Box sx={{ lineHeight: 0, marginRight: 2, opacity: 0.618 }}>{icon}</Box>
+      <Box sx={{ lineHeight: 0, marginRight: 4, opacity: 0.618 }}>{icon}</Box>
       <Box sx={{ flexGrow: 1 }}>
         <Typography
           component="span"
@@ -219,6 +219,11 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
         componentsProps={{
           popper: {
             placement: 'top'
+          },
+          paper: {
+            sx: {
+              border: '1px solid lightgray'
+            }
           }
         }}
         renderOption={renderSlashCommandOption}

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -84,13 +84,13 @@ function renderSlashCommandOption(
             fontSize: 'var(--jp-ui-font-size1)'
           }}
         >
-          {option.label + ' - '}
+          {option.label}
         </Typography>
         <Typography
           component="span"
           sx={{ opacity: 0.618, fontSize: 'var(--jp-ui-font-size0)' }}
         >
-          {option.description}
+          {' — ' + option.description}
         </Typography>
       </Box>
     </li>

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -216,4 +216,17 @@ export namespace AiService {
       method: 'DELETE'
     });
   }
+
+  export type ListSlashCommandsEntry = {
+    slash_id: string;
+    description: string;
+  };
+
+  export type ListSlashCommandsResponse = {
+    slash_commands: ListSlashCommandsEntry[];
+  };
+
+  export async function listSlashCommands(): Promise<ListSlashCommandsResponse> {
+    return requestAPI<ListSlashCommandsResponse>('chats/slash_commands');
+  }
 }


### PR DESCRIPTION
## Description

This PR adds an autocomplete UI for slash commands in the chat box. When the user types `/`, a list of matching slash commands is shown in the UI.

The list of slash commands is retrieved from a new REST API endpoint `ListSlashCommands` on `GET /api/ai/chats/slash_commands`. This only shows the list of slash commands which are valid for the currently selected provider, which handles the case of when `unsupported_slash_commands` is set in a custom provider.

## Demo of first proposal

This is the UI implemented in this PR.

https://github.com/jupyterlab/jupyter-ai/assets/44106031/df170c7e-74a8-48f7-b1fa-442b11cf986d

## Demo of second proposal

This is the UI implemented here: https://github.com/dlqqq/jupyter-ai/pull/2

https://github.com/jupyterlab/jupyter-ai/assets/44106031/de2b2e72-b971-4c84-91f2-155d4b699ee8


