### PR TITLE
Migrate streaming logic to `BaseChatHandler` 

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -73,7 +73,9 @@ class AskChatHandler(BaseChatHandler):
         try:
             with self.pending("Searching learned documents", message):
                 assert self.llm_chain
-                result = await self.llm_chain.acall({"question": query})
+                # TODO: migrate this class to use a LCEL `Runnable` instead of
+                # `Chain`, then remove the below ignore comment.
+                result = await self.llm_chain.acall({"question": query}) # type:ignore[attr-defined]
                 response = result["answer"]
             self.reply(response, message)
         except AssertionError as e:

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -75,7 +75,9 @@ class AskChatHandler(BaseChatHandler):
                 assert self.llm_chain
                 # TODO: migrate this class to use a LCEL `Runnable` instead of
                 # `Chain`, then remove the below ignore comment.
-                result = await self.llm_chain.acall({"question": query}) # type:ignore[attr-defined]
+                result = await self.llm_chain.acall(  # type:ignore[attr-defined]
+                    {"question": query}
+                )
                 response = result["answer"]
             self.reply(response, message)
         except AssertionError as e:

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -532,6 +532,7 @@ class BaseChatHandler:
         additional configuration when streaming from the runnable.
         """
         assert self.llm_chain
+        assert isinstance(self.llm_chain, Runnable)
 
         received_first_chunk = False
         metadata_handler = MetadataCallbackHandler()
@@ -564,7 +565,11 @@ class BaseChatHandler:
                     try:
                         # notify the model provider that streaming was interrupted
                         # (this is essential to allow the model to stop generating)
-                        await chunk_generator.athrow(GenerationInterrupted())
+                        #
+                        # note: `mypy` flags this line, claiming that `athrow` is
+                        # not defined on `AsyncIterator`. This is why an ignore
+                        # comment is placed here.
+                        await chunk_generator.athrow(GenerationInterrupted()) # type:ignore[attr-defined]
                     except GenerationInterrupted:
                         # do not let the exception bubble up in case if
                         # the provider did not handle it

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -503,12 +503,15 @@ class BaseChatHandler:
         stream_id: str,
         content: str,
         complete: bool = False,
-        metadata: Dict[str, Any] = {},
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Sends an `agent-stream-chunk` message containing content that should be
         appended to an existing `agent-stream` message with ID `stream_id`.
         """
+        if not metadata:
+            metadata = {}
+
         stream_chunk_msg = AgentStreamChunkMessage(
             id=stream_id, content=content, stream_complete=complete, metadata=metadata
         )

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -1,9 +1,7 @@
 import asyncio
 from typing import Dict, Type
 
-from jupyter_ai.models import (
-    HumanChatMessage,
-)
+from jupyter_ai.models import HumanChatMessage
 from jupyter_ai_magics.providers import BaseProvider
 from langchain_core.runnables import ConfigurableFieldSpec
 from langchain_core.runnables.history import RunnableWithMessageHistory
@@ -69,9 +67,8 @@ class DefaultChatHandler(BaseChatHandler):
                 return
             inputs["context"] = context_prompt
             inputs["input"] = self.replace_prompt(inputs["input"])
-        
-        await self.stream_reply(inputs, message)
 
+        await self.stream_reply(inputs, message)
 
     async def make_context_prompt(self, human_msg: HumanChatMessage) -> str:
         return "\n\n".join(

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -1,25 +1,15 @@
 import asyncio
-import time
-from typing import Any, Dict, Type
-from uuid import uuid4
+from typing import Dict, Type
 
-from jupyter_ai.callback_handlers import MetadataCallbackHandler
 from jupyter_ai.models import (
-    AgentStreamChunkMessage,
-    AgentStreamMessage,
     HumanChatMessage,
 )
 from jupyter_ai_magics.providers import BaseProvider
-from langchain_core.messages import AIMessageChunk
 from langchain_core.runnables import ConfigurableFieldSpec
 from langchain_core.runnables.history import RunnableWithMessageHistory
 
 from ..context_providers import ContextProviderException, find_commands
 from .base import BaseChatHandler, SlashCommandRoutingType
-
-
-class GenerationInterrupted(asyncio.CancelledError):
-    """Exception raised when streaming is cancelled by the user"""
 
 
 class DefaultChatHandler(BaseChatHandler):
@@ -65,55 +55,8 @@ class DefaultChatHandler(BaseChatHandler):
             )
         self.llm_chain = runnable
 
