### PR TITLE
Prevent overriding `server_settings` on base provider class

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -196,6 +196,18 @@ class ProviderMetaclass(ModelMetaclass):
 
         return cls
 
+    @property
+    def server_settings(cls):
+        return cls._server_settings
+
+    @server_settings.setter
+    def server_settings(cls, value):
+        if cls._server_settings is not None:
+            raise AttributeError("'server_settings' attribute was already set")
+        cls._server_settings = value
+
+    _server_settings = None
+
 
 class BaseProvider(BaseModel, metaclass=ProviderMetaclass):
     #

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_provider_metaclass.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_provider_metaclass.py
@@ -1,8 +1,10 @@
+from types import MappingProxyType
 from typing import ClassVar, Optional
 
 from langchain.pydantic_v1 import BaseModel
+from pytest import raises
 
-from ..providers import ProviderMetaclass
+from ..providers import BaseProvider, ProviderMetaclass
 
 
 def test_provider_metaclass():
@@ -24,3 +26,10 @@ def test_provider_metaclass():
         test: ClassVar[str] = "expected"
 
     assert Child.test == "expected"
+
+
+def test_base_provider_server_settings_read_only():
+    BaseProvider.server_settings = MappingProxyType({})
+
+    with raises(AttributeError, match="'server_settings' attribute was already set"):
+        BaseProvider.server_settings = MappingProxyType({})


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab/jupyter-ai/pull/777#discussion_r1628108967

Prevents overriding `server_settings` on base provider class