### PR TITLE
Improve installation documentation and clarify provider dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,45 +53,48 @@ Below is a simplified overview of the installation and usage process.
 See [our official documentation](https://jupyter-ai.readthedocs.io/en/latest/users/index.html)
 for details on installing and using Jupyter AI.
 
+We offer 3 different ways to install Jupyter AI. You can read through each
+section to pick the installation method that works best for you.
+
+1. Quick installation via `pip` (recommended)
+2. Minimal installation via `pip`
+3. Minimal installation via `conda`
+
 ### Quick installation via `pip` (recommended)
 
 If you want to install both the `%%ai` magic and the JupyterLab extension, you can run:
 
     $ pip install jupyter-ai[all]
 
-Then, restart JupyterLab. This will install every dependency, which will give you access to all models currently supported by `jupyter-ai`.
+Then, restart JupyterLab. This will install every optional dependency, which
+provides access to all models currently supported by `jupyter-ai`.
 
-If you are not using JupyterLab and you only want to install the Jupyter AI `%%ai` magic, you can run:
+If you are not using JupyterLab and you only want to install the Jupyter AI
+`%%ai` magic, you can run:
 
     $ pip install jupyter-ai-magics[all]
 
-`jupyter-ai` depends on `jupyter-ai-magics`, so installing `jupyter-ai` automatically installs `jupyter-ai-magics`.
+`jupyter-ai` depends on `jupyter-ai-magics`, so installing `jupyter-ai`
+automatically installs `jupyter-ai-magics`.
 
-If you do not run install with the `[all]` option, you may need to install third-party packages to use some model providers and some file formats with Jupyter AI. For example, to use OpenAI models, in addition to your current install also run
+### Minimal installation via `pip`
+
+Most model providers in Jupyter AI require a specific dependency to be installed
+before they are available for use. These are called _provider dependencies_.
+Provider dependencies are optional to Jupyter AI, meaning that Jupyter AI can be
+installed with or without any provider dependencies installed. If a provider
+requires a dependency that is not installed, its models are not listed in the
+user interface which allows you to select a language model. 
+
+To perform a minimal installation via `pip` without any provider dependencies,
+omit the `[all]` optional dependency group from the package name:
 
 ```
-pip install langchain-openai
+pip install jupyter-ai
 ```
 
-To use models from Anthropic, install:
-
-```
-pip install langchain-anthropic
-```
-
-After these installs you should see the OpenAI and Anthropic models in the drop down list. If you are using Claude models on AWS Bedrock, you must also install
-
-```
-pip install langchain-aws
-```
-
-Similarly, install `langchain-<provider>` packages for other providers as well. For more information on model providers and which dependencies they require, see [the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
-
-### Minimal installation via `pip` (optional)
-
-Most model providers in Jupyter AI require a specific dependency to be installed before they are available for use. These are called _provider dependencies_. Provider dependencies are optional to Jupyter AI, meaning that Jupyter AI can be installed with or without any provider dependencies installed.
-
-If a provider requires a dependency that is not installed, its models are not listed in the user interface which allows you to select a language model. This offers a way for users to control which models are available in your Jupyter AI environment.
+By selectively installing provider dependencies, you can control which models
+are available in your Jupyter AI environment.
 
 For example, to install Jupyter AI with only added support for Anthropic models, run:
 
@@ -99,24 +102,30 @@ For example, to install Jupyter AI with only added support for Anthropic models,
 pip install jupyter-ai langchain-anthropic
 ```
 
-### With conda
+For more information on model providers and which dependencies they require, see
+[the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
+
+### Minimal installation via `conda`
 
 As an alternative to using `pip`, you can install `jupyter-ai` using
 [Conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
-from the `conda-forge` channel, using one of the following two commands:
+from the `conda-forge` channel:
 
-    $ conda install -c conda-forge jupyter-ai  # or,
     $ conda install conda-forge::jupyter-ai
 
-Most model providers in Jupyter AI require a specific dependency to be installed before they are available for use. These provider dependencies are not installed by default when installing `jupyter-ai` from Conda Forge, and should be installed separately as needed.
+Most model providers in Jupyter AI require a specific _provider dependency_ to
+be installed before they are available for use. Provider dependencies are
+not installed when installing `jupyter-ai` from Conda Forge, and should be
+installed separately as needed.
 
-For example, to install Jupyter AI with support for OpenAI models, run:
+For example, to install Jupyter AI with only added support for OpenAI models, run:
 
 ```
 conda install conda-forge::jupyter-ai conda-forge::langchain-openai
 ```
 
-For more information on model providers and which dependencies they require, see [the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
+For more information on model providers and which dependencies they require, see
+[the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
 
 ## The `%%ai` magic command
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You may need to install third-party packages, for example, to use some model pro
 pip install langchain-openai
 ```
 
-To use models from Anthropic, install: 
+To use models from Anthropic, install:
 
 ```
 pip install langchain-anthropic

--- a/README.md
+++ b/README.md
@@ -53,17 +53,21 @@ Below is a simplified overview of the installation and usage process.
 See [our official documentation](https://jupyter-ai.readthedocs.io/en/latest/users/index.html)
 for details on installing and using Jupyter AI.
 
-### With pip
+### Quick installation via `pip` (recommended)
 
 If you want to install both the `%%ai` magic and the JupyterLab extension, you can run:
 
-    $ pip install jupyter-ai
+    $ pip install jupyter-ai[all]
+
+Then, restart JupyterLab. This will install every dependency, which will give you access to all models currently supported by `jupyter-ai`. 
 
 If you are not using JupyterLab and you only want to install the Jupyter AI `%%ai` magic, you can run:
 
-    $ pip install jupyter-ai-magics
+    $ pip install jupyter-ai-magics[all]
 
-You may need to install third-party packages, for example, to use some model providers and some file formats with Jupyter AI. For example, to use OpenAI models, in addition to your current install also run
+`jupyter-ai` depends on `jupyter-ai-magics`, so installing `jupyter-ai` automatically installs `jupyter-ai-magics`.
+
+If you do not run install with the `[all]` option, you may need to install third-party packages to use some model providers and some file formats with Jupyter AI. For example, to use OpenAI models, in addition to your current install also run
 
 ```
 pip install langchain-openai
@@ -81,12 +85,18 @@ After these installs you should see the OpenAI and Anthropic models in the drop 
 pip install langchain-aws
 ```
 
-Similarly, install `langchain-<provider>` packages for other providers as well, listed [here](#model-providers).
+Similarly, install `langchain-<provider>` packages for other providers as well. For more information on model providers and which dependencies they require, see [the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
 
-To handle all supported use cases, you can install every dependency, which will give you access to all models currently supported by `jupyter-ai`. To install every dependency, run the following command, and then restart JupyterLab:
+### Minimal installation via `pip` (optional)
+
+Most model providers in Jupyter AI require a specific dependency to be installed before they are available for use. These are called _provider dependencies_. Provider dependencies are optional to Jupyter AI, meaning that Jupyter AI can be installed with or without any provider dependencies installed.
+
+If a provider requires a dependency that is not installed, its models are not listed in the user interface which allows you to select a language model. This offers a way for users to control which models are available in your Jupyter AI environment.
+
+For example, to install Jupyter AI with only added support for Anthropic models, run:
 
 ```
-pip install jupyter-ai[all]
+pip install jupyter-ai langchain-anthropic
 ```
 
 ### With conda
@@ -98,11 +108,15 @@ from the `conda-forge` channel, using one of the following two commands:
     $ conda install -c conda-forge jupyter-ai  # or,
     $ conda install conda-forge::jupyter-ai
 
-In addition, install third-party `langchain-<provider>` packages, to use some model providers. For example, if you are using OpenAI models:
+Most model providers in Jupyter AI require a specific dependency to be installed before they are available for use. These provider dependencies are not installed by default when installing `jupyter-ai` from Conda Forge, and should be installed separately as needed.
+
+For example, to install Jupyter AI with support for OpenAI models, run:
 
 ```
-conda install conda-forge::langchain-openai
+conda install conda-forge::jupyter-ai conda-forge::langchain-openai
 ```
+
+For more information on model providers and which dependencies they require, see [the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
 
 ## The `%%ai` magic command
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ before they are available for use. These are called _provider dependencies_.
 Provider dependencies are optional to Jupyter AI, meaning that Jupyter AI can be
 installed with or without any provider dependencies installed. If a provider
 requires a dependency that is not installed, its models are not listed in the
-user interface which allows you to select a language model. 
+user interface which allows you to select a language model.
 
 To perform a minimal installation via `pip` without any provider dependencies,
 omit the `[all]` optional dependency group from the package name:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,31 @@ If you are not using JupyterLab and you only want to install the Jupyter AI `%%a
 
     $ pip install jupyter-ai-magics
 
+You may need to install third-party packages, for example, to use some model providers and some file formats with Jupyter AI. For example, to use OpenAI models, in addition to your current install also run
+
+```
+pip install langchain-openai
+```
+
+To use models from Anthropic, install: 
+
+```
+pip install langchain-anthropic
+```
+
+After these installs you should see the OpenAI and Anthropic models in the drop down list. If you are using Claude models on AWS Bedrock, you must also install
+
+```
+pip install langchain-aws
+```
+
+Similarly, install `langchain-<provider>` packages for other providers as well, listed [here](#model-providers).
+
+To handle all supported use cases, you can install every dependency, which will give you access to all models currently supported by `jupyter-ai`. To install every dependency, run the following command, and then restart JupyterLab:
+
+```
+pip install jupyter-ai[all]
+```
 
 ### With conda
 
@@ -72,6 +97,12 @@ from the `conda-forge` channel, using one of the following two commands:
 
     $ conda install -c conda-forge jupyter-ai  # or,
     $ conda install conda-forge::jupyter-ai
+
+In addition, install third-party `langchain-<provider>` packages, to use some model providers. For example, if you are using OpenAI models:
+
+```
+conda install conda-forge::langchain-openai
+```
 
 ## The `%%ai` magic command
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you want to install both the `%%ai` magic and the JupyterLab extension, you c
 
     $ pip install jupyter-ai[all]
 
-Then, restart JupyterLab. This will install every dependency, which will give you access to all models currently supported by `jupyter-ai`. 
+Then, restart JupyterLab. This will install every dependency, which will give you access to all models currently supported by `jupyter-ai`.
 
 If you are not using JupyterLab and you only want to install the Jupyter AI `%%ai` magic, you can run:
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -119,14 +119,14 @@ If you are not using JupyterLab and you only want to install the Jupyter AI
 `jupyter-ai` depends on `jupyter-ai-magics`, so installing `jupyter-ai`
 automatically installs `jupyter-ai-magics`.
 
-### Minimal installation via `pip` 
+### Minimal installation via `pip`
 
 Most model providers in Jupyter AI require a specific dependency to be installed
 before they are available for use. These are called _provider dependencies_.
 Provider dependencies are optional to Jupyter AI, meaning that Jupyter AI can be
 installed with or without any provider dependencies installed. If a provider
 requires a dependency that is not installed, its models are not listed in the
-user interface which allows you to select a language model. 
+user interface which allows you to select a language model.
 
 To perform a minimal installation via `pip` without any provider dependencies,
 omit the `[all]` optional dependency group from the package name:

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -85,7 +85,7 @@ If you want to install both the `%%ai` magic and the JupyterLab extension, you c
 
     $ pip install jupyter-ai[all]
 
-Then, restart JupyterLab. This will install every dependency, which will give you access to all models currently supported by `jupyter-ai`. 
+Then, restart JupyterLab. This will install every dependency, which will give you access to all models currently supported by `jupyter-ai`.
 
 If you are not using JupyterLab and you only want to install the Jupyter AI `%%ai` magic, you can run:
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -79,15 +79,22 @@ classes in their code.
 
 ## Installation
 
-### Installation via `pip`
+### Quick installation via `pip` (recommended)
 
-To install the JupyterLab extension, you can run:
+If you want to install both the `%%ai` magic and the JupyterLab extension, you can run:
 
-```
-pip install jupyter-ai
-```
+    $ pip install jupyter-ai[all]
 
-You may need to install third-party packages, for example, to use some model providers and some file formats with Jupyter AI. For example, to use OpenAI models, in addition to your current install also run
+Then, restart JupyterLab. This will install every dependency, which will give you access to all models currently supported by `jupyter-ai`. 
+
+If you are not using JupyterLab and you only want to install the Jupyter AI `%%ai` magic, you can run:
+
+    $ pip install jupyter-ai-magics[all]
+
+`jupyter-ai` depends on `jupyter-ai-magics`, so installing `jupyter-ai`
+automatically installs `jupyter-ai-magics`.
+
+If you do not run install with the `[all]` option, you may need to install third-party packages to use some model providers and some file formats with Jupyter AI. For example, to use OpenAI models, in addition to your current install also run
 
 ```
 pip install langchain-openai
@@ -105,29 +112,19 @@ After these installs you should see the OpenAI and Anthropic models in the drop 
 pip install langchain-aws
 ```
 
-Similarly, install `langchain-<provider>` packages for other providers as well, listed [here](#model-providers).
+Similarly, install `langchain-<provider>` packages for other providers as well. For more information on model providers and which dependencies they require, see [the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
 
-To handle all supported use cases, you can install every dependency, which will give you access to all models currently supported by `jupyter-ai`. To install every dependency, run the following command, and then restart JupyterLab:
+### Minimal installation via `pip` (optional)
 
-```
-pip install jupyter-ai[all]
-```
+Most model providers in Jupyter AI require a specific dependency to be installed before they are available for use. These are called _provider dependencies_. Provider dependencies are optional to Jupyter AI, meaning that Jupyter AI can be installed with or without any provider dependencies installed.
 
-The latest major version of `jupyter-ai`, v2, only supports JupyterLab 4. If you
-need support for JupyterLab 3, you should install `jupyter-ai` v1 instead:
+If a provider requires a dependency that is not installed, its models are not listed in the user interface which allows you to select a language model. This offers a way for users to control which models are available in your Jupyter AI environment.
 
-```
-pip install jupyter-ai~=1.0
-```
-
-If you are not using JupyterLab and you only want to install the Jupyter AI `%%ai` magic, you can run:
+For example, to install Jupyter AI with only added support for Anthropic models, run:
 
 ```
-$ pip install jupyter-ai-magics
+pip install jupyter-ai langchain-anthropic
 ```
-
-`jupyter-ai` depends on `jupyter-ai-magics`, so installing `jupyter-ai`
-automatically installs `jupyter-ai-magics`.
 
 ### Installation via `pip` or `conda` in a Conda environment (recommended)
 
@@ -155,13 +152,15 @@ conda activate jupyter-ai
 jupyter lab
 ```
 
-In addition, install third-party `langchain-<provider>` packages, to use some model providers. For example, if you are using OpenAI models:
+Most model providers in Jupyter AI require a specific dependency to be installed before they are available for use. These provider dependencies are not installed by default when installing `jupyter-ai` from Conda Forge, and should be installed separately as needed.
+
+For example, to install Jupyter AI with support for OpenAI models, run:
 
 ```
-conda install conda-forge::langchain-openai
+conda install conda-forge::jupyter-ai conda-forge::langchain-openai
 ```
 
-The list of providers and related python packages is listed [here](#model-providers).
+For more information on model providers and which dependencies they require, see [the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
 
 
 ## Uninstallation

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -87,7 +87,27 @@ To install the JupyterLab extension, you can run:
 pip install jupyter-ai
 ```
 
-You may need to install third-party packages, for example, to use some model providers and some file formats with Jupyter AI. To handle all supported use cases, you can install every dependency, which will give you access to all models currently supported by `jupyter-ai`. To install every dependency, run the following command, and then restart JupyterLab:
+You may need to install third-party packages, for example, to use some model providers and some file formats with Jupyter AI. For example, to use OpenAI models, in addition to your current install also run
+
+```
+pip install langchain-openai
+```
+
+To use models from Anthropic, install: 
+
+```
+pip install langchain-anthropic
+```
+
+After these installs you should see the OpenAI and Anthropic models in the drop down list. If you are using Claude models on AWS Bedrock, you must also install
+
+```
+pip install langchain-aws
+```
+
+Similarly, install `langchain-<provider>` packages for other providers as well, listed [here](#model-providers).
+
+To handle all supported use cases, you can install every dependency, which will give you access to all models currently supported by `jupyter-ai`. To install every dependency, run the following command, and then restart JupyterLab:
 
 ```
 pip install jupyter-ai[all]
@@ -134,6 +154,15 @@ environment first:
 conda activate jupyter-ai
 jupyter lab
 ```
+
+In addition, install third-party `langchain-<provider>` packages, to use some model providers. For example, if you are using OpenAI models:
+
+```
+conda install conda-forge::langchain-openai
+```
+
+The list of providers and related python packages is listed [here](#model-providers).
+
 
 ## Uninstallation
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -79,46 +79,64 @@ classes in their code.
 
 ## Installation
 
+### Setup: creating a Jupyter AI environment (recommended)
+
+Before installing Jupyter AI, we highly recommend first creating a separate
+Conda environment for Jupyter AI. This prevents the installation process from
+clobbering Python packages in your existing Python environment.
+
+To do so, install
+[conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
+and create an environment that uses Python 3.12 and the latest version of
+JupyterLab:
+
+    $ conda create -n jupyter-ai python=3.12 jupyterlab
+    $ conda activate jupyter-ai
+
+You can now choose how to install Jupyter AI.
+
+We offer 3 different ways to install Jupyter AI. You can read through each
+section to pick the installation method that works best for you.
+
+1. Quick installation via `pip` (recommended)
+2. Minimal installation via `pip`
+3. Minimal installation via `conda`
+
 ### Quick installation via `pip` (recommended)
 
 If you want to install both the `%%ai` magic and the JupyterLab extension, you can run:
 
     $ pip install jupyter-ai[all]
 
-Then, restart JupyterLab. This will install every dependency, which will give you access to all models currently supported by `jupyter-ai`.
+Then, restart JupyterLab. This will install every optional dependency, which
+provides access to all models currently supported by `jupyter-ai`.
 
-If you are not using JupyterLab and you only want to install the Jupyter AI `%%ai` magic, you can run:
+If you are not using JupyterLab and you only want to install the Jupyter AI
+`%%ai` magic, you can run:
 
     $ pip install jupyter-ai-magics[all]
 
 `jupyter-ai` depends on `jupyter-ai-magics`, so installing `jupyter-ai`
 automatically installs `jupyter-ai-magics`.
 
-If you do not run install with the `[all]` option, you may need to install third-party packages to use some model providers and some file formats with Jupyter AI. For example, to use OpenAI models, in addition to your current install also run
+### Minimal installation via `pip` 
+
+Most model providers in Jupyter AI require a specific dependency to be installed
+before they are available for use. These are called _provider dependencies_.
+Provider dependencies are optional to Jupyter AI, meaning that Jupyter AI can be
+installed with or without any provider dependencies installed. If a provider
+requires a dependency that is not installed, its models are not listed in the
+user interface which allows you to select a language model. 
+
+To perform a minimal installation via `pip` without any provider dependencies,
+omit the `[all]` optional dependency group from the package name:
 
 ```
-pip install langchain-openai
+pip install jupyter-ai
 ```
 
-To use models from Anthropic, install:
-
-```
-pip install langchain-anthropic
-```
-
-After these installs you should see the OpenAI and Anthropic models in the drop down list. If you are using Claude models on AWS Bedrock, you must also install
-
-```
-pip install langchain-aws
-```
-
-Similarly, install `langchain-<provider>` packages for other providers as well. For more information on model providers and which dependencies they require, see [the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
-
-### Minimal installation via `pip` (optional)
-
-Most model providers in Jupyter AI require a specific dependency to be installed before they are available for use. These are called _provider dependencies_. Provider dependencies are optional to Jupyter AI, meaning that Jupyter AI can be installed with or without any provider dependencies installed.
-
-If a provider requires a dependency that is not installed, its models are not listed in the user interface which allows you to select a language model. This offers a way for users to control which models are available in your Jupyter AI environment.
+By selectively installing provider dependencies, you can control which models
+are available in your Jupyter AI environment.
 
 For example, to install Jupyter AI with only added support for Anthropic models, run:
 
@@ -126,42 +144,30 @@ For example, to install Jupyter AI with only added support for Anthropic models,
 pip install jupyter-ai langchain-anthropic
 ```
 
-### Installation via `pip` or `conda` in a Conda environment (recommended)
+For more information on model providers and which dependencies they require, see
+[the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
 
-We highly recommend installing both JupyterLab and Jupyter AI within an isolated
-Conda environment to avoid clobbering Python packages in your existing Python
-environment.
+### Minimal installation via `conda`
 
-First, install
-[conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
-and create an environment that uses Python 3.12:
+As an alternative to using `pip`, you can install `jupyter-ai` using
+[Conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
+from the `conda-forge` channel:
 
-    $ conda create -n jupyter-ai python=3.12
-    $ conda activate jupyter-ai
-
-Then, use `conda` to install JupyterLab and Jupyter AI in this Conda environment.
-
-    $ conda install -c conda-forge jupyter-ai  # or,
     $ conda install conda-forge::jupyter-ai
 
-When starting JupyterLab with Jupyter AI, make sure to activate the Conda
-environment first:
+Most model providers in Jupyter AI require a specific _provider dependency_ to
+be installed before they are available for use. Provider dependencies are
+not installed when installing `jupyter-ai` from Conda Forge, and should be
+installed separately as needed.
 
-```
-conda activate jupyter-ai
-jupyter lab
-```
-
-Most model providers in Jupyter AI require a specific dependency to be installed before they are available for use. These provider dependencies are not installed by default when installing `jupyter-ai` from Conda Forge, and should be installed separately as needed.
-
-For example, to install Jupyter AI with support for OpenAI models, run:
+For example, to install Jupyter AI with only added support for OpenAI models, run:
 
 ```
 conda install conda-forge::jupyter-ai conda-forge::langchain-openai
 ```
 
-For more information on model providers and which dependencies they require, see [the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
-
+For more information on model providers and which dependencies they require, see
+[the model provider table](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers).
 
 ## Uninstallation
 

--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -93,7 +93,7 @@ You may need to install third-party packages, for example, to use some model pro
 pip install langchain-openai
 ```
 
-To use models from Anthropic, install: 
+To use models from Anthropic, install:
 
 ```
 pip install langchain-anthropic


### PR DESCRIPTION
Fixes #1082 

The user documentation and README now explicitly mentions that additional `langchain-<provider>` packages need to be installed as listed here: https://jupyter-ai.readthedocs.io/en/latest/users/index.html#model-providers