### PR TITLE
Fix streaming in `HuggingFaceHub` provider

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -627,35 +627,6 @@ class HfHubProvider(BaseProvider, HuggingFaceEndpoint):
     auth_strategy = EnvAuthStrategy(name="HUGGINGFACEHUB_API_TOKEN")
     registry = True
 
-    # Override the parent's validate_environment with a custom list of valid tasks
-    @root_validator()
-    def validate_environment(cls, values: Dict) -> Dict:
-        """Validate that api key and python package exists in environment."""
-        try:
-            huggingfacehub_api_token = get_from_dict_or_env(
-                values, "huggingfacehub_api_token", "HUGGINGFACEHUB_API_TOKEN"
-            )
-        except Exception as e:
-            raise ValueError(
-                "Could not authenticate with huggingface_hub. "
-                "Please check your API token."
-            ) from e
-        try:
-            from huggingface_hub import InferenceClient
-
-            values["client"] = InferenceClient(
-                model=values["model"],
-                timeout=values["timeout"],
-                token=huggingfacehub_api_token,
-                **values["server_kwargs"],
-            )
-        except ImportError:
-            raise ValueError(
-                "Could not import huggingface_hub python package. "
-                "Please install it with `pip install huggingface_hub`."
-            )
-        return values
-
     # Handle text and image outputs
     def _call(
         self, prompt: str, stop: Optional[List[str]] = None, **kwargs: Any


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-ai/issues/883

The overridden method is no longer overriding allowed task list since #784 but is only breaking streaming -  it can be removed.

Tested that both chat, streaming of inline completion and image generation works:

![image](https://github.com/user-attachments/assets/17eb97a8-e7b2-492d-bb22-7856df9dc769)
![Screenshot from 2024-07-12 18-20-46](https://github.com/user-attachments/assets/2aa0c10f-622c-4962-ba1e-8b40860ea47e)
![Screenshot from 2024-07-12 18-08-19](https://github.com/user-attachments/assets/50537dc9-57dd-4793-91f8-803fa00863fa)
