### PR TITLE
Fix ydoc `server_settings` usage example

### DIFF
--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -267,7 +267,7 @@ class MyCompletionProvider(BaseProvider, FakeListLLM):
         prefix = request.prefix
         suffix = request.suffix.strip()
 
-        server_ydoc = self.server_settings.get("jupyter_server_ydoc", None)
+        server_ydoc = BaseProvider.server_settings.get("jupyter_server_ydoc", None)
         if not server_ydoc:
             # fallback to prefix/suffix from single cell
             return prefix, suffix


### PR DESCRIPTION
It looks like we need to access it from `BaseProvider`, not from self.