### PR TITLE
Document supported file types for /learn

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -480,6 +480,9 @@ Jupyter AI can only learn from files with the following file extensions:
 * .jsx
 * .tsx
 * .txt
+* .html
+* .pdf
+* .tex
 
 ### Learning arXiv files
 


### PR DESCRIPTION
Fixes #406. Documents a list of supported file types for the `/learn` command, as mentioned here:

https://github.com/jupyterlab/jupyter-ai/blob/465d9913d8f6679dcf79c4f6d9111b18daac08b9/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py#L85-L101

The relevant section of the docs: https://jupyter-ai--816.org.readthedocs.build/en/816/users/index.html#supported-files-for-the-learn-command

![image](https://github.com/jupyterlab/jupyter-ai/assets/93281816/f42b1145-4bc1-468d-91e9-50299c2b5f7b)
