### PR TITLE
Add examples of using Fields and EnvAuthStrategy to developer documentation

### DIFF
--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -161,6 +161,45 @@ class MyProvider(BaseProvider, FakeListLLM):
 
 ```
 
+#### Api key  for custom providers
+
+The following example shows the `EnvAuthStrategy` for specifying API keys for providers.  These will be taken from the
+environment variable with the name specified in `name` and be provided to the model's `__init__` as a kwarg with the 
+name specified in `keyword_param`.
+
+This will also cause a field to be present in the configuration UI with the `name` of the environment variable as the 
+label.
+
+```python
+from jupyter_ai_magics import BaseProvider
+from jupyter_ai_magics.providers import EnvAuthStrategy
+from langchain_community.llms import FakeListLLM
+
+
+class MyProvider(BaseProvider, FakeListLLM):
+    id = "my_provider"
+    name = "My Provider"
+    model_id_key = "model"
+    models = [
+        "model_a",
+        "model_b"
+    ]
+    
+    auth_strategy = EnvAuthStrategy(
+        name="MY_API_KEY", keyword_param="my_api_key_param"
+    )
+    
+    def __init__(self, **kwargs):
+        model = kwargs.get("model_id")
+        kwargs["responses"] = (
+            ["This is a response from model 'a'"]
+            if model == "model_a" else
+            ["This is a response from model 'b'"]
+        )
+        super().__init__(**kwargs)
+
+```
+
 ### Custom embeddings providers
 
 To provide a custom embeddings model an embeddings providers should be defined implementing the API of `jupyter-ai`'s `BaseEmbeddingsProvider` and of `langchain`'s [`Embeddings`][Embeddings] abstract class.

--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -123,8 +123,8 @@ your new provider's `id`:
 
 #### Configuration for custom providers
 
-You can add custom fields into the settings dialogue for your custom model by specifying a list of fields as shown 
-below.  
+You can add custom fields into the settings dialogue for your custom model by specifying a list of fields as shown
+below.
 
 These will be passed into the `__init__` as kwargs, with the key specified by the key in the field object.
 
@@ -132,7 +132,7 @@ The label specified in the field object determines the text shown in the configu
 
 ```python
 from jupyter_ai_magics import BaseProvider
-from jupyter_ai_magics.providers import TextField, MultilineTextField 
+from jupyter_ai_magics.providers import TextField, MultilineTextField
 from langchain_community.llms import FakeListLLM
 
 
@@ -144,12 +144,12 @@ class MyProvider(BaseProvider, FakeListLLM):
         "model_a",
         "model_b"
     ]
-    
+
     fields: ClassVar[List[Field]] = [
         TextField(key="my_llm_parameter", label="The name for my_llm_parameter to show in the UI"),
         MultilineTextField(key="custom_config", label="Custom Json Config", format="json"),
     ]
