### PR TITLE
Merge Anthropic language model providers

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
@@ -11,7 +11,6 @@ class AnthropicProvider(BaseProvider, AnthropicLLM):
         "claude-v1.0",
         "claude-v1.2",
         "claude-2",
-        "claude-2.0",
         "claude-instant-v1",
         "claude-instant-v1.0",
         "claude-instant-v1.2",
@@ -40,7 +39,7 @@ class ChatAnthropicProvider(
     BaseProvider, ChatAnthropic
 ):  # https://docs.anthropic.com/en/docs/about-claude/models
     id = "anthropic-chat"
-    name = "ChatAnthropic"
+    name = "Anthropic"
     models = [
         "claude-2.0",
         "claude-2.1",

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
@@ -10,7 +10,6 @@ class AnthropicProvider(BaseProvider, AnthropicLLM):
         "claude-v1",
         "claude-v1.0",
         "claude-v1.2",
-        "claude-2",
         "claude-instant-v1",
         "claude-instant-v1.0",
         "claude-instant-v1.2",

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/anthropic.py
@@ -42,7 +42,6 @@ class ChatAnthropicProvider(
     models = [
         "claude-2.0",
         "claude-2.1",
-        "claude-instant-1.2",
         "claude-3-opus-20240229",
         "claude-3-sonnet-20240229",
         "claude-3-haiku-20240307",


### PR DESCRIPTION
Fixes #1065 

Older models use the `AnthropicLLM` and newer models use the `ChatAnthropic` class. This PR removes model `claude-2.0` from the former class as it is also available in the latter class. The PR also ensures that all models are now prefixed with the label `Anthropic` and eliminates usage of the label `ChatAnthropic`. 

![image](https://github.com/user-attachments/assets/bedd63db-3163-4a46-ab29-d983062d4bc1)

Note: both classes are needed and both model class ids = {`anthropic`, `anthropic-chat`} are retained as they are needed in `anthropic.py` and in `pyproject.toml`. 



