### PR TITLE
Add claude sonnet 3.5 models

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
@@ -38,7 +38,7 @@ class AnthropicProvider(BaseProvider, AnthropicLLM):
 
 class ChatAnthropicProvider(
     BaseProvider, ChatAnthropic
-):  # https://docs.anthropic.com/en/docs/about-claude/models
+):  # https://docs.anthropic.com/en/docs/about-claude/models 
     id = "anthropic-chat"
     name = "ChatAnthropic"
     models = [

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
@@ -3,6 +3,7 @@ from langchain_anthropic import AnthropicLLM, ChatAnthropic
 from ..providers import BaseProvider, EnvAuthStrategy
 
 
+# https://docs.anthropic.com/en/docs/about-claude/models
 class AnthropicProvider(BaseProvider, AnthropicLLM):
     id = "anthropic"
     name = "Anthropic"
@@ -15,6 +16,7 @@ class AnthropicProvider(BaseProvider, AnthropicLLM):
         "claude-instant-v1",
         "claude-instant-v1.0",
         "claude-instant-v1.2",
+        "claude-3-5-sonnet-20240620",
     ]
     model_id_key = "model"
     pypi_package_deps = ["anthropic"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
@@ -2,8 +2,6 @@ from langchain_anthropic import AnthropicLLM, ChatAnthropic
 
 from ..providers import BaseProvider, EnvAuthStrategy
 
-
-# https://docs.anthropic.com/en/docs/about-claude/models
 class AnthropicProvider(BaseProvider, AnthropicLLM):
     id = "anthropic"
     name = "Anthropic"
@@ -16,7 +14,6 @@ class AnthropicProvider(BaseProvider, AnthropicLLM):
         "claude-instant-v1",
         "claude-instant-v1.0",
         "claude-instant-v1.2",
-        "claude-3-5-sonnet-20240620",
     ]
     model_id_key = "model"
     pypi_package_deps = ["anthropic"]