-    
+
     def __init__(self, **kwargs):
         model = kwargs.get("model_id")
         kwargs["responses"] = (
@@ -164,10 +164,10 @@ class MyProvider(BaseProvider, FakeListLLM):
 #### Api key  for custom providers
 
 The following example shows the `EnvAuthStrategy` for specifying API keys for providers.  These will be taken from the
-environment variable with the name specified in `name` and be provided to the model's `__init__` as a kwarg with the 
+environment variable with the name specified in `name` and be provided to the model's `__init__` as a kwarg with the
 name specified in `keyword_param`.
 
-This will also cause a field to be present in the configuration UI with the `name` of the environment variable as the 
+This will also cause a field to be present in the configuration UI with the `name` of the environment variable as the
 label.
 
 ```python
@@ -184,11 +184,11 @@ class MyProvider(BaseProvider, FakeListLLM):
         "model_a",
         "model_b"
     ]
-    
+
     auth_strategy = EnvAuthStrategy(
         name="MY_API_KEY", keyword_param="my_api_key_param"
     )
-    
+
     def __init__(self, **kwargs):
         model = kwargs.get("model_id")
         kwargs["responses"] = (

--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -121,58 +121,16 @@ your new provider's `id`:
 [LLM]: https://api.python.langchain.com/en/v0.0.339/llms/langchain.llms.base.LLM.html#langchain.llms.base.LLM
 [BaseChatModel]: https://api.python.langchain.com/en/v0.0.339/chat_models/langchain.chat_models.base.BaseChatModel.html
 
-#### Configuration for custom providers
+### API keys and fields for custom providers
 
-You can add custom fields into the settings dialogue for your custom model by specifying a list of fields as shown
+You can add handle authentication via API keys, and configuration with 
+custom parameters using an auth strategy and fields as shown in the example 
 below.
 
-These will be passed into the `__init__` as kwargs, with the key specified by the key in the field object.
-
-The label specified in the field object determines the text shown in the configuration section of the user interface.
-
 ```python
+from typing import ClassVar, List
 from jupyter_ai_magics import BaseProvider
-from jupyter_ai_magics.providers import TextField, MultilineTextField
-from langchain_community.llms import FakeListLLM
-
-
-class MyProvider(BaseProvider, FakeListLLM):
-    id = "my_provider"
-    name = "My Provider"
-    model_id_key = "model"
-    models = [
-        "model_a",
-        "model_b"
-    ]
-
-    fields: ClassVar[List[Field]] = [
-        TextField(key="my_llm_parameter", label="The name for my_llm_parameter to show in the UI"),
-        MultilineTextField(key="custom_config", label="Custom Json Config", format="json"),
-    ]
-
-    def __init__(self, **kwargs):
-        model = kwargs.get("model_id")
-        kwargs["responses"] = (
-            ["This is a response from model 'a'"]
-            if model == "model_a" else
-            ["This is a response from model 'b'"]
-        )
-        super().__init__(**kwargs)
-
-```
-
-#### Api key  for custom providers
-
-The following example shows the `EnvAuthStrategy` for specifying API keys for providers.  These will be taken from the
-environment variable with the name specified in `name` and be provided to the model's `__init__` as a kwarg with the
-name specified in `keyword_param`.
-
-This will also cause a field to be present in the configuration UI with the `name` of the environment variable as the
-label.
-
-```python
-from jupyter_ai_magics import BaseProvider
-from jupyter_ai_magics.providers import EnvAuthStrategy
+from jupyter_ai_magics.providers import EnvAuthStrategy, Field, TextField, MultilineTextField
 from langchain_community.llms import FakeListLLM
 
 
@@ -188,6 +146,11 @@ class MyProvider(BaseProvider, FakeListLLM):
     auth_strategy = EnvAuthStrategy(
         name="MY_API_KEY", keyword_param="my_api_key_param"
     )
+    
+    fields: ClassVar[List[Field]] = [
+        TextField(key="my_llm_parameter", label="The name for my_llm_parameter to show in the UI"),
+        MultilineTextField(key="custom_config", label="Custom Json Config", format="json"),
+    ]
 
     def __init__(self, **kwargs):
         model = kwargs.get("model_id")
@@ -197,8 +160,21 @@ class MyProvider(BaseProvider, FakeListLLM):
             ["This is a response from model 'b'"]
         )
         super().__init__(**kwargs)
-
 ```
+
+The `auth_strategy` handles specifying API keys for providers and models.  
+The example shows the `EnvAuthStrategy` which takes the API key from the
+environment variable with the name specified in `name` and be provided to the 
+model's `__init__` as a kwarg with the name specified in `keyword_param`.  
+This will also cause a field to be present in the configuration UI with the  
+`name` of the environment variable as the label.
+
+Further configuration can be handled adding `fields` into the settings 
+dialogue for your custom model by specifying a list of fields as shown in 
+the example.  These will be passed into the `__init__` as kwargs, with the 
+key specified by the key in the field object. The label specified in the field 
+object determines the text shown in the configuration section of the user 
+interface.
 
 ### Custom embeddings providers
 

--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -123,8 +123,8 @@ your new provider's `id`:
 
 ### API keys and fields for custom providers
 
-You can add handle authentication via API keys, and configuration with 
-custom parameters using an auth strategy and fields as shown in the example 
+You can add handle authentication via API keys, and configuration with
+custom parameters using an auth strategy and fields as shown in the example
 below.
 
 ```python
