### PR TITLE
Unify message clearing & broadcast logic

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -27,6 +27,7 @@ from jupyter_ai.models import (
     ClosePendingMessage,
     HumanChatMessage,
     PendingMessage,
+    Message,
 )
 from jupyter_ai_magics import Persona
 from jupyter_ai_magics.providers import BaseProvider
@@ -260,6 +261,25 @@ class BaseChatHandler:
             f"Sorry, an error occurred. Details below:\n\n```\n{formatted_e}\n```"
         )
         self.reply(response, message)
+    
+    def broadcast_message(self, message: Message):
+        """
+        Broadcasts a message to all WebSocket connections. If there are no
+        WebSocket connections, this method directly appends to
+        `self.chat_history`.
+        """
+        broadcast = False
+        for websocket in self._root_chat_handlers.values():
+            if not websocket:
+                continue
+
+            websocket.broadcast_message(message)
+            broadcast = True
+            break
+            
+        if not broadcast:
+            self._chat_history.append(message)
+        
 
     def reply(self, response: str, human_msg: Optional[HumanChatMessage] = None):
         """
@@ -274,12 +294,8 @@ class BaseChatHandler:
             persona=self.persona,
         )
 
-        for handler in self._root_chat_handlers.values():
-            if not handler:
-                continue
+        self.broadcast_message(agent_msg)
 
-            handler.broadcast_message(agent_msg)
-            break
 
     @property
     def persona(self):
@@ -308,12 +324,7 @@ class BaseChatHandler:
             ellipsis=ellipsis,
         )
 
-        for handler in self._root_chat_handlers.values():
-            if not handler:
-                continue
-
-            handler.broadcast_message(pending_msg)
-            break
+        self.broadcast_message(pending_msg)
         return pending_msg
 
     def close_pending(self, pending_msg: PendingMessage):
@@ -327,13 +338,7 @@ class BaseChatHandler:
             id=pending_msg.id,
         )
 
-        for handler in self._root_chat_handlers.values():
-            if not handler:
-                continue
-
-            handler.broadcast_message(close_pending_msg)
-            break
-
+        self.broadcast_message(close_pending_msg)
         pending_msg.closed = True
 
     @contextlib.contextmanager
@@ -464,6 +469,4 @@ class BaseChatHandler:
             persona=self.persona,
         )
 
-        self._chat_history.append(help_message)
-        for websocket in self._root_chat_handlers.values():
-            websocket.write_message(help_message.json())
+        self.broadcast_message(help_message)

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -26,8 +26,8 @@ from jupyter_ai.models import (
     ChatMessage,
     ClosePendingMessage,
     HumanChatMessage,
-    PendingMessage,
     Message,
+    PendingMessage,
 )
 from jupyter_ai_magics import Persona
 from jupyter_ai_magics.providers import BaseProvider
@@ -261,7 +261,7 @@ class BaseChatHandler:
             f"Sorry, an error occurred. Details below:\n\n```\n{formatted_e}\n```"
         )
         self.reply(response, message)
-    
+
     def broadcast_message(self, message: Message):
         """
         Broadcasts a message to all WebSocket connections. If there are no
@@ -276,10 +276,9 @@ class BaseChatHandler:
             websocket.broadcast_message(message)
             broadcast = True
             break
-            
+
         if not broadcast:
             self._chat_history.append(message)
-        
 
     def reply(self, response: str, human_msg: Optional[HumanChatMessage] = None):
         """
@@ -295,7 +294,6 @@ class BaseChatHandler:
         )
 
         self.broadcast_message(agent_msg)
-
 
     @property
     def persona(self):

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -9,6 +9,7 @@ from typing import (
     Awaitable,
     ClassVar,
     Dict,
+    get_args as get_type_args,
     List,
     Literal,
     Optional,
@@ -265,8 +266,8 @@ class BaseChatHandler:
     def broadcast_message(self, message: Message):
         """
         Broadcasts a message to all WebSocket connections. If there are no
