### PR TITLE
Export context hooks from NPM package entry point

### DIFF
--- a/packages/jupyter-ai/src/contexts/index.ts
+++ b/packages/jupyter-ai/src/contexts/index.ts
@@ -1,0 +1,3 @@
+export * from './active-cell-context';
+export * from './collaborators-context';
+export * from './selection-context';

--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -128,4 +128,5 @@ const plugin: JupyterFrontEndPlugin<IJaiCore> = {
 
 export default [plugin, statusItemPlugin, completionPlugin, menuPlugin];
 
+export * from './contexts';
 export * from './tokens';


### PR DESCRIPTION
# Description

Exports context hooks from the NPM package entry point, making them directly importable from `'@jupyter-ai/core'`. This is necessary for developers who wish to use these hooks in custom components like a configurable message footer (#942).

- Only exports from the root module `'@jupyter-ai/core'` are de-duplicated via JupyterLab's module federation build system. See #1019.