### PR TITLE
Trim leading whitespace when processing

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/completion_utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/completion_utils.py
@@ -38,8 +38,9 @@ def post_process_suggestion(suggestion: str, request: InlineCompletionRequest) -
         for identifier in markdown_identifiers.get(language, [language])
     ] + ["```"]
     for opening in bad_openings:
-        if suggestion.startswith(opening):
-            suggestion = suggestion[len(opening) :].lstrip()
+        # ollama models tend to add spurious whitespace
+        if suggestion.lstrip().startswith(opening):
+            suggestion = suggestion.lstrip()[len(opening) :].lstrip()
             # check for the prefix inclusion (only if there was a bad opening)
             if suggestion.startswith(request.prefix):
                 suggestion = suggestion[len(request.prefix) :]

--- a/packages/jupyter-ai/jupyter_ai/tests/completions/test_handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/completions/test_handlers.py
@@ -102,6 +102,8 @@ expected_suggestions_cases = [
     ("```python\nTest python code\n```", "Test python code"),
     ("```\ntest\n```\n   \n", "test"),
     ("```hello```world```", "hello```world"),
+    (" ```\nprint(test)\n```", "print(test)"),
+    ("``` \nprint(test)\n```", "print(test)"),
 ]
 
 


### PR DESCRIPTION
Related to https://github.com/jupyterlab/jupyter-ai/issues/896

Partially fixes an issue where prefix is not stripped of suggestions generate by ollama due to a spurious space.

![image](https://github.com/user-attachments/assets/8d3b25da-8f79-4b4d-b642-5e4c54a896a8)

I think this does not fix the general issue of the model returning ` print(1)` when prompted `pr`, which results in `pr print(1)` (if I recall correctly, there is some prefix trimming on lab side but it would fail here).