### PR TITLE
Upgrade to `langchain~=0.2.0` and `langchain_community~=0.2.0`

### DIFF
--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -23,7 +23,8 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 dependencies = [
     "ipython",
     "importlib_metadata>=5.2.0",
-    "langchain>=0.1.0,<0.2.0",
+    "langchain>=0.2.0,<0.3.0",
+    "langchain_community>=0.2.0,<0.3.0",
     "typing_extensions>=4.5.0",
     "click~=8.0",
     "jsonpath-ng>=1.5.3,<2",

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -23,8 +23,8 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 dependencies = [
     "ipython",
     "importlib_metadata>=5.2.0",
-    "langchain>=0.2.0,<0.3.0",
-    "langchain_community>=0.2.0,<0.3.0",
+    "langchain>=0.1.0,<0.3.0",
+    "langchain_community>=0.1.0,<0.3.0",
     "typing_extensions>=4.5.0",
     "click~=8.0",
     "jsonpath-ng>=1.5.3,<2",


### PR DESCRIPTION
Fixes #856.

- Declares a new direct dependency on the `langchain_community` package, since the newer versions of the `langchain` package no longer depend on `langchain_community`.
- Verified default chat, `/fix`, `/learn`, and `/ask` functionality locally after fresh dev installation.

