### PR TITLE
Export tokens from `lib/index.js`

### DIFF
--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -127,3 +127,5 @@ const plugin: JupyterFrontEndPlugin<IJaiCore> = {
 };
 
 export default [plugin, statusItemPlugin, completionPlugin, menuPlugin];
+
+export * from './tokens';


### PR DESCRIPTION
# Description

Exports tokens from `lib/index.js` to allow labextension configuration.

# Motivation

I was not able to configure a custom message footer (https://github.com/jupyterlab/jupyter-ai/pull/942) by providing the `IJaiMessageFooter` token in a separate labextension, scaffolded via the latest [`extension-template`](https://github.com/jupyterlab/extension-template).

In my custom extension, I imported the tokens from `@jupyter-ai/core/lib/tokens` and defined a plugin that provided the `IJaiMessageFooter` token. I also added this to my `package.json` file, according to the [labextension docs](https://jupyterlab.readthedocs.io/en/4.2.x/extension/extension_dev.html#deduplication-of-dependencies):

```json
    "jupyterlab": {
        "discovery": {
            "server": {
                "managers": [
                    "pip"
                ],
                "base": {
                    "name": "test_extension"
                }
            }
        },
        "extension": true,
        "outputDir": "test_extension/labextension",
        "sharedPackages": {
            "@jupyter-ai/core": {
                "bundled": false,
                "singleton": true
            },
            "@jupyter-ai/core/lib/tokens": {
                "bundled": false,
                "singleton": true
            }
        }
    },
```

However, this did not add a custom message footer to the chat messages, and I received an error message in the browser console:

```
Shared module @jupyter-ai/core/lib/tokens doesn't exist in shared scope default
```

After doing a bit of digging, I noticed that all other labextensions re-export their tokens from `src/index.ts`, so you can import the tokens from the package directly (instead of a module within that package). I made the code changes in `jupyter-ai`, built new JavaScript & Python packages via `jupyter-releaser` and installed these locally. 

Then, I updated the import in my extension to:

```ts
import { IJaiMessageFooter } from '@jupyter-ai/core';
```

Finally, I rebuilt my extension. To my surprise, this worked! I could see the new message footer in the chat UI.

It seems that tokens must be imported from a package's main file, `lib/index.js`. Otherwise, the tokens aren't available as a shared singleton module.