### PR TITLE
Fix magic commands when using non-chat providers w/ history

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -603,17 +603,17 @@ class AiMagics(Magics):
         else:
             # generate output from model via provider
             if context:
-                inputs = [
+                inputs = "\n\n".join([
                     (
                         f"AI: {message.content}"
                         if message.type == "ai"
                         else f"{message.type.title()}: {message.content}"
                     )
                     for message in context + [HumanMessage(content=prompt)]
-                ]
+                ])
             else:
-                inputs = [prompt]
-            result = provider.generate(inputs)
+                inputs = prompt
+            result = provider.generate([inputs])
 
         output = result.generations[0][0].text
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -603,14 +603,16 @@ class AiMagics(Magics):
         else:
             # generate output from model via provider
             if context:
-                inputs = "\n\n".join([
-                    (
-                        f"AI: {message.content}"
-                        if message.type == "ai"
-                        else f"{message.type.title()}: {message.content}"
-                    )
-                    for message in context + [HumanMessage(content=prompt)]
-                ])
+                inputs = "\n\n".join(
+                    [
+                        (
+                            f"AI: {message.content}"
+                            if message.type == "ai"
+                            else f"{message.type.title()}: {message.content}"
+                        )
+                        for message in context + [HumanMessage(content=prompt)]
+                    ]
+                )
             else:
                 inputs = prompt
             result = provider.generate([inputs])


### PR DESCRIPTION
When we're calling provider.generate, ultimately we're calling the generate  function as specified in langchain_core.language_models.llms.BaseLLM. This function expects a list of string prompts, where each should have a separate generation performed for it - this being to allow taking advantage  of batch processing where possible.

The bug here is that we pass in each message from the context as a separate generation question,  rather than combining them together into a single prompt including both the context and human message.

The edit here concatenates them all with two new lines between each message and ensures that we pass only a single element list to the generate function.