-        WebSocket connections, this method directly appends to
-        `self.chat_history`.
+        WebSocket connections and the message is a chat message, this method
+        directly appends to `self.chat_history`.
         """
         broadcast = False
         for websocket in self._root_chat_handlers.values():
@@ -278,7 +279,9 @@ class BaseChatHandler:
             break
 
         if not broadcast:
-            self._chat_history.append(message)
+            if isinstance(message, get_type_args(ChatMessage)):
+                cast(ChatMessage, message)
+                self._chat_history.append(message)
 
     def reply(self, response: str, human_msg: Optional[HumanChatMessage] = None):
         """

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -9,7 +9,6 @@ from typing import (
     Awaitable,
     ClassVar,
     Dict,
-    get_args as get_type_args,
     List,
     Literal,
     Optional,
@@ -17,6 +16,7 @@ from typing import (
     Union,
     cast,
 )
+from typing import get_args as get_type_args
 from uuid import uuid4
 
 from dask.distributed import Client as DaskClient

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -1,4 +1,5 @@
 from jupyter_ai.models import ClearRequest
+
 from .base import BaseChatHandler, SlashCommandRoutingType
 
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -1,5 +1,4 @@
-from jupyter_ai.models import ClearMessage
-
+from jupyter_ai.models import ClearRequest
 from .base import BaseChatHandler, SlashCommandRoutingType
 
 
@@ -17,10 +16,10 @@ class ClearChatHandler(BaseChatHandler):
         super().__init__(*args, **kwargs)
 
     async def process_message(self, _):
-        # Clear chat
+        # Clear chat by triggering `RootChatHandler.on_clear_request()`.
         for handler in self._root_chat_handlers.values():
             if not handler:
                 continue
 
-            handler.broadcast_message(ClearMessage())
+            handler.on_clear_request(ClearRequest())
             break

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -319,7 +319,7 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
         # handling messages from a websocket.  instead, process each message
         # as a distinct concurrent task.
         self.loop.create_task(self._route(chat_message))
-    
+
     def on_clear_request(self, request: ClearRequest):
         target = request.target
 
@@ -340,7 +340,7 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
         self.cleared_message_ids.add(target)
         for msg in self.chat_history[::-1]:
             # interrupt the single message
-            if (msg.type == "agent-stream" and getattr(msg, "reply_to", None) == target):
+            if msg.type == "agent-stream" and getattr(msg, "reply_to", None) == target:
                 try:
                     self.message_interrupted[msg.id].set()
                 except KeyError:
@@ -409,7 +409,6 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
         latency_ms = round((time.time() - start) * 1000)
         command_readable = "Default" if command == "default" else command
         self.log.info(f"{command_readable} chat handler resolved in {latency_ms} ms.")
-
 
     def on_close(self):
         self.log.debug("Disconnecting client with user %s", self.client_id)

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -38,7 +38,6 @@ from .models import (
     ListSlashCommandsResponse,
     Message,
     PendingMessage,
-    StopMessage,
     StopRequest,
     UpdateConfigRequest,
 )

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -293,21 +293,10 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
             return
 
         if isinstance(request, ClearRequest):
-            if not request.target:
-                targets = None
-            elif request.after:
-                target_msg = None
-                for msg in self.chat_history:
-                    if msg.id == request.target:
-                        target_msg = msg
-                if target_msg:
-                    targets = [
-                        msg.id
-                        for msg in self.chat_history
-                        if msg.time >= target_msg.time and msg.type == "human"
-                    ]
-            else:
+            if request.target:
                 targets = [request.target]
+            else:
+                targets = None
             self.broadcast_message(ClearMessage(targets=targets))
             return
 

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -121,16 +121,16 @@ class RootChatHandler(JupyterHandler, websocket.WebSocketHandler):
     def pending_messages(self) -> List[PendingMessage]:
         return self.settings["pending_messages"]
 
+    @pending_messages.setter
+    def pending_messages(self, new_pending_messages):
+        self.settings["pending_messages"] = new_pending_messages
+
     @property
     def cleared_message_ids(self) -> Set[str]:
         """Set of `HumanChatMessage.id` that were cleared via `ClearRequest`."""
         if "cleared_message_ids" not in self.settings:
             self.settings["cleared_message_ids"] = set()
         return self.settings["cleared_message_ids"]
-
-    @pending_messages.setter
-    def pending_messages(self, new_pending_messages):
-        self.settings["pending_messages"] = new_pending_messages
 
     def initialize(self):
         self.log.debug("Initializing websocket connection %s", self.request.path)

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -59,12 +59,6 @@ class ClearRequest(BaseModel):
     If not provided, this requests the backend to clear all messages.
     """
 
-    after: Optional[bool]
-    """
-    Whether to clear target and all subsequent exchanges.
-    """
-
-
 class ChatUser(BaseModel):
     # User ID assigned by IdentityProvider.
     username: str

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -59,6 +59,7 @@ class ClearRequest(BaseModel):
     If not provided, this requests the backend to clear all messages.
     """
 
+
 class ChatUser(BaseModel):
     # User ID assigned by IdentityProvider.
     username: str

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -52,7 +52,7 @@ class StopRequest(BaseModel):
 
 
 class ClearRequest(BaseModel):
-    type: Literal["clear"]
+    type: Literal["clear"] = "clear"
     target: Optional[str]
     """
     Message ID of the HumanChatMessage to delete an exchange at.

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -148,13 +148,6 @@ class HumanChatMessage(BaseModel):
     client: ChatClient
 
 
-class StopMessage(BaseModel):
-    """Message broadcast to clients after receiving a request to stop stop streaming or generating response"""
-
-    type: Literal["stop"] = "stop"
-    target: str
-
-
 class ClearMessage(BaseModel):
     type: Literal["clear"] = "clear"
     targets: Optional[List[str]] = None

--- a/packages/jupyter-ai/src/components/chat-messages/chat-message-delete.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages/chat-message-delete.tsx
@@ -15,8 +15,7 @@ type DeleteButtonProps = {
 export function ChatMessageDelete(props: DeleteButtonProps): JSX.Element {
   const request: AiService.ClearRequest = {
     type: 'clear',
-    target: props.message.id,
-    after: false
+    target: props.message.id
   };
   return (
     <TooltippedIconButton

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -86,7 +86,6 @@ export namespace AiService {
   export type ClearRequest = {
     type: 'clear';
     target?: string;
-    after?: boolean;
   };
 
   export type StopRequest = {


### PR DESCRIPTION
## Description

- Gathers all message clearing logic into a single method, `RootChatHandler.on_clear_request()`. Now, the backend history & memory models are cleared **before** a `ClearMessage` is broadcast to all clients.
- `ClearChatHandler` now just calls `RootChatHandler.on_clear_request()`.
- Adds new `BaseChatHandler.broadcast_message()` method, which removes duplicate logic for broadcasting messages scattered across different methods.
- Removes unused `StopMessage` backend model accidentally merged with #1022.
- Removes unused `ClearRequest.after` field in frontend & backend models that should have been reverted before merging #951.
  - If we want to implement bulk message clearing in a future release, a new `ClearRequest.targets: Optional[List[str]]` field can be added. Some of the methods involved with clearing messages still accept a list of message IDs, so this change shouldn't be too difficult if needed.

## Demo


https://github.com/user-attachments/assets/59924f91-bd56-453b-b1d4-49324ece1188

