### PR TITLE
Fix `RunnableWithMessageHistory` import

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -9,7 +9,8 @@ from jupyter_ai.models import (
 )
 from jupyter_ai_magics.providers import BaseProvider
 from langchain_core.messages import AIMessageChunk
-from langchain_core.runnables import ConfigurableFieldSpec, RunnableWithMessageHistory
+from langchain_core.runnables import ConfigurableFieldSpec
+from langchain_core.runnables.history import RunnableWithMessageHistory
 
 from ..models import HumanChatMessage
 from .base import BaseChatHandler, SlashCommandRoutingType


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-ai/issues/978 by restoring import conventions as used in langchain documentation for `RunnableWithMessageHistory`.