### PR TITLE
Fix pending message overlapping text

### DIFF
--- a/packages/jupyter-ai/src/components/pending-messages.tsx
+++ b/packages/jupyter-ai/src/components/pending-messages.tsx
@@ -32,7 +32,7 @@ function PendingMessageElement(props: PendingMessageElementProps): JSX.Element {
   return (
     <Box>
       {text.split('\n').map((line, index) => (
-        <Typography key={index} sx={{ lineHeight: 0.6 }}>
+        <Typography key={index}>
           {line}
         </Typography>
       ))}


### PR DESCRIPTION
Removed the lineHeight style for pending messages. I added the lineHeight: 0.6 when I was using the paragraph <p> tags to have nicer line spacing to separate multiple pending messages. However, since the change to Typography, the lineHeight: 0.6 causes overlapping when text is wrapped or has multiple lines. The default styling already provides a nice line separation and does not need to be configured further.

Screenshot of overlapping issue.
<img width="278" alt="Screenshot 2024-06-22 at 6 30 36 PM" src="https://github.com/jupyterlab/jupyter-ai/assets/16421143/e3d4ae1a-5202-4e08-bca7-d0a73e828eda">