-    def _start_stream(self, human_msg: HumanChatMessage) -> str:
-        """
-        Sends an `agent-stream` message to indicate the start of a response
-        stream. Returns the ID of the message, denoted as the `stream_id`.
-        """
-        stream_id = uuid4().hex
-        stream_msg = AgentStreamMessage(
-            id=stream_id,
-            time=time.time(),
-            body="",
-            reply_to=human_msg.id,
-            persona=self.persona,
-            complete=False,
-        )
-
-        for handler in self._root_chat_handlers.values():
-            if not handler:
-                continue
-
-            handler.broadcast_message(stream_msg)
-            break
-
-        return stream_id
-
-    def _send_stream_chunk(
-        self,
-        stream_id: str,
-        content: str,
-        complete: bool = False,
-        metadata: Dict[str, Any] = {},
-    ):
-        """
-        Sends an `agent-stream-chunk` message containing content that should be
-        appended to an existing `agent-stream` message with ID `stream_id`.
-        """
-        stream_chunk_msg = AgentStreamChunkMessage(
-            id=stream_id, content=content, stream_complete=complete, metadata=metadata
-        )
-
-        for handler in self._root_chat_handlers.values():
-            if not handler:
-                continue
-
-            handler.broadcast_message(stream_chunk_msg)
-            break
-
     async def process_message(self, message: HumanChatMessage):
         self.get_llm_chain()
-        received_first_chunk = False
         assert self.llm_chain
 
         inputs = {"input": message.body}
@@ -126,61 +69,9 @@ class DefaultChatHandler(BaseChatHandler):
                 return
             inputs["context"] = context_prompt
             inputs["input"] = self.replace_prompt(inputs["input"])
+        
+        await self.stream_reply(inputs, message)
 
