### PR TITLE
Respect selected persona in chat input placeholder

### DIFF
--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -38,6 +38,11 @@ type ChatInputProps = {
   toggleIncludeSelection: () => unknown;
   sendWithShiftEnter: boolean;
   sx?: SxProps<Theme>;
+  /**
+   * Name of the persona, set by the selected chat model. This defaults to
+   * `'Jupyternaut'`, but can differ for custom providers.
+   */
+  personaName: string;
 };
 
 type SlashCommandOption = {
@@ -300,7 +305,7 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
             variant="outlined"
             maxRows={20}
             multiline
-            placeholder="Ask Jupyternaut"
+            placeholder={`Ask ${props.personaName}`}
             onKeyDown={handleKeyDown}
             inputRef={inputRef}
             InputProps={{

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -40,19 +40,14 @@ type ChatBodyProps = {
  * Defaults to `'Jupyternaut'` if history is insufficient.
  */
 function getPersonaName(messages: AiService.ChatMessage[]): string {
-  let personaName = 'Jupyternaut';
-
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
-    if (message.type !== 'agent' && message.type !== 'agent-stream') {
-      continue;
+    if (message.type === 'agent' || message.type === 'agent-stream') {
+      return message.persona.name;
     }
-
-    personaName = message.persona.name;
-    break;
   }
 
-  return personaName;
+  return 'Jupyternaut';
 }
 
 function ChatBody({

--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -35,6 +35,26 @@ type ChatBodyProps = {
   focusInputSignal: ISignal<unknown, void>;
 };
 
+/**
+ * Determines the name of the current persona based on the message history.
+ * Defaults to `'Jupyternaut'` if history is insufficient.
+ */
+function getPersonaName(messages: AiService.ChatMessage[]): string {
+  let personaName = 'Jupyternaut';
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.type !== 'agent' && message.type !== 'agent-stream') {
+      continue;
+    }
+
+    personaName = message.persona.name;
+    break;
+  }
+
+  return personaName;
+}
+
 function ChatBody({
   chatHandler,
   focusInputSignal,
@@ -47,6 +67,9 @@ function ChatBody({
   const [pendingMessages, setPendingMessages] = useState<
     AiService.PendingMessage[]
   >([...chatHandler.history.pending_messages]);
+  const [personaName, setPersonaName] = useState<string>(
+    getPersonaName(messages)
+  );
   const [showWelcomeMessage, setShowWelcomeMessage] = useState<boolean>(false);
   const [includeSelection, setIncludeSelection] = useState(true);
   const [input, setInput] = useState('');
@@ -79,6 +102,7 @@ function ChatBody({
     function onHistoryChange(_: unknown, history: AiService.ChatHistory) {
       setMessages([...history.messages]);
       setPendingMessages([...history.pending_messages]);
+      setPersonaName(getPersonaName(history.messages));
     }
 
     chatHandler.historyChanged.connect(onHistoryChange);
@@ -166,6 +190,7 @@ function ChatBody({
           borderTop: '1px solid var(--jp-border-color1)'
         }}
         sendWithShiftEnter={sendWithShiftEnter}
+        personaName={personaName}
       />
     </>
   );


### PR DESCRIPTION
Ensures that the persona (set by the selected chat model) is respected in the chat input placeholder. For example, if a custom provider defines itself a `"Baguette AI"` persona name and a model from that provider is selected, the chat input placeholder will read as `"Ask Baguette AI"` instead of `"Ask Jupyternaut"`.