### PR TITLE
Fix import deprecations

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -20,8 +20,6 @@ from typing import (
 
 from jsonpath_ng import parse
 from langchain.chat_models.base import BaseChatModel
-from langchain.llms.sagemaker_endpoint import LLMContentHandler
-from langchain.llms.utils import enforce_stop_tokens
 from langchain.prompts import (
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
@@ -44,6 +42,7 @@ from langchain_community.llms import (
     SagemakerEndpoint,
     Together,
 )
+from langchain_community.llms.sagemaker_endpoint import LLMContentHandler
 
 # this is necessary because `langchain.pydantic_v1.main` does not include
 # `ModelMetaclass`, as it is not listed in `__all__` by the `pydantic.main`


### PR DESCRIPTION
Fix a couple of deprecation warnings logged at JupyterLab startup:

```
PREFIX/envs/jupyter-ai/lib/python3.11/site-packages/langchain/_api/module_import.py:120: LangChainDeprecationWarning: Importing LLMContentHandler from langchain.llms is deprecated. Please replace deprecated imports:

>> from langchain.llms import LLMContentHandler

with new imports of:

>> from langchain_community.llms.sagemaker_endpoint import LLMContentHandler

  warn_deprecated(
PREFIX/envs/jupyter-ai/lib/python3.11/site-packages/langchain/_api/module_import.py:120: LangChainDeprecationWarning: Importing enforce_stop_tokens from langchain.llms is deprecated. Please replace deprecated imports:

>> from langchain.llms import enforce_stop_tokens

with new imports of:

>> from langchain_community.llms.utils import enforce_stop_tokens

```