### PR TITLE
Fix saving chat settings

### DIFF
--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -146,20 +146,31 @@ export function ChatSettings(props: ChatSettingsProps): JSX.Element {
     const newApiKeys: Record<string, string> = {};
     const lmAuth = lmProvider?.auth_strategy;
     const emAuth = emProvider?.auth_strategy;
-    if (lmAuth?.type === 'env') {
+    if (
+      lmAuth?.type === 'env' &&
+      !server.config.api_keys.includes(lmAuth.name)
+    ) {
       newApiKeys[lmAuth.name] = '';
     }
     if (lmAuth?.type === 'multienv') {
       lmAuth.names.forEach(apiKey => {
-        newApiKeys[apiKey] = '';
+        if (!server.config.api_keys.includes(apiKey)) {
+          newApiKeys[apiKey] = '';
+        }
       });
     }
-    if (emAuth?.type === 'env') {
+
+    if (
+      emAuth?.type === 'env' &&
+      !server.config.api_keys.includes(emAuth.name)
+    ) {
       newApiKeys[emAuth.name] = '';
     }
     if (emAuth?.type === 'multienv') {
       emAuth.names.forEach(apiKey => {
-        newApiKeys[apiKey] = '';
+        if (!server.config.api_keys.includes(apiKey)) {
+          newApiKeys[apiKey] = '';
+        }
       });
     }
 
@@ -472,27 +483,21 @@ export function ChatSettings(props: ChatSettingsProps): JSX.Element {
       {/* API Keys section */}
       <h2 className="jp-ai-ChatSettings-header">API Keys</h2>
       {/* API key inputs for newly-used providers */}
-      {Object.entries(apiKeys).length === 0 ? (
-        <p>No API Keys needed for selected model.</p>
-      ) : (
-        Object.entries(apiKeys).map(([apiKeyName, apiKeyValue], idx) =>
-          !server.config.api_keys.includes(apiKeyName) ? (
-            <TextField
-              key={idx}
-              label={apiKeyName}
-              value={apiKeyValue}
-              fullWidth
-              type="password"
-              onChange={e =>
-                setApiKeys(apiKeys => ({
-                  ...apiKeys,
-                  [apiKeyName]: e.target.value
-                }))
-              }
-            />
-          ) : null
-        )
-      )}
+      {Object.entries(apiKeys).map(([apiKeyName, apiKeyValue], idx) => (
+        <TextField
+          key={idx}
+          label={apiKeyName}
+          value={apiKeyValue}
+          fullWidth
+          type="password"
+          onChange={e =>
+            setApiKeys(apiKeys => ({
+              ...apiKeys,
+              [apiKeyName]: e.target.value
+            }))
+          }
+        />
+      ))}
       {/* Pre-existing API keys */}
       <ExistingApiKeys
         alert={apiKeysAlert}


### PR DESCRIPTION
- Ensures that only new API keys are included in the request payload sent to `/api/ai/config`.
- Addresses regression introduced by #918.
- Fixes #933