### PR TITLE
Always use `username` from `IdentityProvider`

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -174,7 +174,7 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
         login = getpass.getuser()
         initials = login[0].capitalize()
         return ChatUser(
-            username=login,
+            username=self.current_user.username,
             initials=initials,
             name=login,
             display_name=login,


### PR DESCRIPTION
- Alleviates https://github.com/jupyterlab/jupyter-ai/issues/1025: username is now sourced from identity provider, but display name and name are kept as-is (from identity provider if jupyter-collaboration is enabled, otherwise from OS login)
- Split off from https://github.com/jupyterlab/jupyter-ai/pull/1022

This allows to identify whether a message was sent by the current user or a different user.