### PR TITLE
Added new Bedrock Llama 3.1 models and gpt-4o-mini

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
@@ -46,6 +46,7 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
         "gpt-4-0125-preview",
         "gpt-4-1106-preview",
         "gpt-4o",
+        "gpt-4o-mini",
     ]
     model_id_key = "model_name"
     pypi_package_deps = ["langchain_openai"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -798,6 +798,8 @@ class BedrockProvider(BaseProvider, Bedrock):
         "meta.llama2-70b-chat-v1",
         "meta.llama3-8b-instruct-v1:0",
         "meta.llama3-70b-instruct-v1:0",
+        "meta.llama3-1-8b-instruct-v1:0",
+        "meta.llama3-1-70b-instruct-v1:0",
         "mistral.mistral-7b-instruct-v0:2",
         "mistral.mixtral-8x7b-instruct-v0:1",
         "mistral.mistral-large-2402-v1:0",


### PR DESCRIPTION
Added the latest llama-3.1 models available on Amazon Bedrock, and gpt-4o mini. All these models were recently released and have become popular.

Models are tested and work well. 