### PR TITLE
Address error on `/learn` after change of embedding model

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -267,7 +267,7 @@ class LearnChatHandler(BaseChatHandler):
         for dir in metadata.dirs:
             # TODO: do not relearn directories in serial, but instead
             # concurrently or in parallel
-            await self.learn_dir(dir.path, dir.chunk_size, dir.chunk_overlap)
+            await self.learn_dir(dir.path, dir.chunk_size, dir.chunk_overlap, all_files=False)
 
         self.save()
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -267,7 +267,9 @@ class LearnChatHandler(BaseChatHandler):
         for dir in metadata.dirs:
             # TODO: do not relearn directories in serial, but instead
             # concurrently or in parallel
-            await self.learn_dir(dir.path, dir.chunk_size, dir.chunk_overlap, all_files=False)
+            await self.learn_dir(
+                dir.path, dir.chunk_size, dir.chunk_overlap, all_files=False
+            )
 
         self.save()
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -175,7 +175,7 @@ class LearnChatHandler(BaseChatHandler):
         return message
 
     async def learn_dir(
-        self, path: str, chunk_size: int, chunk_overlap: int, all_files: bool
+        self, path: str, chunk_size: int, chunk_overlap: int, all_files: bool=False
     ):
         dask_client: DaskClient = await self.dask_client_future
         splitter_kwargs = {"chunk_size": chunk_size, "chunk_overlap": chunk_overlap}

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -175,7 +175,7 @@ class LearnChatHandler(BaseChatHandler):
         return message
 
     async def learn_dir(
-        self, path: str, chunk_size: int, chunk_overlap: int, all_files: bool=False
+        self, path: str, chunk_size: int, chunk_overlap: int, all_files: bool = False
     ):
         dask_client: DaskClient = await self.dask_client_future
         splitter_kwargs = {"chunk_size": chunk_size, "chunk_overlap": chunk_overlap}


### PR DESCRIPTION
Fixes Issue #869 

The `all_files` parameter was not being passed to learn the RAG folder when the embedding provider is changed. This has now been fixed and tested. To test, an initial embedding model is used and `/learn` is applied. 
![image](https://github.com/jupyterlab/jupyter-ai/assets/29005/6a53de57-0dff-4a60-9bb5-f77d210e431e)

(See Issue #869 for the error that is addressed below.)

Next, the embedding model is changed on the settings page and `/learn` is tested again to make sure it is working as expected, as shown: 
![image](https://github.com/jupyterlab/jupyter-ai/assets/29005/b2ffb81f-8b26-4d75-9735-aa0ba31fe502)