@@ -40,7 +37,8 @@ class AnthropicProvider(BaseProvider, AnthropicLLM):
 
 class ChatAnthropicProvider(
     BaseProvider, ChatAnthropic
-):  # https://docs.anthropic.com/claude/docs/models-overview
+):  # https://docs.anthropic.com/en/docs/about-claude/models
+
     id = "anthropic-chat"
     name = "ChatAnthropic"
     models = [
@@ -50,6 +48,7 @@ class ChatAnthropicProvider(
         "claude-3-opus-20240229",
         "claude-3-sonnet-20240229",
         "claude-3-haiku-20240307",
+        "claude-3-5-sonnet-20240620",
     ]
     model_id_key = "model"
     pypi_package_deps = ["anthropic"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
@@ -2,6 +2,7 @@ from langchain_anthropic import AnthropicLLM, ChatAnthropic
 
 from ..providers import BaseProvider, EnvAuthStrategy
 
+
 class AnthropicProvider(BaseProvider, AnthropicLLM):
     id = "anthropic"
     name = "Anthropic"
@@ -38,7 +39,6 @@ class AnthropicProvider(BaseProvider, AnthropicLLM):
 class ChatAnthropicProvider(
     BaseProvider, ChatAnthropic
 ):  # https://docs.anthropic.com/en/docs/about-claude/models
-
     id = "anthropic-chat"
     name = "ChatAnthropic"
     models = [

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
@@ -38,7 +38,7 @@ class AnthropicProvider(BaseProvider, AnthropicLLM):
 
 class ChatAnthropicProvider(
     BaseProvider, ChatAnthropic
-):  # https://docs.anthropic.com/en/docs/about-claude/models 
+):  # https://docs.anthropic.com/en/docs/about-claude/models
     id = "anthropic-chat"
     name = "ChatAnthropic"
     models = [

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -849,6 +849,7 @@ class BedrockChatProvider(BaseProvider, BedrockChat):
         "anthropic.claude-3-sonnet-20240229-v1:0",
         "anthropic.claude-3-haiku-20240307-v1:0",
         "anthropic.claude-3-opus-20240229-v1:0",
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
     ]
     model_id_key = "model_id"
     pypi_package_deps = ["boto3"]

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -1,9 +1,7 @@
 from typing import List
-
 from jupyter_ai.models import ChatMessage, ClearMessage
-
 from .base import BaseChatHandler, SlashCommandRoutingType
-
+from jupyter_ai.chat_handlers.help import build_help_message
 
 class ClearChatHandler(BaseChatHandler):
     """Clear the chat panel and show the help menu"""
@@ -19,15 +17,20 @@ class ClearChatHandler(BaseChatHandler):
         super().__init__(*args, **kwargs)
 
     async def process_message(self, _):
-        tmp_chat_history = self._chat_history[0]
-        self._chat_history.clear()
         for handler in self._root_chat_handlers.values():
             if not handler:
                 continue
 
+            # Clear chat 
             handler.broadcast_message(ClearMessage())
+            self._chat_history.clear()
 
-            self._chat_history = [tmp_chat_history]
-            self.reply(tmp_chat_history.body)
+            # Build /help message and reinstate it in chat
+            chat_handlers = handler.chat_handlers
+            persona = self.config_manager.persona
+            lm_provider = self.config_manager.lm_provider
+            unsupported_slash_commands = (lm_provider.unsupported_slash_commands if lm_provider else set())
+            msg = build_help_message(chat_handlers, persona, unsupported_slash_commands)
+            self.reply(msg.body)
 
             break

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -1,7 +1,10 @@
 from typing import List
-from jupyter_ai.models import ChatMessage, ClearMessage
-from .base import BaseChatHandler, SlashCommandRoutingType
+
 from jupyter_ai.chat_handlers.help import build_help_message
+from jupyter_ai.models import ChatMessage, ClearMessage
+
+from .base import BaseChatHandler, SlashCommandRoutingType
+
 
 class ClearChatHandler(BaseChatHandler):
     """Clear the chat panel and show the help menu"""
@@ -21,7 +24,7 @@ class ClearChatHandler(BaseChatHandler):
             if not handler:
                 continue
 
-            # Clear chat 
+            # Clear chat
             handler.broadcast_message(ClearMessage())
             self._chat_history.clear()
 
@@ -29,7 +32,9 @@ class ClearChatHandler(BaseChatHandler):
             chat_handlers = handler.chat_handlers
             persona = self.config_manager.persona
             lm_provider = self.config_manager.lm_provider
-            unsupported_slash_commands = (lm_provider.unsupported_slash_commands if lm_provider else set())
+            unsupported_slash_commands = (
+                lm_provider.unsupported_slash_commands if lm_provider else set()
+            )
             msg = build_help_message(chat_handlers, persona, unsupported_slash_commands)
             self.reply(msg.body)
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -2,7 +2,6 @@ from typing import List
 
 from jupyter_ai.models import ChatMessage, ClearMessage
 
-
 from .base import BaseChatHandler, SlashCommandRoutingType
 
 
@@ -32,4 +31,3 @@ class ClearChatHandler(BaseChatHandler):
             self.reply(tmp_chat_history.body)
 
             break
-

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from jupyter_ai.chat_handlers.help import build_help_message
 from jupyter_ai.models import ChatMessage, ClearMessage
+
 
 from .base import BaseChatHandler, SlashCommandRoutingType
 
@@ -20,22 +20,16 @@ class ClearChatHandler(BaseChatHandler):
         super().__init__(*args, **kwargs)
 
     async def process_message(self, _):
+        tmp_chat_history = self._chat_history[0]
+        self._chat_history.clear()
         for handler in self._root_chat_handlers.values():
             if not handler:
                 continue
 
-            # Clear chat
             handler.broadcast_message(ClearMessage())
-            self._chat_history.clear()
 
-            # Build /help message and reinstate it in chat
-            chat_handlers = handler.chat_handlers
-            persona = self.config_manager.persona
-            lm_provider = self.config_manager.lm_provider
-            unsupported_slash_commands = (
-                lm_provider.unsupported_slash_commands if lm_provider else set()
-            )
-            msg = build_help_message(chat_handlers, persona, unsupported_slash_commands)
-            self.reply(msg.body)
+            self._chat_history = [tmp_chat_history]
+            self.reply(tmp_chat_history.body)
 
             break
+


### PR DESCRIPTION
Fixes #845 

Added Anthropic's Claude 3.5 Sonnet model, which was released on 20th June 2024. It shows in the drop down list for Anthropic's models and Bedrock's models: 

In Bedrock:
<img width="980" alt="image" src="https://github.com/jupyterlab/jupyter-ai/assets/29005/f66ee5f4-b623-465a-8824-64bb6da9285c">

In Anthropic chat:
<img width="986" alt="image" src="https://github.com/jupyterlab/jupyter-ai/assets/29005/e5946c5c-0057-4a26-975d-269d789a61c8">