-        # start with a pending message
-        with self.pending("Generating response", message) as pending_message:
-            # stream response in chunks. this works even if a provider does not
-            # implement streaming, as `astream()` defaults to yielding `_call()`
-            # when `_stream()` is not implemented on the LLM class.
-            metadata_handler = MetadataCallbackHandler()
-            chunk_generator = self.llm_chain.astream(
-                inputs,
-                config={
-                    "configurable": {"last_human_msg": message},
-                    "callbacks": [metadata_handler],
-                },
-            )
-            stream_interrupted = False
-            async for chunk in chunk_generator:
-                if not received_first_chunk:
-                    # when receiving the first chunk, close the pending message and
-                    # start the stream.
-                    self.close_pending(pending_message)
-                    stream_id = self._start_stream(human_msg=message)
-                    received_first_chunk = True
-                    self.message_interrupted[stream_id] = asyncio.Event()
-
-                if self.message_interrupted[stream_id].is_set():
-                    try:
-                        # notify the model provider that streaming was interrupted
-                        # (this is essential to allow the model to stop generating)
-                        await chunk_generator.athrow(GenerationInterrupted())
-                    except GenerationInterrupted:
-                        # do not let the exception bubble up in case if
-                        # the provider did not handle it
-                        pass
-                    stream_interrupted = True
-                    break
-
-                if isinstance(chunk, AIMessageChunk) and isinstance(chunk.content, str):
-                    self._send_stream_chunk(stream_id, chunk.content)
-                elif isinstance(chunk, str):
-                    self._send_stream_chunk(stream_id, chunk)
-                else:
-                    self.log.error(f"Unrecognized type of chunk yielded: {type(chunk)}")
-                    break
-
-            # complete stream after all chunks have been streamed
-            stream_tombstone = (
-                "\n\n(AI response stopped by user)" if stream_interrupted else ""
-            )
-            self._send_stream_chunk(
-                stream_id,
-                stream_tombstone,
-                complete=True,
-                metadata=metadata_handler.jai_metadata,
-            )
-            del self.message_interrupted[stream_id]
 
     async def make_context_prompt(self, human_msg: HumanChatMessage) -> str:
         return "\n\n".join(

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
@@ -77,7 +77,9 @@ class FixChatHandler(BaseChatHandler):
         self.llm = llm
         # TODO: migrate this class to use a LCEL `Runnable` instead of
         # `Chain`, then remove the below ignore comment.
-        self.llm_chain = LLMChain(llm=llm, prompt=FIX_PROMPT_TEMPLATE, verbose=True) # type:ignore[arg-type]
+        self.llm_chain = LLMChain(  # type:ignore[arg-type]
+            llm=llm, prompt=FIX_PROMPT_TEMPLATE, verbose=True
+        )
 
     async def process_message(self, message: HumanChatMessage):
         if not (message.selection and message.selection.type == "cell-with-error"):
@@ -98,7 +100,7 @@ class FixChatHandler(BaseChatHandler):
             assert self.llm_chain
             # TODO: migrate this class to use a LCEL `Runnable` instead of
             # `Chain`, then remove the below ignore comment.
-            response = await self.llm_chain.apredict( # type:ignore[attr-defined]
+            response = await self.llm_chain.apredict(  # type:ignore[attr-defined]
                 extra_instructions=extra_instructions,
                 stop=["\nHuman:"],
                 cell_content=selection.source,

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
@@ -2,7 +2,7 @@ from typing import Dict, Type
 
 from jupyter_ai.models import CellWithErrorSelection, HumanChatMessage
 from jupyter_ai_magics.providers import BaseProvider
-from langchain.chains.llm import LLMChain
+from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 
 from .base import BaseChatHandler, SlashCommandRoutingType

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
@@ -2,7 +2,7 @@ from typing import Dict, Type
 
 from jupyter_ai.models import CellWithErrorSelection, HumanChatMessage
 from jupyter_ai_magics.providers import BaseProvider
-from langchain.chains import LLMChain
+from langchain.chains.llm import LLMChain
 from langchain.prompts import PromptTemplate
 
 from .base import BaseChatHandler, SlashCommandRoutingType
@@ -75,7 +75,9 @@ class FixChatHandler(BaseChatHandler):
         llm = provider(**unified_parameters)
 
         self.llm = llm
-        self.llm_chain = LLMChain(llm=llm, prompt=FIX_PROMPT_TEMPLATE, verbose=True)
+        # TODO: migrate this class to use a LCEL `Runnable` instead of
+        # `Chain`, then remove the below ignore comment.
+        self.llm_chain = LLMChain(llm=llm, prompt=FIX_PROMPT_TEMPLATE, verbose=True) # type:ignore[arg-type]
 
     async def process_message(self, message: HumanChatMessage):
         if not (message.selection and message.selection.type == "cell-with-error"):
@@ -94,7 +96,9 @@ class FixChatHandler(BaseChatHandler):
         self.get_llm_chain()
         with self.pending("Analyzing error", message):
             assert self.llm_chain
-            response = await self.llm_chain.apredict(
+            # TODO: migrate this class to use a LCEL `Runnable` instead of
+            # `Chain`, then remove the below ignore comment.
+            response = await self.llm_chain.apredict( # type:ignore[attr-defined]
                 extra_instructions=extra_instructions,
                 stop=["\nHuman:"],
                 cell_content=selection.source,


### PR DESCRIPTION
## Description

- Migrates streaming logic from `DefaultChatHandler` to `BaseChatHandler`, "lifting up" the implementation such that it can be re-used by different child classes.
- This will allow for streaming support in other slash commands we provide, e.g. `/ask` and `/fix`.
- This will also allow developers using custom slash commands to re-use our streaming logic, which will stay updated when `jupyter_ai` is upgraded.
  - The new "stop streaming" feature introduced by #1022 required changes to the streaming logic, meaning that this feature will not work for existing custom slash commands that implement streaming. Developers will have to manually intervene if they want their slash commands to be stoppable after upgrading to v2.26.0.
  - This change will prevent this scenario from happening again in the future.

## Follow-up issues

Issues that should be addressed after this PR is merged & released (in descending priority).

- https://github.com/jupyterlab/jupyter-ai/issues/1040
- https://github.com/jupyterlab/jupyter-ai/issues/863
- https://github.com/jupyterlab/jupyter-ai/issues/1041
