### PR TITLE
Rework selection replacement

### DIFF
--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -36,8 +36,6 @@ type ChatInputProps = {
   includeSelection: boolean;
   focusInputSignal: ISignal<unknown, void>;
   toggleIncludeSelection: () => unknown;
-  replaceSelection: boolean;
-  toggleReplaceSelection: () => unknown;
   sendWithShiftEnter: boolean;
   sx?: SxProps<Theme>;
 };
@@ -333,15 +331,6 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
               />
             }
             label="Include selection"
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={props.replaceSelection}
-                onChange={props.toggleReplaceSelection}
-              />
-            }
-            label="Replace selection"
           />
         </FormGroup>
       )}

--- a/packages/jupyter-ai/src/components/chat-messages.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages.tsx
@@ -9,6 +9,7 @@ import { ServerConnection } from '@jupyterlab/services';
 import { AiService } from '../handler';
 import { RendermimeMarkdown } from './rendermime-markdown';
 import { useCollaboratorsContext } from '../contexts/collaborators-context';
+import { ChatMessageMenu } from './chat-messages/chat-message-menu';
 
 type ChatMessagesProps = {
   rmRegistry: IRenderMimeRegistry;
@@ -107,6 +108,10 @@ export function ChatMessageHeader(props: ChatMessageHeaderProps): JSX.Element {
       ? props.message.client.display_name
       : props.message.persona.name;
 
+  const shouldShowMenu =
+    props.message.type === 'agent' ||
+    (props.message.type === 'agent-stream' && props.message.complete);
+
   return (
     <Box
       sx={{
@@ -131,15 +136,23 @@ export function ChatMessageHeader(props: ChatMessageHeaderProps): JSX.Element {
         <Typography sx={{ fontWeight: 700, color: 'var(--jp-ui-font-color1)' }}>
           {name}
         </Typography>
-        <Typography
-          sx={{
-            fontSize: '0.8em',
-            color: 'var(--jp-ui-font-color2)',
-            fontWeight: 300
-          }}
-        >
-          {props.timestamp}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Typography
+            sx={{
+              fontSize: '0.8em',
+              color: 'var(--jp-ui-font-color2)',
+              fontWeight: 300
+            }}
+          >
+            {props.timestamp}
+          </Typography>
+          {shouldShowMenu && (
+            <ChatMessageMenu
+              message={props.message}
+              sx={{ marginLeft: '4px', marginRight: '-8px' }}
+            />
+          )}
+        </Box>
       </Box>
     </Box>
   );

--- a/packages/jupyter-ai/src/components/chat-messages/chat-message-menu.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages/chat-message-menu.tsx
@@ -1,0 +1,94 @@
+import React, { useRef, useState } from 'react';
+
+import { IconButton, Menu, MenuItem, SxProps } from '@mui/material';
+import { MoreVert } from '@mui/icons-material';
+import {
+  addAboveIcon,
+  addBelowIcon,
+  copyIcon
+} from '@jupyterlab/ui-components';
+
+import { AiService } from '../../handler';
+import { CopyStatus, useCopy } from '../../hooks/use-copy';
+import { useReplace } from '../../hooks/use-replace';
+import { useActiveCellContext } from '../../contexts/active-cell-context';
+import { replaceCellIcon } from '../../icons';
+
+type ChatMessageMenuProps = {
+  message: AiService.ChatMessage;
+
+  /**
+   * Styles applied to the menu icon button.
+   */
+  sx?: SxProps;
+};
+
+export function ChatMessageMenu(props: ChatMessageMenuProps): JSX.Element {
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const { copy, copyLabel } = useCopy({
+    labelOverrides: { [CopyStatus.None]: 'Copy response' }
+  });
+  const { replace, replaceLabel } = useReplace();
+  const activeCell = useActiveCellContext();
+
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const openMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+    setMenuOpen(true);
+  };
+
+  const insertAboveLabel = activeCell.exists
+    ? 'Insert response above active cell'
+    : 'Insert response above active cell (no active cell)';
+
+  const insertBelowLabel = activeCell.exists
+    ? 'Insert response below active cell'
+    : 'Insert response below active cell (no active cell)';
+
+  const menuItemSx: SxProps = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    lineHeight: 0
+  };
+
+  return (
+    <>
+      <IconButton onClick={openMenu} ref={menuButtonRef} sx={props.sx}>
+        <MoreVert />
+      </IconButton>
+      <Menu
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        anchorEl={anchorEl}
+      >
+        <MenuItem onClick={() => copy(props.message.body)} sx={menuItemSx}>
+          <copyIcon.react />
+          {copyLabel}
+        </MenuItem>
+        <MenuItem onClick={() => replace(props.message.body)} sx={menuItemSx}>
+          <replaceCellIcon.react />
+          {replaceLabel}
+        </MenuItem>
+        <MenuItem
+          onClick={() => activeCell.manager.insertAbove(props.message.body)}
+          disabled={!activeCell.exists}
+          sx={menuItemSx}
+        >
+          <addAboveIcon.react />
+          {insertAboveLabel}
+        </MenuItem>
+        <MenuItem
+          onClick={() => activeCell.manager.insertBelow(props.message.body)}
+          disabled={!activeCell.exists}
+          sx={menuItemSx}
+        >
+          <addBelowIcon.react />
+          {insertBelowLabel}
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -49,9 +49,8 @@ function ChatBody({
   >([...chatHandler.history.pending_messages]);
   const [showWelcomeMessage, setShowWelcomeMessage] = useState<boolean>(false);
   const [includeSelection, setIncludeSelection] = useState(true);
-  const [replaceSelection, setReplaceSelection] = useState(false);
   const [input, setInput] = useState('');
-  const [textSelection, replaceTextSelection] = useSelectionContext();
+  const [textSelection] = useSelectionContext();
   const [sendWithShiftEnter, setSendWithShiftEnter] = useState(true);
 
   /**
@@ -105,17 +104,7 @@ function ChatBody({
     const messageId = await chatHandler.sendMessage({ prompt, selection });
 
     // await reply from agent
-    // no need to append to messageGroups state variable, since that's already
-    // handled in the effect hooks.
-    const reply = await chatHandler.replyFor(messageId);
-    if (replaceSelection && textSelection) {
-      const { cellId, ...selectionProps } = textSelection;
-      replaceTextSelection({
-        ...selectionProps,
-        ...(cellId && { cellId }),
-        text: reply.body
-      });
-    }
+    await chatHandler.replyFor(messageId);
   };
 
   const openSettingsView = () => {
@@ -168,10 +157,6 @@ function ChatBody({
         focusInputSignal={focusInputSignal}
         toggleIncludeSelection={() =>
           setIncludeSelection(includeSelection => !includeSelection)
-        }
-        replaceSelection={replaceSelection}
-        toggleReplaceSelection={() =>
-          setReplaceSelection(replaceSelection => !replaceSelection)
         }
         sx={{
           paddingLeft: 4,

--- a/packages/jupyter-ai/src/components/code-blocks/code-toolbar.tsx
+++ b/packages/jupyter-ai/src/components/code-blocks/code-toolbar.tsx
@@ -10,6 +10,7 @@ import {
   useActiveCellContext
 } from '../../contexts/active-cell-context';
 import { TooltippedIconButton } from '../mui-extras/tooltipped-icon-button';
+import { useReplace } from '../../hooks/use-replace';
 
 export type CodeToolbarProps = {
   /**
@@ -40,7 +41,7 @@ export function CodeToolbar(props: CodeToolbarProps): JSX.Element {
     >
       <InsertAboveButton {...sharedToolbarButtonProps} />
       <InsertBelowButton {...sharedToolbarButtonProps} />
-      <ReplaceButton {...sharedToolbarButtonProps} />
+      <ReplaceButton value={props.content} />
       <CopyButton value={props.content} />
     </Box>
   );
@@ -84,16 +85,14 @@ function InsertBelowButton(props: ToolbarButtonProps) {
   );
 }
 
-function ReplaceButton(props: ToolbarButtonProps) {
-  const tooltip = props.activeCellExists
-    ? 'Replace active cell'
-    : 'Replace active cell (no active cell)';
+function ReplaceButton(props: { value: string }) {
+  const { replace, replaceDisabled, replaceLabel } = useReplace();
 
   return (
     <TooltippedIconButton
-      tooltip={tooltip}
-      disabled={!props.activeCellExists}
-      onClick={() => props.activeCellManager.replace(props.content)}
+      tooltip={replaceLabel}
+      disabled={replaceDisabled}
+      onClick={() => replace(props.value)}
     >
       <replaceCellIcon.react height="16px" width="16px" />
     </TooltippedIconButton>

--- a/packages/jupyter-ai/src/components/code-blocks/copy-button.tsx
+++ b/packages/jupyter-ai/src/components/code-blocks/copy-button.tsx
@@ -1,55 +1,22 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React from 'react';
 
 import { copyIcon } from '@jupyterlab/ui-components';
 
 import { TooltippedIconButton } from '../mui-extras/tooltipped-icon-button';
-
-enum CopyStatus {
-  None,
-  Copying,
-  Copied
-}
-
-const COPYBTN_TEXT_BY_STATUS: Record<CopyStatus, string> = {
-  [CopyStatus.None]: 'Copy to clipboard',
-  [CopyStatus.Copying]: 'Copying…',
-  [CopyStatus.Copied]: 'Copied!'
-};
+import { useCopy } from '../../hooks/use-copy';
 
 type CopyButtonProps = {
   value: string;
 };
 
 export function CopyButton(props: CopyButtonProps): JSX.Element {
-  const [copyStatus, setCopyStatus] = useState<CopyStatus>(CopyStatus.None);
-  const timeoutId = useRef<number | null>(null);
-
-  const copy = useCallback(async () => {
-    // ignore if we are already copying
-    if (copyStatus === CopyStatus.Copying) {
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(props.value);
-    } catch (err) {
-      console.error('Failed to copy text: ', err);
-      setCopyStatus(CopyStatus.None);
-      return;
-    }
-
-    setCopyStatus(CopyStatus.Copied);
-    if (timeoutId.current) {
-      clearTimeout(timeoutId.current);
-    }
-    timeoutId.current = setTimeout(() => setCopyStatus(CopyStatus.None), 1000);
-  }, [copyStatus, props.value]);
+  const { copy, label } = useCopy();
 
   return (
     <TooltippedIconButton
-      tooltip={COPYBTN_TEXT_BY_STATUS[copyStatus]}
+      tooltip={label}
       placement="top"
-      onClick={copy}
+      onClick={() => copy(props.value)}
       aria-label="Copy to clipboard"
     >
       <copyIcon.react height="16px" width="16px" />

--- a/packages/jupyter-ai/src/components/code-blocks/copy-button.tsx
+++ b/packages/jupyter-ai/src/components/code-blocks/copy-button.tsx
@@ -10,11 +10,11 @@ type CopyButtonProps = {
 };
 
 export function CopyButton(props: CopyButtonProps): JSX.Element {
-  const { copy, label } = useCopy();
+  const { copy, copyLabel } = useCopy();
 
   return (
     <TooltippedIconButton
-      tooltip={label}
+      tooltip={copyLabel}
       placement="top"
       onClick={() => copy(props.value)}
       aria-label="Copy to clipboard"

--- a/packages/jupyter-ai/src/hooks/use-copy.ts
+++ b/packages/jupyter-ai/src/hooks/use-copy.ts
@@ -28,7 +28,7 @@ export type UseCopyReturn = {
    * This can be selectively overridden via the `labelOverrides` prop passed to
    * the `useCopy()` hook.
    */
-  label: string;
+  copyLabel: string;
   /**
    * Function that takes a string and copies it to the clipboard.
    */
@@ -41,6 +41,10 @@ const DEFAULT_LABELS_BY_COPY_STATUS: Record<CopyStatus, string> = {
   [CopyStatus.Copied]: 'Copied!'
 };
 
+/**
+ * Hook that provides a function to copy a string to a clipboard and manages
+ * related UI state. Should be used by any button that intends to copy text.
+ */
 export function useCopy(props?: UseCopyProps): UseCopyReturn {
   const [copyStatus, setCopyStatus] = useState<CopyStatus>(CopyStatus.None);
   const timeoutId = useRef<number | null>(null);
@@ -72,14 +76,14 @@ export function useCopy(props?: UseCopyProps): UseCopyReturn {
     [copyStatus]
   );
 
-  const label = {
+  const copyLabel = {
     ...DEFAULT_LABELS_BY_COPY_STATUS,
     ...props?.labelOverrides
   }[copyStatus];
 
   return {
     copyStatus,
-    label,
+    copyLabel,
     copy
   };
 }

--- a/packages/jupyter-ai/src/hooks/use-copy.ts
+++ b/packages/jupyter-ai/src/hooks/use-copy.ts
@@ -1,0 +1,85 @@
+import { useState, useRef, useCallback } from 'react';
+
+export enum CopyStatus {
+  None,
+  Copying,
+  Copied
+}
+
+export type UseCopyProps = {
+  /**
+   * List of labels by copy status. Used to override the default labels provided
+   * by this hook.
+   */
+  labelOverrides?: Partial<Record<CopyStatus, string>>;
+};
+
+export type UseCopyReturn = {
+  /**
+   * The status of the copy operation. This is set to CopyStatus.None when no
+   * copy operation was performed, set to CopyStatus.Copying while the copy
+   * operation is executing, and set to CopyStatus.Copied for 1000ms after the
+   * copy operation completes.
+   *
+   */
+  copyStatus: CopyStatus;
+  /**
+   * Label that should be shown by the copy button based on the copy status.
+   * This can be selectively overridden via the `labelOverrides` prop passed to
+   * the `useCopy()` hook.
+   */
+  label: string;
+  /**
+   * Function that takes a string and copies it to the clipboard.
+   */
+  copy: (value: string) => unknown;
+};
+
+const DEFAULT_LABELS_BY_COPY_STATUS: Record<CopyStatus, string> = {
+  [CopyStatus.None]: 'Copy to clipboard',
+  [CopyStatus.Copying]: 'Copying…',
+  [CopyStatus.Copied]: 'Copied!'
+};
+
+export function useCopy(props?: UseCopyProps): UseCopyReturn {
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>(CopyStatus.None);
+  const timeoutId = useRef<number | null>(null);
+
+  const copy = useCallback(
+    async (value: string) => {
+      // ignore if we are already copying
+      if (copyStatus === CopyStatus.Copying) {
+        return;
+      }
+
+      try {
+        await navigator.clipboard.writeText(value);
+      } catch (err) {
+        console.error('Failed to copy text: ', err);
+        setCopyStatus(CopyStatus.None);
+        return;
+      }
+
+      setCopyStatus(CopyStatus.Copied);
+      if (timeoutId.current) {
+        clearTimeout(timeoutId.current);
+      }
+      timeoutId.current = setTimeout(
+        () => setCopyStatus(CopyStatus.None),
+        1000
+      );
+    },
+    [copyStatus]
+  );
+
+  const label = {
+    ...DEFAULT_LABELS_BY_COPY_STATUS,
+    ...props?.labelOverrides
+  }[copyStatus];
+
+  return {
+    copyStatus,
+    label,
+    copy
+  };
+}

--- a/packages/jupyter-ai/src/hooks/use-replace.ts
+++ b/packages/jupyter-ai/src/hooks/use-replace.ts
@@ -1,0 +1,55 @@
+import { useActiveCellContext } from '../contexts/active-cell-context';
+import { useSelectionContext } from '../contexts/selection-context';
+
+export type UseReplaceReturn = {
+  /**
+   * If a user has a range of text selected, this function replaces the
+   * selection range with `value`. Otherwise, if the user has an active notebook
+   * cell, this function replaces the contents of the active cell with `value`.
+   *
+   * Otherwise (if a user does not have a text selection or active cell), this
+   * function does nothing.
+   */
+  replace: (value: string) => unknown;
+  /**
+   * Whether the replace button should be disabled, i.e. the user does not have
+   * a text selection or active cell.
+   */
+  replaceDisabled: boolean;
+  /**
+   * Label that should be shown by the replace button using this hook.
+   */
+  replaceLabel: string;
+};
+
+/**
+ * Hook that provides a function to either replace a text selection or an active
+ * cell. Manages related UI state. Should be used by any button that intends to
+ * replace some user selection.
+ */
+export function useReplace(): UseReplaceReturn {
+  const [textSelection, replaceTextSelection] = useSelectionContext();
+  const activeCell = useActiveCellContext();
+
+  const replace = (value: string) => {
+    if (textSelection) {
+      replaceTextSelection({ ...textSelection, text: value });
+    } else if (activeCell.exists) {
+      activeCell.manager.replace(value);
+    }
+  };
+
+  const replaceDisabled = !(textSelection || activeCell.exists);
+
+  const replaceLabel = textSelection
+    ? `Replace selection (${textSelection.text.split('\n').length} lines)`
+    : activeCell.exists
+    ? 'Replace selection (1 active cell)'
+    : 'Replace selection (no selection or active cell)';
+
+  return {
+    replace,
+    replaceDisabled,
+    replaceLabel
+  };
+}

--- a/packages/jupyter-ai/src/hooks/use-replace.ts
+++ b/packages/jupyter-ai/src/hooks/use-replace.ts
@@ -41,8 +41,9 @@ export function useReplace(): UseReplaceReturn {
 
   const replaceDisabled = !(textSelection || activeCell.exists);
 
+  const numLines = textSelection?.text.split('\n').length || 0;
   const replaceLabel = textSelection
-    ? `Replace selection (${textSelection.text.split('\n').length} lines)`
+    ? `Replace selection (${numLines} ${numLines === 1 ? 'line' : 'lines'})`
     : activeCell.exists
     ? 'Replace selection (1 active cell)'
     : 'Replace selection (no selection or active cell)';


### PR DESCRIPTION
## Description

- Removes "Replace selection" checkbox that shows underneath the chat input when the user selects a range of text
- Re-implements selection replacement by _allowing users to both replace a text selection or an active cell_, with the text selection taking priority.
- Implements a hamburger menu that shows next to each agent message, which allows replacing/inserting the entire response (not just a single code block) into the user's main panel.
- Fixes #865.

## Demo

https://github.com/user-attachments/assets/7f7fba6e-b887-42e4-8652-4b7aa78f8750


