### PR TITLE
Reduced padding in cell around code icons in code toolbar

### DIFF
--- a/packages/jupyter-ai/src/components/code-blocks/code-toolbar.tsx
+++ b/packages/jupyter-ai/src/components/code-blocks/code-toolbar.tsx
@@ -116,7 +116,7 @@ function InsertAboveButton(props: ToolbarButtonProps) {
       }}
       disabled={!props.activeCellExists}
     >
-      <addAboveIcon.react height="16px" width="16px" />
+      <addAboveIcon.react height="16px" width="16px" paddingRight="8px" />
     </TooltippedIconButton>
   );
 }
@@ -142,7 +142,7 @@ function InsertBelowButton(props: ToolbarButtonProps) {
         }
       }}
     >
-      <addBelowIcon.react height="16px" width="16px" />
+      <addBelowIcon.react height="16px" width="16px" paddingRight="8px" />
     </TooltippedIconButton>
   );
 }
@@ -166,7 +166,7 @@ function ReplaceButton(props: ToolbarButtonProps) {
         }
       }}
     >
-      <replaceCellIcon.react height="16px" width="16px" />
+      <replaceCellIcon.react height="16px" width="16px" paddingRight="8px" />
     </TooltippedIconButton>
   );
 }

--- a/packages/jupyter-ai/src/components/code-blocks/code-toolbar.tsx
+++ b/packages/jupyter-ai/src/components/code-blocks/code-toolbar.tsx
@@ -44,7 +44,7 @@ export function CodeToolbar(props: CodeToolbarProps): JSX.Element {
         display: 'flex',
         justifyContent: 'flex-end',
         alignItems: 'center',
-        padding: '6px 2px',
+        padding: '2px 2px',
         marginBottom: '1em',
         border: '1px solid var(--jp-cell-editor-border-color)',
         borderTop: 'none'

--- a/packages/jupyter-ai/src/components/code-blocks/code-toolbar.tsx
+++ b/packages/jupyter-ai/src/components/code-blocks/code-toolbar.tsx
@@ -116,7 +116,7 @@ function InsertAboveButton(props: ToolbarButtonProps) {
       }}
       disabled={!props.activeCellExists}
     >
-      <addAboveIcon.react height="16px" width="16px" paddingRight="8px" />
+      <addAboveIcon.react height="16px" width="16px" />
     </TooltippedIconButton>
   );
 }
@@ -142,7 +142,7 @@ function InsertBelowButton(props: ToolbarButtonProps) {
         }
       }}
     >
-      <addBelowIcon.react height="16px" width="16px" paddingRight="8px" />
+      <addBelowIcon.react height="16px" width="16px" />
     </TooltippedIconButton>
   );
 }
@@ -166,7 +166,7 @@ function ReplaceButton(props: ToolbarButtonProps) {
         }
       }}
     >
-      <replaceCellIcon.react height="16px" width="16px" paddingRight="8px" />
+      <replaceCellIcon.react height="16px" width="16px" />
     </TooltippedIconButton>
   );
 }

--- a/packages/jupyter-ai/src/components/mui-extras/tooltipped-icon-button.tsx
+++ b/packages/jupyter-ai/src/components/mui-extras/tooltipped-icon-button.tsx
@@ -80,7 +80,7 @@ export function TooltippedIconButton(
           onClick={props.onClick}
           disabled={props.disabled}
           sx={{
-            mr: '8px',
+            ml: '8px',
             lineHeight: 0,
             ...(props.disabled && { opacity: 0.5 }),
             ...props.sx

--- a/packages/jupyter-ai/src/components/mui-extras/tooltipped-icon-button.tsx
+++ b/packages/jupyter-ai/src/components/mui-extras/tooltipped-icon-button.tsx
@@ -80,6 +80,7 @@ export function TooltippedIconButton(
           onClick={props.onClick}
           disabled={props.disabled}
           sx={{
+            mr: '8px',
             lineHeight: 0,
             ...(props.disabled && { opacity: 0.5 }),
             ...props.sx


### PR DESCRIPTION
Fixes #1070 

Reduces vertical and horizontal padding to 2px

New look: 
![image](https://github.com/user-attachments/assets/86130f0f-c61f-473b-904b-ad93b986b777)
