### PR TITLE
Allow to disable automatic inline completions

### DIFF
--- a/packages/jupyter-ai/src/completions/provider.ts
+++ b/packages/jupyter-ai/src/completions/provider.ts
@@ -56,7 +56,10 @@ export class JaiInlineProvider
   ): Promise<IInlineCompletionList<IInlineCompletionItem>> {
     const allowedTriggerKind = this._settings.triggerKind;
     const triggerKind = context.triggerKind;
-    if (allowedTriggerKind === 'manual' && triggerKind !== InlineCompletionTriggerKind.Invoke) {
+    if (
+      allowedTriggerKind === 'manual' &&
+      triggerKind !== InlineCompletionTriggerKind.Invoke
+    ) {
       // Short-circuit if user requested to only invoke inline completions
       // on manual trigger for jupyter-ai. Users may still get completions
       // from other (e.g. less expensive or faster) providers.
@@ -293,7 +296,7 @@ export namespace JaiInlineProvider {
   }
 
   export interface ISettings {
-    triggerKind: 'any' | 'manual',
+    triggerKind: 'any' | 'manual';
     maxPrefix: number;
     maxSuffix: number;
     debouncerDelay: number;


### PR DESCRIPTION
Closes #968

Allows to disable completion on typing for jupyter-ai provider. Adds one setting field with two options:

| Default | New option |
|--|--|
| ![image](https://github.com/user-attachments/assets/94282097-ccbc-4ffa-8d8d-918700ce3f6e) | ![Screenshot from 2024-09-07 11-45-59](https://github.com/user-attachments/assets/b3160e2c-d38e-4d76-8ebd-098855706305) |

The label can be easily adjusted as the underlying value has a separate enum. In future more options could be added, e.g. "automatic in code, manual in markdown".