### PR TITLE
Clear both chat history and conversation memory when `/clear` is applied

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -267,7 +267,10 @@ class BaseChatHandler:
         if not lm_provider or not lm_provider_params:
             return None
 
-        if curr_lm_id != next_lm_id:
+        if len(self._chat_history) <= 2: # Check if chat history has been cleared, then reinitialize the llm chain
+            self.log.info("Clear conversation memory, re-initializing the llm chain.")
+            self.create_llm_chain(lm_provider, lm_provider_params)      
+        elif curr_lm_id != next_lm_id:
             self.log.info(
                 f"Switching chat language model from {curr_lm_id} to {next_lm_id}."
             )

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -19,13 +19,14 @@ class ClearChatHandler(BaseChatHandler):
         super().__init__(*args, **kwargs)
 
     async def process_message(self, _):
-        tmp_chat_history = self._chat_history[0]
-        self._chat_history.clear()
         for handler in self._root_chat_handlers.values():
             if not handler:
                 continue
 
             handler.broadcast_message(ClearMessage())
+
+            tmp_chat_history = self._chat_history[0]
+            self._chat_history.clear()
 
             self._chat_history = [tmp_chat_history]
             self.reply(tmp_chat_history.body)


### PR DESCRIPTION
Addresses #616 

1. Updated `clear.py` to clear chat history and display the help command again. 
2. Updated `base.py` to remove conversation memory when chat history is cleared.

Use chat to ask questions and verify that the logs show it is using conversation memory to the default depth of `k=2`. 
<img width="918" alt="Screenshot 2024-06-19 at 8 47 27 AM" src="https://github.com/jupyterlab/jupyter-ai/assets/29005/e9c53ab0-ef65-4648-b891-580c60353e18">

Then also check that `/export` contains the entire question history:
<img width="805" alt="image" src="https://github.com/jupyterlab/jupyter-ai/assets/29005/14aa5db7-bac0-47c1-9fd9-fc80a7949d61">

Next, use `/clear` and see that the next question does not have any conversation memory:
<img width="923" alt="Screenshot 2024-06-19 at 8 49 19 AM" src="https://github.com/jupyterlab/jupyter-ai/assets/29005/420adebf-f6ae-4d49-8324-ad1dc931eb90">
See the log message above: `Clear conversation memory, re-initializing the llm chain.`

Then check that `/export` only shows the new entries in chat:
<img width="807" alt="image" src="https://github.com/jupyterlab/jupyter-ai/assets/29005/664d62cd-0c5d-473f-b834-603532e8c21c">
