### PR TITLE
Add keyboard shortcut command to focus chat input

### DIFF
--- a/packages/jupyter-ai/schema/plugin.json
+++ b/packages/jupyter-ai/schema/plugin.json
@@ -8,7 +8,8 @@
     {
       "command": "jupyter-ai:focus-chat-input",
       "keys": ["Accel Shift 1"],
-      "selector": "body"
+      "selector": "body",
+      "preventDefault": false
     }
   ],
   "additionalProperties": false,

--- a/packages/jupyter-ai/schema/plugin.json
+++ b/packages/jupyter-ai/schema/plugin.json
@@ -4,6 +4,13 @@
   "description": "JupyterLab generative artificial intelligence integration.",
   "jupyter.lab.setting-icon": "jupyter-ai::chat",
   "jupyter.lab.setting-icon-label": "Jupyter AI Chat",
+  "jupyter.lab.shortcuts": [
+    {
+      "command": "jupyter-ai:focus-chat-input",
+      "keys": ["Accel Shift 1"],
+      "selector": "body"
+    }
+  ],
   "additionalProperties": false,
   "type": "object"
 }

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -34,7 +34,7 @@ type ChatInputProps = {
   onSend: (selection?: AiService.Selection) => unknown;
   hasSelection: boolean;
   includeSelection: boolean;
-  inputFocusRequested: ISignal<unknown, void>;
+  focusInputSignal: ISignal<unknown, void>;
   toggleIncludeSelection: () => unknown;
   replaceSelection: boolean;
   toggleReplaceSelection: () => unknown;
@@ -145,9 +145,9 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
         inputRef.current.focus();
       }
     };
