### PR TITLE
Update docs to reflect Python 3.12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Documentation is available on [ReadTheDocs](https://jupyter-ai.readthedocs.io/en
 
 You will need to have installed the following software to use Jupyter AI:
 
-- Python 3.8 - 3.11
+- Python 3.8 - 3.12
 - JupyterLab 4 or Notebook 7
 
 In addition, you will need access to at least one model provider.

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -18,7 +18,7 @@ Issues and pull requests that violate the above principles may be declined. If y
 
 ## Prerequisites
 
-You can develop Jupyter AI on any system that can run a supported Python version up to and including 3.11, including recent Windows, macOS, and Linux versions.
+You can develop Jupyter AI on any system that can run a supported Python version up to and including 3.12, including recent Windows, macOS, and Linux versions.
 
 Each Jupyter AI major version works with only one major version of JupyterLab. Jupyter AI 1.x supports JupyterLab 3.x, and Jupyter AI 2.x supports JupyterLab 4.x.
 
@@ -35,7 +35,7 @@ Due to a compatibility issue with Webpack, Node.js 18.15.0 does not work with Ju
 After you have installed the prerequisites, create a new conda environment and activate it.
 
 ```
-conda create -n jupyter-ai -c conda-forge python=3.11 nodejs=20
+conda create -n jupyter-ai -c conda-forge python=3.12 nodejs=20
 conda activate jupyter-ai
 ```
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -11,12 +11,12 @@ please see the {doc}`developer's guide </developers/index>`.
 ## Prerequisites
 
 You can run Jupyter AI on any system that can run a supported Python version
-from 3.8 to 3.11, including recent Windows, macOS, and Linux versions.
+from 3.8 to 3.12, including recent Windows, macOS, and Linux versions.
 
-If you use `conda`, you can install Python 3.11 in your environment by running:
+If you use `conda`, you can install Python 3.12 in your environment by running:
 
 ```
-conda install python=3.11
+conda install python=3.12
 ```
 
 The `jupyter_ai` package, which provides the lab extension and user interface in
@@ -111,9 +111,9 @@ environment.
 
 First, install
 [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
-and create an environment that uses Python 3.11:
+and create an environment that uses Python 3.12:
 
-    $ conda create -n jupyter-ai python=3.11
+    $ conda create -n jupyter-ai python=3.12
     $ conda activate jupyter-ai
 
 Then, use `conda` to install JupyterLab and Jupyter AI in this Conda environment.

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]

--- a/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.root_dir_name}}/README.md
+++ b/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.root_dir_name}}/README.md
@@ -6,7 +6,7 @@ extension.
 
 ## Requirements
 
-- Python 3.8 - 3.11
+- Python 3.8 - 3.12
 - JupyterLab 4
 
 ## Install

--- a/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.root_dir_name}}/pyproject.toml
+++ b/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.root_dir_name}}/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 version = "{{ cookiecutter.version }}"
 description = "A Jupyter AI extension."

--- a/packages/jupyter-ai-test/README.md
+++ b/packages/jupyter-ai-test/README.md
@@ -6,7 +6,7 @@ environment. This package should never published on NPM or PyPI.
 
 ## Requirements
 
-- Python 3.8 - 3.11
+- Python 3.8 - 3.12
 - JupyterLab 4
 
 ## Install

--- a/packages/jupyter-ai-test/pyproject.toml
+++ b/packages/jupyter-ai-test/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 version = "0.1.0"
 description = "A Jupyter AI extension."

--- a/packages/jupyter-ai/README.md
+++ b/packages/jupyter-ai/README.md
@@ -24,9 +24,9 @@ Before you can use Jupyter AI, you will need to install any packages and set env
 
 ### With conda
 
-First, install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) and create an environment that uses Python 3.11:
+First, install [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) and create an environment that uses Python 3.12:
 
-    $ conda create -n jupyter-ai python=3.11
+    $ conda create -n jupyter-ai python=3.12
     $ conda activate jupyter-ai
     $ pip install jupyter_ai
 

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "jupyter_server>=1.6,<3",


### PR DESCRIPTION
## Description

Fixes #538. 

## Context

The release of `faiss-cpu==1.8.0` brought Python 3.12 support to Jupyter AI when installed from PyPI.

These 2 PRs were recently merged into the Jupyter AI feedstock, bringing Python 3.12 support to Jupyter AI when installed from Conda Forge:
- https://github.com/conda-forge/jupyter-ai-feedstock/pull/36
- https://github.com/conda-forge/jupyter-ai-feedstock/pull/37