### PR TITLE
Update copyright template

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 import time
 
 project = "Jupyter AI"
-copyright = f"2023-{time.localtime().tm_year}, Project Jupyter"
+copyright = f"2023–{time.localtime().tm_year}, Project Jupyter"
 author = "Project Jupyter"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,8 +6,10 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import time
+
 project = "Jupyter AI"
-copyright = "2023, Project Jupyter"
+copyright = f"2023-{time.localtime().tm_year}, Project Jupyter"
 author = "Project Jupyter"
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Set it to automatically update the end year for the copyright footer in `readthedocs`.
Recompiled docs and tested it to see: 
<img width="338" alt="image" src="https://github.com/user-attachments/assets/1c5b0827-f3eb-4c53-9cec-008be3a6519f">
