### PR TITLE
Allow configuring a default model for cell magics (and line error magic)

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -675,6 +675,29 @@ We currently support the following language model providers:
 - `openai-chat`
 - `sagemaker-endpoint`
 
+### Configuring a default model
+
+To configure a default model you can use the IPython `%config` magic:
+
+```python
+%config AiMagics.default_language_model = "anthropic:claude-v1.2"
+```
+
+Then subsequent magics can be invoked without typing in the model:
+
+```
+%%ai
+Write a poem about C++.
+```
+
+You can configure the default model for all notebooks by specifying `c.AiMagics.default_language_model` tratilet in `ipython_config.py`, for example:
+
+```python
+c.AiMagics.default_language_model = "anthropic:claude-v1.2"
+```
+
+The location of `ipython_config.py` file is documented in [IPython configuration reference](https://ipython.readthedocs.io/en/stable/config/intro.html).
+
 ### Listing available models
 
 Jupyter AI also includes multiple subcommands, which may be invoked via the

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/exception.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/exception.py
@@ -1,6 +1,5 @@
 import traceback
 
-from IPython.core.getipython import get_ipython
 from IPython.core.magic import register_line_magic
 from IPython.core.ultratb import ListTB
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
@@ -121,7 +121,7 @@ def verify_json_value(ctx, param, value):
 
 
 @click.command()
-@click.argument("model_id")
+@click.argument("model_id", required=False)
 @click.option(
     "-f",
     "--format",
@@ -156,7 +156,8 @@ def verify_json_value(ctx, param, value):
     callback=verify_json_value,
     default="{}",
 )
-def cell_magic_parser(**kwargs):
+@click.pass_context
+def cell_magic_parser(context: click.Context, **kwargs):
     """
     Invokes a language model identified by MODEL_ID, with the prompt being
     contained in all lines after the first. Both local model IDs and global
@@ -165,6 +166,8 @@ def cell_magic_parser(**kwargs):
 
     To view available language models, please run `%ai list`.
     """
+    if not kwargs["model_id"] and context.default_map:
+        kwargs["model_id"] = context.default_map["cell_magic_parser"]["model_id"]
     return CellArgs(**kwargs)
 
 
@@ -176,7 +179,7 @@ def line_magic_parser():
 
 
 @line_magic_parser.command(name="error")
-@click.argument("model_id")
+@click.argument("model_id", required=False)
 @click.option(
     "-f",
     "--format",
@@ -211,11 +214,14 @@ def line_magic_parser():
     callback=verify_json_value,
     default="{}",
 )
-def error_subparser(**kwargs):
+@click.pass_context
+def error_subparser(context: click.Context, **kwargs):
     """
     Explains the most recent error. Takes the same options (except -r) as
     the basic `%%ai` command.
     """
+    if not kwargs["model_id"] and context.default_map:
+        kwargs["model_id"] = context.default_map["error_subparser"]["model_id"]
     return ErrorArgs(**kwargs)
 
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_magics.py
@@ -1,11 +1,50 @@
+from unittest.mock import patch
+
 from IPython import InteractiveShell
+from jupyter_ai_magics.magics import AiMagics
+from pytest import fixture
 from traitlets.config.loader import Config
 
 
-def test_aliases_config():
+@fixture
+def ip() -> InteractiveShell:
     ip = InteractiveShell()
     ip.config = Config()
+    return ip
+
+
+def test_aliases_config(ip):
     ip.config.AiMagics.aliases = {"my_custom_alias": "my_provider:my_model"}
     ip.extension_manager.load_extension("jupyter_ai_magics")
     providers_list = ip.run_line_magic("ai", "list").text
     assert "my_custom_alias" in providers_list
+
+
+def test_default_model_cell(ip):
+    ip.config.AiMagics.default_language_model = "my-favourite-llm"
+    ip.extension_manager.load_extension("jupyter_ai_magics")
+    with patch.object(AiMagics, "run_ai_cell", return_value=None) as mock_run:
+        ip.run_cell_magic("ai", "", cell="Write code for me please")
+        assert mock_run.called
+        cell_args = mock_run.call_args.args[0]
+        assert cell_args.model_id == "my-favourite-llm"
+
+
+def test_non_default_model_cell(ip):
+    ip.config.AiMagics.default_language_model = "my-favourite-llm"
+    ip.extension_manager.load_extension("jupyter_ai_magics")
+    with patch.object(AiMagics, "run_ai_cell", return_value=None) as mock_run:
+        ip.run_cell_magic("ai", "some-different-llm", cell="Write code for me please")
+        assert mock_run.called
+        cell_args = mock_run.call_args.args[0]
+        assert cell_args.model_id == "some-different-llm"
+
+
+def test_default_model_error_line(ip):
+    ip.config.AiMagics.default_language_model = "my-favourite-llm"
+    ip.extension_manager.load_extension("jupyter_ai_magics")
+    with patch.object(AiMagics, "handle_error", return_value=None) as mock_run:
+        ip.run_cell_magic("ai", "error", cell=None)
+        assert mock_run.called
+        cell_args = mock_run.call_args.args[0]
+        assert cell_args.model_id == "my-favourite-llm"


### PR DESCRIPTION
- Fixes https://github.com/jupyterlab/jupyter-ai/issues/372
- Fixes https://github.com/jupyterlab/jupyter-ai/issues/952 (this was required to add tests here)

The name and help for `default_language_model` is copied over from the one used in equivalent `jupyter-ai` traitlet.