-    props.inputFocusRequested.connect(focusInputElement);
+    props.focusInputSignal.connect(focusInputElement);
     return () => {
-      props.inputFocusRequested.disconnect(focusInputElement);
+      props.focusInputSignal.disconnect(focusInputElement);
     };
   }, []);
 

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import {
   Autocomplete,
@@ -22,6 +22,7 @@ import {
   HideSource,
   AutoFixNormal
 } from '@mui/icons-material';
+import { ISignal } from '@lumino/signaling';
 
 import { AiService } from '../handler';
 import { SendButton, SendButtonProps } from './chat-input/send-button';
@@ -33,6 +34,7 @@ type ChatInputProps = {
   onSend: (selection?: AiService.Selection) => unknown;
   hasSelection: boolean;
   includeSelection: boolean;
+  inputFocusRequested: ISignal<unknown, void>;
   toggleIncludeSelection: () => unknown;
   replaceSelection: boolean;
   toggleReplaceSelection: () => unknown;
@@ -130,6 +132,24 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
 
   // controls whether the slash command autocomplete is open
   const [open, setOpen] = useState<boolean>(false);
+
+  // store reference to the input element to enable focusing it easily
+  const inputRef = useRef<HTMLInputElement>();
+
+  /**
+   * Effect: connect the signal emitted on input focus request.
+   */
+  useEffect(() => {
+    const focusInputElement = () => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    };
+    props.inputFocusRequested.connect(focusInputElement);
+    return () => {
+      props.inputFocusRequested.disconnect(focusInputElement);
+    };
+  }, []);
 
   /**
    * Effect: Open the autocomplete when the user types a slash into an empty
@@ -284,6 +304,7 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
             multiline
             placeholder="Ask Jupyternaut"
             onKeyDown={handleKeyDown}
+            inputRef={inputRef}
             InputProps={{
               ...params.InputProps,
               endAdornment: (

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -6,6 +6,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import type { Awareness } from 'y-protocols/awareness';
 import type { IThemeManager } from '@jupyterlab/apputils';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { ISignal } from '@lumino/signaling';
 
 import { JlThemeProvider } from './jl-theme-provider';
 import { ChatMessages } from './chat-messages';
@@ -31,10 +32,12 @@ type ChatBodyProps = {
   chatHandler: ChatHandler;
   setChatView: (view: ChatView) => void;
   rmRegistry: IRenderMimeRegistry;
+  inputFocusRequested: ISignal<unknown, void>;
 };
 
 function ChatBody({
   chatHandler,
+  inputFocusRequested,
   setChatView: chatViewHandler,
   rmRegistry: renderMimeRegistry
 }: ChatBodyProps): JSX.Element {
@@ -162,6 +165,7 @@ function ChatBody({
         onSend={onSend}
         hasSelection={!!textSelection?.text}
         includeSelection={includeSelection}
+        inputFocusRequested={inputFocusRequested}
         toggleIncludeSelection={() =>
           setIncludeSelection(includeSelection => !includeSelection)
         }
@@ -192,6 +196,7 @@ export type ChatProps = {
   completionProvider: IJaiCompletionProvider | null;
   openInlineCompleterSettings: () => void;
   activeCellManager: ActiveCellManager;
+  inputFocusRequested: ISignal<unknown, void>;
 };
 
 enum ChatView {
@@ -244,6 +249,7 @@ export function Chat(props: ChatProps): JSX.Element {
                   chatHandler={props.chatHandler}
                   setChatView={setView}
                   rmRegistry={props.rmRegistry}
+                  inputFocusRequested={props.inputFocusRequested}
                 />
               )}
               {view === ChatView.Settings && (

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -32,12 +32,12 @@ type ChatBodyProps = {
   chatHandler: ChatHandler;
   setChatView: (view: ChatView) => void;
   rmRegistry: IRenderMimeRegistry;
-  inputFocusRequested: ISignal<unknown, void>;
+  focusInputSignal: ISignal<unknown, void>;
 };
 
 function ChatBody({
   chatHandler,
-  inputFocusRequested,
+  focusInputSignal,
   setChatView: chatViewHandler,
   rmRegistry: renderMimeRegistry
 }: ChatBodyProps): JSX.Element {
@@ -165,7 +165,7 @@ function ChatBody({
         onSend={onSend}
         hasSelection={!!textSelection?.text}
         includeSelection={includeSelection}
-        inputFocusRequested={inputFocusRequested}
+        focusInputSignal={focusInputSignal}
         toggleIncludeSelection={() =>
           setIncludeSelection(includeSelection => !includeSelection)
         }
@@ -196,7 +196,7 @@ export type ChatProps = {
   completionProvider: IJaiCompletionProvider | null;
   openInlineCompleterSettings: () => void;
   activeCellManager: ActiveCellManager;
-  inputFocusRequested: ISignal<unknown, void>;
+  focusInputSignal: ISignal<unknown, void>;
 };
 
 enum ChatView {
@@ -249,7 +249,7 @@ export function Chat(props: ChatProps): JSX.Element {
                   chatHandler={props.chatHandler}
                   setChatView={setView}
                   rmRegistry={props.rmRegistry}
-                  inputFocusRequested={props.inputFocusRequested}
+                  focusInputSignal={props.focusInputSignal}
                 />
               )}
               {view === ChatView.Settings && (

--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -21,8 +21,16 @@ import { statusItemPlugin } from './status';
 import { IJaiCompletionProvider } from './tokens';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ActiveCellManager } from './contexts/active-cell-context';
+import { Signal } from '@lumino/signaling';
 
 export type DocumentTracker = IWidgetTracker<IDocumentWidget>;
+
+export namespace CommandIDs {
+  /**
+   * Command to focus the input.
+   */
+  export const focusChatInput = 'jupyter-ai:focus-chat-input';
+}
 
 /**
  * Initialization data for the jupyter_ai extension.
@@ -66,7 +74,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
       });
     };
 
-    let chatWidget: ReactWidget | null = null;
+    const inputFocusRequested = new Signal<unknown, void>({});
+
+    let chatWidget: ReactWidget;
     try {
       await chatHandler.initialize();
       chatWidget = buildChatSidebar(
@@ -77,7 +87,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
         rmRegistry,
         completionProvider,
         openInlineCompleterSettings,
-        activeCellManager
+        activeCellManager,
+        inputFocusRequested
       );
     } catch (e) {
       chatWidget = buildErrorWidget(themeManager);
@@ -91,6 +102,15 @@ const plugin: JupyterFrontEndPlugin<void> = {
     if (restorer) {
       restorer.add(chatWidget, 'jupyter-ai-chat');
     }
+
+    // Define jupyter-ai commands
+    app.commands.addCommand(CommandIDs.focusChatInput, {
+      execute: () => {
+        app.shell.activateById(chatWidget.id);
+        inputFocusRequested.emit();
+      },
+      label: 'Focus the jupyter-ai chat'
+    });
   }
 };
 

--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -74,7 +74,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       });
     };
 
-    const inputFocusRequested = new Signal<unknown, void>({});
+    const focusInputSignal = new Signal<unknown, void>({});
 
     let chatWidget: ReactWidget;
     try {
@@ -88,7 +88,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
         completionProvider,
         openInlineCompleterSettings,
         activeCellManager,
-        inputFocusRequested
+        focusInputSignal
       );
     } catch (e) {
       chatWidget = buildErrorWidget(themeManager);
@@ -107,7 +107,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     app.commands.addCommand(CommandIDs.focusChatInput, {
       execute: () => {
         app.shell.activateById(chatWidget.id);
-        inputFocusRequested.emit();
+        focusInputSignal.emit();
       },
       label: 'Focus the jupyter-ai chat'
     });

--- a/packages/jupyter-ai/src/widgets/chat-sidebar.tsx
+++ b/packages/jupyter-ai/src/widgets/chat-sidebar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ISignal } from '@lumino/signaling';
 import { ReactWidget } from '@jupyterlab/apputils';
 import type { IThemeManager } from '@jupyterlab/apputils';
 import type { Awareness } from 'y-protocols/awareness';
@@ -19,7 +20,8 @@ export function buildChatSidebar(
   rmRegistry: IRenderMimeRegistry,
   completionProvider: IJaiCompletionProvider | null,
   openInlineCompleterSettings: () => void,
-  activeCellManager: ActiveCellManager
+  activeCellManager: ActiveCellManager,
+  inputFocusRequested: ISignal<unknown, void>
 ): ReactWidget {
   const ChatWidget = ReactWidget.create(
     <Chat
@@ -31,6 +33,7 @@ export function buildChatSidebar(
       completionProvider={completionProvider}
       openInlineCompleterSettings={openInlineCompleterSettings}
       activeCellManager={activeCellManager}
+      inputFocusRequested={inputFocusRequested}
     />
   );
   ChatWidget.id = 'jupyter-ai::chat';

--- a/packages/jupyter-ai/src/widgets/chat-sidebar.tsx
+++ b/packages/jupyter-ai/src/widgets/chat-sidebar.tsx
@@ -21,7 +21,7 @@ export function buildChatSidebar(
   completionProvider: IJaiCompletionProvider | null,
   openInlineCompleterSettings: () => void,
   activeCellManager: ActiveCellManager,
-  inputFocusRequested: ISignal<unknown, void>
+  focusInputSignal: ISignal<unknown, void>
 ): ReactWidget {
   const ChatWidget = ReactWidget.create(
     <Chat
@@ -33,7 +33,7 @@ export function buildChatSidebar(
       completionProvider={completionProvider}
       openInlineCompleterSettings={openInlineCompleterSettings}
       activeCellManager={activeCellManager}
-      inputFocusRequested={inputFocusRequested}
+      focusInputSignal={focusInputSignal}
     />
   );
   ChatWidget.id = 'jupyter-ai::chat';


### PR DESCRIPTION
This is one way to fix https://github.com/jupyterlab/jupyter-ai/issues/799

This implementation uses a signal to trigger the focus event.

There are two alternatives:
- passing the `inputRef` from where the command is defined, all the way down to the React element
- setting a hard-coded ID on the input element and discovering it in the command by querying DOM

A distinct advantage of the alternative approaches would be that they could also check if the input element is already focused (something that a signal cannot do). That said, using a signal is clearer with respect to the API surface, and the detection of focus state can be done by using a selector on the shortcut.

If you would prefer me to use one of the alternative approaches I would argue in favour of `inputRef` over hard-coded ID on the basis of better type safety and integrity guarantees.

--

The first commit includes a shortcut `Accel Shift 1` but I am not set on keeping this shortcut, we could choose a different on in the review, or remove it and let user choose a shortcut (but this would mean users need to define it in the JSON Settings Editor manually as the UI editor does not support it yet, c-f https://github.com/jupyterlab/jupyterlab/issues/13705).

To enable loading of the shortcut from schema this PR includes a change to the plugin ID, but I also opened a dedicated PR to fix this across the board: https://github.com/jupyterlab/jupyter-ai/pull/872.

Please let me know what you all think.