### PR TITLE
Allow overriding the Ollama base URL

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -5,6 +5,7 @@ from jupyter_ai_magics.providers import (
     EnvAuthStrategy,
     Field,
     MultiEnvAuthStrategy,
+    TextField,
 )
 from langchain.pydantic_v1 import BaseModel, Extra
 from langchain_community.embeddings import (
@@ -76,6 +77,9 @@ class OllamaEmbeddingsProvider(BaseEmbeddingsProvider, OllamaEmbeddings):
         "snowflake-arctic-embed",
     ]
     model_id_key = "model"
+    fields = [
+        TextField(key="base_url", label="Base API URL (optional)", format="text"),
+    ]
 
 
 class HfHubEmbeddingsProvider(BaseEmbeddingsProvider, HuggingFaceHubEmbeddings):


### PR DESCRIPTION

https://github.com/jupyterlab/jupyter-ai/issues/1004
- import TextField from providers
- add base_url to allow custom url for ollama embeddings provider