### PR TITLE
Upload `jupyter-releaser` built distributions

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -30,7 +30,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jupyter-ai-jupyter-releaser-dist-${{ github.run_number }}
-          path: .jupyter_releaser_checkout/dist
+          path: |
+            .jupyter_releaser_checkout/packages/jupyter-ai/dist
+            .jupyter_releaser_checkout/packages/jupyter-ai-magics/dist
 
       - name: Runner debug info
         if: always()

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -26,6 +26,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: minor
 
+      - name: Upload Distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: jupyter-ai-jupyter-releaser-dist-${{ github.run_number }}
+          path: .jupyter_releaser_checkout/dist
 
       - name: Runner debug info
         if: always()

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -30,9 +30,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jupyter-ai-jupyter-releaser-dist-${{ github.run_number }}
-          path: |
-            .jupyter_releaser_checkout/packages/jupyter-ai/dist
-            .jupyter_releaser_checkout/packages/jupyter-ai-magics/dist
+          path: .jupyter_releaser_checkout/dist
 
       - name: Runner debug info
         if: always()


### PR DESCRIPTION
Update the `check-release` workflow to upload the distributions built by the releaser as GitHub artifacts, so they can be downloaded and installed locally easily.

This makes it easier for folks to try the latest commit on the `main` branch for instance.

This is what it looks like on the JupyterLab repo for reference:

![image](https://github.com/user-attachments/assets/3d99a04a-393b-456f-86b8-ed73eb6e0ffe)
