### PR TITLE
Make path argument required on /learn

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -180,7 +180,7 @@ class LearnChatHandler(BaseChatHandler):
             no_path_arg_message = (
                 "Please specify a directory or pattern you would like to "
                 'learn on. "/learn" supports directories relative to '
-                "the root (or prefferred dir, if set) and unix-style "
+                "the root (or preferred dir, if set) and Unix-style "
                 "wildcard matching.\n\n"
                 "Examples:\n"
                 "- Learn on the root directory recursively: `/learn .`\n"

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -185,7 +185,7 @@ class LearnChatHandler(BaseChatHandler):
                 "Examples:\n"
                 "- Learn on the root directory recursively: `/learn .`\n"
                 "- Learn on files in the root directory: `/learn *`\n"
-                "- Learn all python files under the root directory recursevely: `/learn **/*.py`"
+                "- Learn all python files under the root directory recursively: `/learn **/*.py`"
             )
             self.reply(f"{self.parser.format_usage()}\n\n {no_path_arg_message}")
             return

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -175,7 +175,7 @@ class LearnChatHandler(BaseChatHandler):
                     return
 
         # Make sure the path exists.
-        if (not len(args.path) == 1) or (not args.path[0]):
+        if not (len(args.path) == 1 and args.path[0]):
             print(self.parser.format_usage())
             no_path_arg_message = (
                 "Please specify a directory or pattern you would like to "

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -176,7 +176,6 @@ class LearnChatHandler(BaseChatHandler):
 
         # Make sure the path exists.
         if not (len(args.path) == 1 and args.path[0]):
-            print(self.parser.format_usage())
             no_path_arg_message = (
                 "Please specify a directory or pattern you would like to "
                 'learn on. "/learn" supports directories relative to '

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -175,8 +175,19 @@ class LearnChatHandler(BaseChatHandler):
                     return
 
         # Make sure the path exists.
-        if not len(args.path) == 1:
-            self.reply(f"{self.parser.format_usage()}", message)
+        if (not len(args.path) == 1) or (not args.path[0]):
+            print(self.parser.format_usage())
+            no_path_arg_message = (
+                "Please specify a directory or pattern you would like to "
+                'learn on. "/learn" supports directories relative to '
+                "the root (or prefferred dir, if set) and unix-style "
+                "wildcard matching.\n\n"
+                "Examples:\n"
+                "- Learn on the root directory recursively: `/learn .`\n"
+                "- Learn on files in the root directory: `/learn *`\n"
+                "- Learn all python files under the root directory recursevely: `/learn **/*.py`"
+            )
+            self.reply(f"{self.parser.format_usage()}\n\n {no_path_arg_message}")
             return
         short_path = args.path[0]
         load_path = os.path.join(self.output_dir, short_path)

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -20,6 +20,7 @@ import {
   AutoFixNormal
 } from '@mui/icons-material';
 import { ISignal } from '@lumino/signaling';
+import { Dialog as Dialog, showDialog } from '@jupyterlab/apputils';
 
 import { AiService } from '../handler';
 import { SendButton, SendButtonProps } from './chat-input/send-button';
@@ -200,6 +201,21 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
         prompt,
         selection: { ...cellWithError, type: 'cell-with-error' }
       });
+      return;
+    }
+    else if (currSlashCommand === '/learn') {
+      let prompt_split = prompt.split(" ")
+      if (prompt_split[prompt_split.length - 1] === "") {
+        showDialog({
+          title: "No directory specified for /learn",
+          body: "/learn will create embeddings on all valid files under your root directory (or preferred directory if set.) This may take a long time. Was this intended?",
+          buttons: [Dialog.cancelButton(), Dialog.warnButton({label: "OK"})]
+        }).then(result => {
+          if (result.button.accept) {
+            props.chatHandler.sendMessage({ prompt, selection });
+          }
+        })
+      }
       return;
     }
 

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -203,8 +203,8 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
       });
       return;
     } else if (currSlashCommand === '/learn') {
-      const prompt_split = prompt.split(' ');
-      if (prompt_split[prompt_split.length - 1] === '') {
+      const promptSplit = prompt.split(' ');
+      if (promptSplit[promptSplit.length - 1] === '') {
         showDialog({
           title: 'No directory specified for /learn',
           body: '/learn will create embeddings on all valid files under your root directory (or preferred directory if set.) This may take a long time.',

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -202,19 +202,18 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
         selection: { ...cellWithError, type: 'cell-with-error' }
       });
       return;
-    }
-    else if (currSlashCommand === '/learn') {
-      let prompt_split = prompt.split(" ")
-      if (prompt_split[prompt_split.length - 1] === "") {
+    } else if (currSlashCommand === '/learn') {
+      const prompt_split = prompt.split(' ');
+      if (prompt_split[prompt_split.length - 1] === '') {
         showDialog({
-          title: "No directory specified for /learn",
-          body: "/learn will create embeddings on all valid files under your root directory (or preferred directory if set.) This may take a long time. Was this intended?",
-          buttons: [Dialog.cancelButton(), Dialog.warnButton({label: "OK"})]
+          title: 'No directory specified for /learn',
+          body: '/learn will create embeddings on all valid files under your root directory (or preferred directory if set.) This may take a long time.',
+          buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'OK' })]
         }).then(result => {
           if (result.button.accept) {
             props.chatHandler.sendMessage({ prompt, selection });
           }
-        })
+        });
       }
       return;
     }

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -208,7 +208,7 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
         showDialog({
           title: 'No directory specified for /learn',
           body: '/learn will create embeddings on all valid files under your root directory (or preferred directory if set.) This may take a long time.',
-          buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'OK' })]
+          buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Ok' })]
         }).then(result => {
           if (result.button.accept) {
             props.chatHandler.sendMessage({ prompt, selection });

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -20,7 +20,6 @@ import {
   AutoFixNormal
 } from '@mui/icons-material';
 import { ISignal } from '@lumino/signaling';
-import { Dialog as Dialog, showDialog } from '@jupyterlab/apputils';
 
 import { AiService } from '../handler';
 import { SendButton, SendButtonProps } from './chat-input/send-button';
@@ -224,22 +223,6 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
         prompt,
         selection: { ...cellWithError, type: 'cell-with-error' }
       });
-      return;
-    } else if (currSlashCommand === '/learn') {
-      const promptSplit = prompt.split(' ');
-      if (promptSplit[promptSplit.length - 1] === '') {
-        showDialog({
-          title: 'No directory specified for /learn',
-          body: '/learn will create embeddings on all valid files under your root directory (or preferred directory if set.) This may take a long time.',
-          buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Ok' })]
-        }).then(result => {
-          if (result.button.accept) {
-            props.chatHandler.sendMessage({ prompt, selection });
-          }
-        });
-      } else {
-        props.chatHandler.sendMessage({ prompt, selection });
-      }
       return;
     }
 

--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -214,6 +214,8 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
             props.chatHandler.sendMessage({ prompt, selection });
           }
         });
+      } else {
+        props.chatHandler.sendMessage({ prompt, selection });
       }
       return;
     }


### PR DESCRIPTION
closes #819

~~This PR adds a dialog pop-up when `/learn` is used without a directory parameter. This makes it clear what is happening and gives people the opportunity to cancel the operation if learning on all files under the root (or preferred) directory wasn't intended.~~

Updated to make /learn require a path argument. Now /learn will respond with a helpful message and example input if no path argument is given.

![image](https://github.com/user-attachments/assets/d9cde276-bf68-4d56-8e9e-4c86ed9131da)

