### PR TITLE
Update `clear` slash command to use `HelpChatHandler` to reinstate the help menu

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -1,9 +1,7 @@
 from typing import List
-
 from jupyter_ai.models import ChatMessage, ClearMessage
-
 from .base import BaseChatHandler, SlashCommandRoutingType
-
+from jupyter_ai.chat_handlers.help import build_help_message
 
 class ClearChatHandler(BaseChatHandler):
     """Clear the chat panel and show the help menu"""
@@ -19,15 +17,20 @@ class ClearChatHandler(BaseChatHandler):
         super().__init__(*args, **kwargs)
 
     async def process_message(self, _):
-        tmp_chat_history = self._chat_history[0]
-        self._chat_history.clear()
         for handler in self._root_chat_handlers.values():
             if not handler:
                 continue
 
+            # Clear chat 
             handler.broadcast_message(ClearMessage())
+            self._chat_history.clear()
 
-            self._chat_history = [tmp_chat_history]
-            self.reply(tmp_chat_history.body)
+            # Build /help message and reinstate it in chat
+            chat_handlers = handler.chat_handlers
+            persona = self.config_manager.persona
+            lm_provider = self.config_manager.lm_provider
+            unsupported_slash_commands = (lm_provider.unsupported_slash_commands if lm_provider else set())
+            msg = build_help_message(chat_handlers, persona, unsupported_slash_commands)
+            self.reply(msg.body)
 
             break

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -1,7 +1,10 @@
 from typing import List
-from jupyter_ai.models import ChatMessage, ClearMessage
-from .base import BaseChatHandler, SlashCommandRoutingType
+
 from jupyter_ai.chat_handlers.help import build_help_message
+from jupyter_ai.models import ChatMessage, ClearMessage
+
+from .base import BaseChatHandler, SlashCommandRoutingType
+
 
 class ClearChatHandler(BaseChatHandler):
     """Clear the chat panel and show the help menu"""
@@ -21,7 +24,7 @@ class ClearChatHandler(BaseChatHandler):
             if not handler:
                 continue
 
-            # Clear chat 
+            # Clear chat
             handler.broadcast_message(ClearMessage())
             self._chat_history.clear()
 
@@ -29,7 +32,9 @@ class ClearChatHandler(BaseChatHandler):
             chat_handlers = handler.chat_handlers
             persona = self.config_manager.persona
             lm_provider = self.config_manager.lm_provider
-            unsupported_slash_commands = (lm_provider.unsupported_slash_commands if lm_provider else set())
+            unsupported_slash_commands = (
+                lm_provider.unsupported_slash_commands if lm_provider else set()
+            )
             msg = build_help_message(chat_handlers, persona, unsupported_slash_commands)
             self.reply(msg.body)
 


### PR DESCRIPTION
Partially related to Issue #616 
Also related to: https://github.com/jupyterlab/jupyter-ai/pull/842#discussion_r1646581404 

Builds the message in the help handler and then uses it after clearing chat. This replaces the earlier version that was re-using the previous chat history to build the message. 

Before `/clear`:
<img width="972" alt="image" src="https://github.com/jupyterlab/jupyter-ai/assets/29005/850a4d22-4000-4d02-a612-3501153a7e2b">

After `/clear`:
<img width="983" alt="image" src="https://github.com/jupyterlab/jupyter-ai/assets/29005/564b1880-6b08-4b3e-a8e0-60d9c556b292">

Verified also by examining the histories exported via `/export`. 