### PR TITLE
Fixed `/export` for timestamp, agent name

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -511,7 +511,7 @@ The `/learn` command also provides downloading and processing papers from the [a
 ```
 
 ### Exporting chat history
-Use the `/export` command to export the chat history from the current session to a markdown file named `chat_history-YYYY-MM-DD-HH-mm.md`. Using `/export <file_name>` will export the chat history to `<file_name>-YYYY-MM-DD-HH-mm.md` instead. You can export chat history as many times as you like in a single session. Each successive export will include the entire chat history up to that point in the session.
+Use the `/export` command to export the chat history from the current session to a markdown file named `chat_history-YYYY-MM-DD-HH-mm-ss.md`. Using `/export <file_name>` will export the chat history to `<file_name>` without the timestamp instead. You can export chat history as many times as you like in a single session. Each successive export will include the entire chat history up to that point in the session.
 
 
 ### Fixing a code cell with an error

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -511,7 +511,7 @@ The `/learn` command also provides downloading and processing papers from the [a
 ```
 
 ### Exporting chat history
-Use the `/export` command to export the chat history from the current session to a markdown file named `chat_history-YYYY-MM-DD-HH-mm-ss.md`. Using `/export <file_name>` will export the chat history to `<file_name>` without the timestamp instead. You can export chat history as many times as you like in a single session. Each successive export will include the entire chat history up to that point in the session.
+Use the `/export` command to export the chat history from the current session to a markdown file named `chat_history-YYYY-MM-DD-HH-mm-ss.md`. You can also specify a filename using `/export <file_name>`. Each export will include the entire chat history up to that point in the session.
 
 
 ### Fixing a code cell with an error

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
@@ -23,8 +23,8 @@ class ExportChatHandler(BaseChatHandler):
 
     def chat_message_to_markdown(self, message):
         if isinstance(message, AgentChatMessage):
-            Agent = self.config_manager.persona.name
-            return f"**{Agent}**: {message.body}"
+            agent = self.config_manager.persona.name
+            return f"**{agent}**: {message.body}"
         elif isinstance(message, HumanChatMessage):
             return f"**{message.client.display_name}**: {message.body}"
         else:

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
@@ -23,7 +23,8 @@ class ExportChatHandler(BaseChatHandler):
 
     def chat_message_to_markdown(self, message):
         if isinstance(message, AgentChatMessage):
-            return f"**Agent**: {message.body}"
+            Agent = self.config_manager.persona.name
+            return f"**{Agent}**: {message.body}"
         elif isinstance(message, HumanChatMessage):
             return f"**{message.client.display_name}**: {message.body}"
         else:
@@ -35,11 +36,10 @@ class ExportChatHandler(BaseChatHandler):
             self.chat_message_to_markdown(msg) for msg in self._chat_history
         )
         args = self.parse_args(message)
-        chat_filename = (
-            args.path[0] if (args.path and args.path[0] != "") else "chat_history"
+        chat_filename = ( # if no filename, use "chat_history" + timestamp
+            args.path[0] if (args.path and args.path[0] != "") else f"chat_history-{datetime.now():%Y-%m-%d-%H-%M-%S}.md"
         )  # Handles both empty args and double tap <Enter> key
-        chat_filename = f"{chat_filename}-{datetime.now():%Y-%m-%d-%H-%M}.md"
-        chat_file = os.path.join(self.root_dir, chat_filename)
+        chat_file = os.path.join(self.root_dir, chat_filename) # Do not use timestamp if filename is entered as argument
         with open(chat_file, "w") as chat_history:
             chat_history.write(markdown_content)
         self.reply(f"File saved to `{chat_file}`")


### PR DESCRIPTION
Fixes #852 

Fixes #853 

(1) Added seconds to the end of the filename with timestamp.
![image](https://github.com/jupyterlab/jupyter-ai/assets/29005/e0f342f0-1e0c-4ee2-aaa4-6e7dc037c693)

(2) If user provides a filename, we do not use the timestamp. This will allow the user to avoid using the timestamp if required. 
![image](https://github.com/jupyterlab/jupyter-ai/assets/29005/486906e9-2d57-4d54-a77e-a80e1dbca80f)

(3) If user does not provide a filename, we use "chat_history"+timestamp, as shown above. 

(4) Make sure the correct Agent name is used in the exported output.
![image](https://github.com/jupyterlab/jupyter-ai/assets/29005/bf078959-6a74-47f7-8437-e3f954270bf5)

(5) Updated the docs page for the `/export` command. 