@@ -146,7 +146,7 @@ class MyProvider(BaseProvider, FakeListLLM):
     auth_strategy = EnvAuthStrategy(
         name="MY_API_KEY", keyword_param="my_api_key_param"
     )
-    
+
     fields: ClassVar[List[Field]] = [
         TextField(key="my_llm_parameter", label="The name for my_llm_parameter to show in the UI"),
         MultilineTextField(key="custom_config", label="Custom Json Config", format="json"),
@@ -162,18 +162,18 @@ class MyProvider(BaseProvider, FakeListLLM):
         super().__init__(**kwargs)
 ```
 
-The `auth_strategy` handles specifying API keys for providers and models.  
+The `auth_strategy` handles specifying API keys for providers and models.
 The example shows the `EnvAuthStrategy` which takes the API key from the
-environment variable with the name specified in `name` and be provided to the 
-model's `__init__` as a kwarg with the name specified in `keyword_param`.  
-This will also cause a field to be present in the configuration UI with the  
+environment variable with the name specified in `name` and be provided to the
+model's `__init__` as a kwarg with the name specified in `keyword_param`.
+This will also cause a field to be present in the configuration UI with the
 `name` of the environment variable as the label.
 
-Further configuration can be handled adding `fields` into the settings 
-dialogue for your custom model by specifying a list of fields as shown in 
-the example.  These will be passed into the `__init__` as kwargs, with the 
-key specified by the key in the field object. The label specified in the field 
-object determines the text shown in the configuration section of the user 
+Further configuration can be handled adding `fields` into the settings
+dialogue for your custom model by specifying a list of fields as shown in
+the example.  These will be passed into the `__init__` as kwargs, with the
+key specified by the key in the field object. The label specified in the field
+object determines the text shown in the configuration section of the user
 interface.
 
 ### Custom embeddings providers

--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -121,6 +121,46 @@ your new provider's `id`:
 [LLM]: https://api.python.langchain.com/en/v0.0.339/llms/langchain.llms.base.LLM.html#langchain.llms.base.LLM
 [BaseChatModel]: https://api.python.langchain.com/en/v0.0.339/chat_models/langchain.chat_models.base.BaseChatModel.html
 
+#### Configuration for custom providers
+
+You can add custom fields into the settings dialogue for your custom model by specifying a list of fields as shown 
+below.  
+
+These will be passed into the `__init__` as kwargs, with the key specified by the key in the field object.
+
+The label specified in the field object determines the text shown in the configuration section of the user interface.
+
+```python
+from jupyter_ai_magics import BaseProvider
+from jupyter_ai_magics.providers import TextField, MultilineTextField 
+from langchain_community.llms import FakeListLLM
+
+
+class MyProvider(BaseProvider, FakeListLLM):
+    id = "my_provider"
+    name = "My Provider"
+    model_id_key = "model"
+    models = [
+        "model_a",
+        "model_b"
+    ]
+    
+    fields: ClassVar[List[Field]] = [
+        TextField(key="my_llm_parameter", label="The name for my_llm_parameter to show in the UI"),
+        MultilineTextField(key="custom_config", label="Custom Json Config", format="json"),
+    ]
+    
+    def __init__(self, **kwargs):
+        model = kwargs.get("model_id")
+        kwargs["responses"] = (
+            ["This is a response from model 'a'"]
+            if model == "model_a" else
+            ["This is a response from model 'b'"]
+        )
+        super().__init__(**kwargs)
+
+```
+
 ### Custom embeddings providers
 
 To provide a custom embeddings model an embeddings providers should be defined implementing the API of `jupyter-ai`'s `BaseEmbeddingsProvider` and of `langchain`'s [`Embeddings`][Embeddings] abstract class.


### PR DESCRIPTION
Based on my (as yet unsuccessful) attempts to add a custom provider, I have captured the bits which I have managed to figure out and get working and added examples of them to the developer docs to help any one looking to add new providers in the future.

I think this could do with a review from someone who understands the Provider design better than I do, to make sure that what I have put is reasonably correct.