### PR TITLE
Limit chat input height to 20 lines

### DIFF
--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -287,7 +287,10 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
             InputProps={{
               ...params.InputProps,
               endAdornment: (
-                <InputAdornment position="end">
+                <InputAdornment
+                  position="end"
+                  sx={{ height: 'unset', alignSelf: 'flex-end' }}
+                >
                   <SendButton {...sendButtonProps} />
                 </InputAdornment>
               )

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -280,6 +280,7 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
             {...params}
             fullWidth
             variant="outlined"
+            maxRows={20}
             multiline
             placeholder="Ask Jupyternaut"
             onKeyDown={handleKeyDown}


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-ai/issues/796

| Before | After | After (Firefox) |
|--|--|--|
| ![Screenshot from 2024-07-07 16-47-33](https://github.com/jupyterlab/jupyter-ai/assets/5832902/2f90b990-c1b9-4df4-b26a-8a6d1f088e74) | ![Screenshot from 2024-07-07 16-48-01](https://github.com/jupyterlab/jupyter-ai/assets/5832902/e604e1c2-d0f3-4447-96b3-5a6c8a3a0d65) | ![image](https://github.com/jupyterlab/jupyter-ai/assets/5832902/d155ff2d-ac01-4e2a-8fc1-46079c31c9b3) |

Why 20? Because in my testing I saw that:
- ChatGPT limits displayed lines to 20
- VSCode limits displayed lines to 10

I think it is better to go with a larger number. I am happy to change it to a different number based on review though :)

As to the visible scrollbar in Chrome:
- VSCode appears to hide scrollbars (which is not very accessible), ChatGPT shows it the same
- we could use `scrollbar-width: thin` or change the side of the scrollbar (here simulated with `direction: rtl; text-align: left;` trick, but it is not accessible; there is a clean solution but mui does not support it)

| Chrome as-is | Chrome thin | Chrome flipped side |
|--|--|--|
| ![Screenshot from 2024-07-07 16-48-01](https://github.com/jupyterlab/jupyter-ai/assets/5832902/e604e1c2-d0f3-4447-96b3-5a6c8a3a0d65) | ![image](https://github.com/jupyterlab/jupyter-ai/assets/5832902/ef6ad529-3a19-4251-8d26-75817e45222d) | ![image](https://github.com/jupyterlab/jupyter-ai/assets/5832902/6b1aa9d1-aa97-4183-a595-8f09ec5b9608) |

Alternatively we could move it to the right of the send button by reimplementing `endAdornment` as an element placed outside; this is trivial by making it `position: absolute; right: 20px` but would need some background to cover the text which might be underneath:

![image](https://github.com/jupyterlab/jupyter-ai/assets/5832902/794b20e4-2309-4e04-8faf-1b6d54edd35c)

While covering some text might be annoying at times, this could be a good tradeoff as it would increase the width available for the user prompt.