### PR TITLE
Migrate to `ChatOllama` base class in Ollama provider

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
@@ -5,7 +5,6 @@ from .embedding_providers import (
     BaseEmbeddingsProvider,
     GPT4AllEmbeddingsProvider,
     HfHubEmbeddingsProvider,
-    OllamaEmbeddingsProvider,
     QianfanEmbeddingsEndpointProvider,
 )
 from .exception import store_exception
@@ -21,7 +20,6 @@ from .providers import (
     BaseProvider,
     GPT4AllProvider,
     HfHubProvider,
-    OllamaProvider,
     QianfanProvider,
     TogetherAIProvider,
 )

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -10,7 +10,6 @@ from langchain.pydantic_v1 import BaseModel, Extra
 from langchain_community.embeddings import (
     GPT4AllEmbeddings,
     HuggingFaceHubEmbeddings,
-    OllamaEmbeddings,
     QianfanEmbeddingsEndpoint,
 )
 
@@ -63,19 +62,6 @@ class BaseEmbeddingsProvider(BaseModel):
             model_kwargs[self.__class__.model_id_key] = kwargs["model_id"]
 
         super().__init__(*args, **kwargs, **model_kwargs)
-
-
-class OllamaEmbeddingsProvider(BaseEmbeddingsProvider, OllamaEmbeddings):
-    id = "ollama"
-    name = "Ollama"
-    # source: https://ollama.com/library
-    models = [
-        "nomic-embed-text",
-        "mxbai-embed-large",
-        "all-minilm",
-        "snowflake-arctic-embed",
-    ]
-    model_id_key = "model"
 
 
 class HfHubEmbeddingsProvider(BaseEmbeddingsProvider, HuggingFaceHubEmbeddings):

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/ollama.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/ollama.py
@@ -30,4 +30,3 @@ class OllamaEmbeddingsProvider(BaseEmbeddingsProvider, OllamaEmbeddings):
         "snowflake-arctic-embed",
     ]
     model_id_key = "model"
-

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/ollama.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/ollama.py
@@ -1,0 +1,33 @@
+from langchain_ollama import ChatOllama, OllamaEmbeddings
+
+from ..embedding_providers import BaseEmbeddingsProvider
+from ..providers import BaseProvider, EnvAuthStrategy, TextField
+
+
+class OllamaProvider(BaseProvider, ChatOllama):
+    id = "ollama"
+    name = "Ollama"
+    model_id_key = "model"
+    help = (
+        "See [https://www.ollama.com/library](https://www.ollama.com/library) for a list of models. "
+        "Pass a model's name; for example, `deepseek-coder-v2`."
+    )
+    models = ["*"]
+    registry = True
+    fields = [
+        TextField(key="base_url", label="Base API URL (optional)", format="text"),
+    ]
+
+
+class OllamaEmbeddingsProvider(BaseEmbeddingsProvider, OllamaEmbeddings):
+    id = "ollama"
+    name = "Ollama"
+    # source: https://ollama.com/library
+    models = [
+        "nomic-embed-text",
+        "mxbai-embed-large",
+        "all-minilm",
+        "snowflake-arctic-embed",
+    ]
+    model_id_key = "model"
+

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -33,7 +33,6 @@ from langchain_community.llms import (
     AI21,
     GPT4All,
     HuggingFaceEndpoint,
-    Ollama,
     Together,
 )
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -706,20 +705,6 @@ class HfHubProvider(BaseProvider, HuggingFaceEndpoint):
     async def _acall(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
         return await self._call_in_executor(*args, **kwargs)
 
-
-class OllamaProvider(BaseProvider, Ollama):
-    id = "ollama"
-    name = "Ollama"
-    model_id_key = "model"
-    help = (
-        "See [https://www.ollama.com/library](https://www.ollama.com/library) for a list of models. "
-        "Pass a model's name; for example, `deepseek-coder-v2`."
-    )
-    models = ["*"]
-    registry = True
-    fields = [
-        TextField(key="base_url", label="Base API URL (optional)", format="text"),
-    ]
 
 
 class TogetherAIProvider(BaseProvider, Together):

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -29,12 +29,7 @@ from langchain.schema import LLMResult
 from langchain.schema.output_parser import StrOutputParser
 from langchain.schema.runnable import Runnable
 from langchain_community.chat_models import QianfanChatEndpoint
-from langchain_community.llms import (
-    AI21,
-    GPT4All,
-    HuggingFaceEndpoint,
-    Together,
-)
+from langchain_community.llms import AI21, GPT4All, HuggingFaceEndpoint, Together
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.language_models.llms import BaseLLM
 
@@ -704,7 +699,6 @@ class HfHubProvider(BaseProvider, HuggingFaceEndpoint):
 
     async def _acall(self, *args, **kwargs) -> Coroutine[Any, Any, str]:
         return await self._call_in_executor(*args, **kwargs)
-
 
 
 class TogetherAIProvider(BaseProvider, Together):

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -48,6 +48,7 @@ all = [
     "langchain_mistralai",
     "langchain_nvidia_ai_endpoints",
     "langchain_openai",
+    "langchain_ollama",
     "pillow",
     "boto3",
     "qianfan",
@@ -61,7 +62,7 @@ anthropic-chat = "jupyter_ai_magics.partner_providers.anthropic:ChatAnthropicPro
 cohere = "jupyter_ai_magics.partner_providers.cohere:CohereProvider"
 gpt4all = "jupyter_ai_magics:GPT4AllProvider"
 huggingface_hub = "jupyter_ai_magics:HfHubProvider"
-ollama = "jupyter_ai_magics:OllamaProvider"
+ollama = "jupyter_ai_magics.partner_providers.ollama:OllamaProvider"
 openai = "jupyter_ai_magics.partner_providers.openai:OpenAIProvider"
 openai-chat = "jupyter_ai_magics.partner_providers.openai:ChatOpenAIProvider"
 azure-chat-openai = "jupyter_ai_magics.partner_providers.openai:AzureChatOpenAIProvider"
@@ -83,7 +84,7 @@ cohere = "jupyter_ai_magics.partner_providers.cohere:CohereEmbeddingsProvider"
 mistralai = "jupyter_ai_magics.partner_providers.mistralai:MistralAIEmbeddingsProvider"
 gpt4all = "jupyter_ai_magics:GPT4AllEmbeddingsProvider"
 huggingface_hub = "jupyter_ai_magics:HfHubEmbeddingsProvider"
-ollama = "jupyter_ai_magics:OllamaEmbeddingsProvider"
+ollama = "jupyter_ai_magics.partner_providers.ollama:OllamaEmbeddingsProvider"
 openai = "jupyter_ai_magics.partner_providers.openai:OpenAIEmbeddingsProvider"
 qianfan = "jupyter_ai_magics:QianfanEmbeddingsEndpointProvider"
 


### PR DESCRIPTION
Refactored the code to create a separate file for models provided by Ollama:
1. Created a separate file `ollama.py` as a unique provider. Refactored other code accordingly.
2. Also changed the `Ollama` class to `ChatOllama` so that it can support binding tools to the LLM.
3. Updated the imports to come from `langchain_ollama` instead of `langchain_community`
4. Tested on several Ollama models, both LLMs and embedding models: `mxbai-embed-large`, `nomic-embed-text`, `ima/deepseek-math`, `mathstral`, `qwen2-math`, `snowflake-arctic-embed`, `mistral`, `llama3.1`, `starcoder2:15b-instruct`

Reference: https://github.com/langchain-ai/langchain/blob/master/libs/partners/ollama/langchain_ollama/chat_models.py