### PR TITLE
Fix /clear during pending message

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -201,6 +201,15 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
         """Broadcasts message to all connected clients.
         Appends message to chat history.
         """
+        # do not broadcast agent messages that are replying to cleared human message
+        if (
+            isinstance(message, (AgentChatMessage, AgentStreamMessage))
+            and message.reply_to
+        ):
+            if message.reply_to not in [
+                m.id for m in self.chat_history if isinstance(m, HumanChatMessage)
+            ]:
+                return
 
         self.log.debug("Broadcasting message: %s to all clients...", message)
         client_ids = self.root_chat_handlers.keys()

--- a/packages/jupyter-ai/src/chat_handler.ts
+++ b/packages/jupyter-ai/src/chat_handler.ts
@@ -133,6 +133,7 @@ export class ChatHandler implements IDisposable {
         break;
       case 'clear':
         this._messages = [];
+        this._pendingMessages = [];
         break;
       case 'pending':
         this._pendingMessages = [...this._pendingMessages, newMessage];


### PR DESCRIPTION
## Description
Currently, if /clear is triggered while a message is pending, the pending message will remain and the agent reply will still come through even though the human message it is associated with is removed.

This PR clears the pending message and prevents the agent reply from being broadcasted to the front-end after a clear is triggered.