### PR TITLE
Fix Cohere models by using new `langchain-cohere` partner package

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -160,7 +160,7 @@ Jupyter AI supports the following model providers:
 | Anthropic (chat)    | `anthropic-chat`     | `ANTHROPIC_API_KEY`        | `langchain-anthropic`           |
 | Bedrock             | `bedrock`            | N/A                        | `boto3`                         |
 | Bedrock (chat)      | `bedrock-chat`       | N/A                        | `boto3`                         |
-| Cohere              | `cohere`             | `COHERE_API_KEY`           | `cohere`                        |
+| Cohere              | `cohere`             | `COHERE_API_KEY`           | `langchain_cohere`              |
 | ERNIE-Bot           | `qianfan`            | `QIANFAN_AK`, `QIANFAN_SK` | `qianfan`                       |
 | Gemini              | `gemini`             | `GOOGLE_API_KEY`           | `langchain-google-genai`        |
 | GPT4All             | `gpt4all`            | N/A                        | `gpt4all`                       |

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
@@ -4,7 +4,6 @@ from ._version import __version__
 from .embedding_providers import (
     BaseEmbeddingsProvider,
     BedrockEmbeddingsProvider,
-    CohereEmbeddingsProvider,
     GPT4AllEmbeddingsProvider,
     HfHubEmbeddingsProvider,
     QianfanEmbeddingsEndpointProvider,
@@ -22,7 +21,6 @@ from .providers import (
     BaseProvider,
     BedrockChatProvider,
     BedrockProvider,
-    CohereProvider,
     GPT4AllProvider,
     HfHubProvider,
     QianfanProvider,

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -10,10 +10,8 @@ from jupyter_ai_magics.providers import (
 from langchain.pydantic_v1 import BaseModel, Extra
 from langchain_community.embeddings import (
     BedrockEmbeddings,
-    CohereEmbeddings,
     GPT4AllEmbeddings,
     HuggingFaceHubEmbeddings,
-    OpenAIEmbeddings,
     QianfanEmbeddingsEndpoint,
 )
 
@@ -66,23 +64,6 @@ class BaseEmbeddingsProvider(BaseModel):
             model_kwargs[self.__class__.model_id_key] = kwargs["model_id"]
 
         super().__init__(*args, **kwargs, **model_kwargs)
-
-
-class CohereEmbeddingsProvider(BaseEmbeddingsProvider, CohereEmbeddings):
-    id = "cohere"
-    name = "Cohere"
-    models = [
-        "embed-english-v2.0",
-        "embed-english-light-v2.0",
-        "embed-multilingual-v2.0",
-        "embed-english-v3.0",
-        "embed-english-light-v3.0",
-        "embed-multilingual-v3.0",
-        "embed-multilingual-light-v3.0",
-    ]
-    model_id_key = "model"
-    pypi_package_deps = ["cohere"]
-    auth_strategy = EnvAuthStrategy(name="COHERE_API_KEY")
 
 
 class HfHubEmbeddingsProvider(BaseEmbeddingsProvider, HuggingFaceHubEmbeddings):

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/cohere.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/cohere.py
@@ -1,0 +1,40 @@
+from langchain_cohere import ChatCohere, CohereEmbeddings
+
+from ..embedding_providers import BaseEmbeddingsProvider
+from ..providers import BaseProvider, EnvAuthStrategy
+
+
+class CohereProvider(BaseProvider, ChatCohere):
+    id = "cohere"
+    name = "Cohere"
+    # https://docs.cohere.com/docs/models
+    # note: This provider uses the Chat endpoint instead of the Generate
+    # endpoint, which is now deprecated.
+    models = [
+        "command",
+        "command-nightly",
+        "command-light",
+        "command-light-nightly",
+        "command-r-plus",
+        "command-r",
+    ]
+    model_id_key = "model"
+    pypi_package_deps = ["cohere"]
+    auth_strategy = EnvAuthStrategy(name="COHERE_API_KEY")
+
+
+class CohereEmbeddingsProvider(BaseEmbeddingsProvider, CohereEmbeddings):
+    id = "cohere"
+    name = "Cohere"
+    models = [
+        "embed-english-v2.0",
+        "embed-english-light-v2.0",
+        "embed-multilingual-v2.0",
+        "embed-english-v3.0",
+        "embed-english-light-v3.0",
+        "embed-multilingual-v3.0",
+        "embed-multilingual-light-v3.0",
+    ]
+    model_id_key = "model"
+    pypi_package_deps = ["cohere"]
+    auth_strategy = EnvAuthStrategy(name="COHERE_API_KEY")

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/cohere.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/cohere.py
@@ -19,7 +19,7 @@ class CohereProvider(BaseProvider, ChatCohere):
         "command-r",
     ]
     model_id_key = "model"
-    pypi_package_deps = ["cohere"]
+    pypi_package_deps = ["langchain_cohere"]
     auth_strategy = EnvAuthStrategy(name="COHERE_API_KEY")
 
 
@@ -36,5 +36,5 @@ class CohereEmbeddingsProvider(BaseEmbeddingsProvider, CohereEmbeddings):
         "embed-multilingual-light-v3.0",
     ]
     model_id_key = "model"
-    pypi_package_deps = ["cohere"]
+    pypi_package_deps = ["langchain_cohere"]
     auth_strategy = EnvAuthStrategy(name="COHERE_API_KEY")

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -36,7 +36,6 @@ from langchain_community.chat_models import BedrockChat, QianfanChatEndpoint
 from langchain_community.llms import (
     AI21,
     Bedrock,
-    Cohere,
     GPT4All,
     HuggingFaceEndpoint,
     SagemakerEndpoint,

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -546,26 +546,6 @@ class AI21Provider(BaseProvider, AI21):
         return False
 
 
-class CohereProvider(BaseProvider, Cohere):
-    id = "cohere"
-    name = "Cohere"
-    # Source: https://docs.cohere.com/reference/generate; https://docs.cohere.com/docs/models
-    models = [
-        "command",
-        "command-nightly",
-        "command-light",
-        "command-light-nightly",
-        "command-r-plus",
-        "command-r",
-    ]
-    model_id_key = "model"
-    pypi_package_deps = ["cohere"]
-    auth_strategy = EnvAuthStrategy(name="COHERE_API_KEY")
-
-    async def _acall(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
-        return await self._call_in_executor(*args, **kwargs)
-
-
 class GPT4AllProvider(BaseProvider, GPT4All):
     def __init__(self, **kwargs):
         model = kwargs.get("model_id")

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -36,15 +36,15 @@ test = ["coverage", "pytest", "pytest-asyncio", "pytest-cov"]
 
 all = [
     "ai21",
-    "cohere>4.40,<5",
     "gpt4all",
     "huggingface_hub",
     "ipywidgets",
     "langchain_anthropic",
-    "langchain-mistralai",
+    "langchain_cohere",
+    "langchain_google_genai",
+    "langchain_mistralai",
     "langchain_nvidia_ai_endpoints",
-    "langchain-google-genai",
-    "langchain-openai",
+    "langchain_openai",
     "pillow",
     "boto3",
     "qianfan",
@@ -55,7 +55,7 @@ all = [
 ai21 = "jupyter_ai_magics:AI21Provider"
 anthropic = "jupyter_ai_magics.partner_providers.anthropic:AnthropicProvider"
 anthropic-chat = "jupyter_ai_magics.partner_providers.anthropic:ChatAnthropicProvider"
-cohere = "jupyter_ai_magics:CohereProvider"
+cohere = "jupyter_ai_magics.partner_providers.cohere:CohereProvider"
 gpt4all = "jupyter_ai_magics:GPT4AllProvider"
 huggingface_hub = "jupyter_ai_magics:HfHubProvider"
 openai = "jupyter_ai_magics.partner_providers.openai:OpenAIProvider"
@@ -72,7 +72,7 @@ mistralai = "jupyter_ai_magics.partner_providers.mistralai:MistralAIProvider"
 
 [project.entry-points."jupyter_ai.embeddings_model_providers"]
 bedrock = "jupyter_ai_magics:BedrockEmbeddingsProvider"
-cohere = "jupyter_ai_magics:CohereEmbeddingsProvider"
+cohere = "jupyter_ai_magics.partner_providers.cohere:CohereEmbeddingsProvider"
 mistralai = "jupyter_ai_magics.partner_providers.mistralai:MistralAIEmbeddingsProvider"
 gpt4all = "jupyter_ai_magics:GPT4AllEmbeddingsProvider"
 huggingface_hub = "jupyter_ai_magics:HfHubEmbeddingsProvider"


### PR DESCRIPTION
## Description

- Uses new `langchain_cohere` partner package instead of deprecated import from `langchain_community`
- Uses new `ChatCohere` (ChatModel) class instead of deprecated `Cohere` (LLM) class to fix Cohere models
  - The previous `Cohere` class used the now-deprecated [Generate endpoint](https://docs.cohere.com/reference/generate).
  - The new `ChatCohere` class uses the [Chat endpoint](https://docs.cohere.com/reference/chat).

## Demo

Tested with `command-r` language model and `embed-english-v3.0` embedding model. 

<img width="705" alt="Screenshot 2024-06-21 at 7 20 24 AM" src="https://github.com/jupyterlab/jupyter-ai/assets/44106031/be0add46-73e4-488b-aace-5b10c4ec90b7">
