### PR TITLE
Continue to allow `$` symbols to delimit inline math in human messages

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -57,11 +57,10 @@ You are talkative and you provide lots of specific details from the foundation m
 You may use Markdown to format your response.
 If your response includes code, they must be enclosed in Markdown fenced code blocks (with triple backticks before and after).
 If your response includes mathematical notation, they must be expressed in LaTeX markup and enclosed in LaTeX delimiters.
-- Human messages may still use `$` symbols to delimit inline math.
-  However, your response should never use `$` symbols to delimit inline math.
-- Valid inline math: `\\( \\infty \\)`
-- Valid display math: `\\[ \\infty \\]`
-- Invalid inline math: `$\\infty$`
+All quantities of USD must be formatted in LaTeX and not plaintext.
+- Example prompt: `If I have \\\\$100 and spend \\\\$20, how much money do I have left?`
+- **Correct** response: `You have \\(\\$80\\) remaining.`
+- **Incorrect** response: `You have $80 remaining.`
 If you do not know the answer to a question, answer truthfully by responding that you do not know.
 The following is a friendly conversation between you and a human.
 """.strip()

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -57,7 +57,8 @@ You are talkative and you provide lots of specific details from the foundation m
 You may use Markdown to format your response.
 If your response includes code, they must be enclosed in Markdown fenced code blocks (with triple backticks before and after).
 If your response includes mathematical notation, they must be expressed in LaTeX markup and enclosed in LaTeX delimiters.
-- Single dollar signs ($) should never be used as delimiters for inline math.
+- Human messages may still use `$` symbols to delimit inline math.
+  However, your response should never use `$` symbols to delimit inline math.
 - Valid inline math: `\\( \\infty \\)`
 - Valid display math: `\\[ \\infty \\]`
 - Invalid inline math: `$\\infty$`

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -57,7 +57,7 @@ You are talkative and you provide lots of specific details from the foundation m
 You may use Markdown to format your response.
 If your response includes code, they must be enclosed in Markdown fenced code blocks (with triple backticks before and after).
 If your response includes mathematical notation, they must be expressed in LaTeX markup and enclosed in LaTeX delimiters.
-All dollar quantities must be formatted in LaTeX and not plaintext.
+All dollar quantities (of USD) must be formatted in LaTeX, with the `$` symbol escaped by a single backslash `\\`.
 - Example prompt: `If I have \\\\$100 and spend \\\\$20, how much money do I have left?`
 - **Correct** response: `You have \\(\\$80\\) remaining.`
 - **Incorrect** response: `You have $80 remaining.`

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -57,7 +57,7 @@ You are talkative and you provide lots of specific details from the foundation m
 You may use Markdown to format your response.
 If your response includes code, they must be enclosed in Markdown fenced code blocks (with triple backticks before and after).
 If your response includes mathematical notation, they must be expressed in LaTeX markup and enclosed in LaTeX delimiters.
-All quantities of USD must be formatted in LaTeX and not plaintext.
+All dollar quantities must be formatted in LaTeX and not plaintext.
 - Example prompt: `If I have \\\\$100 and spend \\\\$20, how much money do I have left?`
 - **Correct** response: `You have \\(\\$80\\) remaining.`
 - **Incorrect** response: `You have $80 remaining.`

--- a/packages/jupyter-ai/src/components/rendermime-markdown.tsx
+++ b/packages/jupyter-ai/src/components/rendermime-markdown.tsx
@@ -51,11 +51,11 @@ function isTextNode(node: Node | null): node is Text {
  * Escapes all `$` symbols present in an HTML element except those within the
  * following elements: `pre`, `code`, `samp`, `kbd`.
  *
- * This prevents `$` symbols from being used as inline math delimiters, allowing
- * `$` symbols to be used literally to denote quantities of USD. This does not
- * escape literal `$` within elements that display their contents literally,
- * like code elements. This overrides JupyterLab's default rendering of MarkDown
- * w/ LaTeX.
+ * This prevents `$` symbols from being used as inline math delimiters in AI
+ * messages, allowing `$` symbols to be used literally to denote quantities of
+ * USD. This does not escape literal `$` within elements that display their
+ * contents literally, like code elements. This overrides JupyterLab's default
+ * rendering of MarkDown w/ LaTeX for AI messages.
  *
  * The Jupyter AI system prompt should explicitly request that the LLM not use
  * `$` as an inline math delimiter. This is the default behavior.
@@ -82,7 +82,7 @@ function escapeDollarSymbols(el: HTMLElement) {
     }
   }
 
-  // Replace each `$` symbol with `\$` for each text node, unless there is
+  // Replaces each `$` symbol with `\$` for each text node, unless there is
   // another `$` symbol adjacent or it is already escaped. Examples:
   // - `$10 - $5` => `\$10 - \$5` (escaped)
   // - `$$ \infty $$` => `$$ \infty $$` (unchanged)
@@ -131,8 +131,14 @@ function RendermimeMarkdownBase(props: RendermimeMarkdownProps): JSX.Element {
         );
       }
 
-      // step 2: render LaTeX via MathJax, while escaping single dollar symbols.
-      escapeDollarSymbols(renderer.node);
+      // step 2: render LaTeX via MathJax, while escaping single dollar symbols
+      // in agent messages.
+      if (
+        props.parentMessage?.type === 'agent' ||
+        props.parentMessage?.type === 'agent-stream'
+      ) {
+        escapeDollarSymbols(renderer.node);
+      }
       props.rmRegistry.latexTypesetter?.typeset(renderer.node);
 
       // insert the rendering into renderingContainer if not yet inserted

--- a/packages/jupyter-ai/src/components/rendermime-markdown.tsx
+++ b/packages/jupyter-ai/src/components/rendermime-markdown.tsx
@@ -39,61 +39,6 @@ function escapeLatexDelimiters(text: string) {
     .replace(/\\\]/g, '\\\\]');
 }
 
-/**
- * Type predicate function that determines whether a given DOM Node is a Text
- * node.
- */
-function isTextNode(node: Node | null): node is Text {
-  return node?.nodeType === Node.TEXT_NODE;
-}
-
-/**
- * Escapes all `$` symbols present in an HTML element except those within the
- * following elements: `pre`, `code`, `samp`, `kbd`.
- *
- * This prevents `$` symbols from being used as inline math delimiters in AI
- * messages, allowing `$` symbols to be used literally to denote quantities of
- * USD. This does not escape literal `$` within elements that display their
- * contents literally, like code elements. This overrides JupyterLab's default
- * rendering of MarkDown w/ LaTeX for AI messages.
- *
- * The Jupyter AI system prompt should explicitly request that the LLM not use
- * `$` as an inline math delimiter. This is the default behavior.
- */
-function escapeDollarSymbols(el: HTMLElement) {
-  // Get all text nodes that are not within pre, code, samp, or kbd elements
-  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
-    acceptNode: node => {
-      const isInSkippedElements = node.parentElement?.closest(
-        'pre, code, samp, kbd'
-      );
-      return isInSkippedElements
-        ? NodeFilter.FILTER_SKIP
-        : NodeFilter.FILTER_ACCEPT;
-    }
-  });
-
-  // Collect all valid text nodes in an array.
-  const textNodes: Text[] = [];
-  let currentNode: Node | null;
-  while ((currentNode = walker.nextNode())) {
-    if (isTextNode(currentNode)) {
-      textNodes.push(currentNode);
-    }
-  }
-
-  // Replaces each `$` symbol with `\$` for each text node, unless there is
-  // another `$` symbol adjacent or it is already escaped. Examples:
-  // - `$10 - $5` => `\$10 - \$5` (escaped)
-  // - `$$ \infty $$` => `$$ \infty $$` (unchanged)
-  // - `\$10` => `\$10` (unchanged, already escaped)
-  textNodes.forEach(node => {
-    if (node.textContent) {
-      node.textContent = node.textContent.replace(/(?<![$\\])\$(?!\$)/g, '\\$');
-    }
-  });
-}
-
 function RendermimeMarkdownBase(props: RendermimeMarkdownProps): JSX.Element {
   // create a single renderer object at component mount
   const [renderer] = useState(() => {
@@ -131,14 +76,7 @@ function RendermimeMarkdownBase(props: RendermimeMarkdownProps): JSX.Element {
         );
       }
 
-      // step 2: render LaTeX via MathJax, while escaping single dollar symbols
-      // in agent messages.
-      if (
-        props.parentMessage?.type === 'agent' ||
-        props.parentMessage?.type === 'agent-stream'
-      ) {
-        escapeDollarSymbols(renderer.node);
-      }
+      // step 2: render LaTeX via MathJax
       props.rmRegistry.latexTypesetter?.typeset(renderer.node);
 
       // insert the rendering into renderingContainer if not yet inserted


### PR DESCRIPTION
## Description

Closes #1089.

Mostly reverts #1068.

This PR reverts the frontend changes in #1068 and just updates the system prompt to encourage the LLM to express quantities of USD in LaTeX instead of plaintext.

- Users can still use `$` to delimit inline math, and must double-escape `$` symbols to use them literally. This is aligned with JupyterLab's rendering behavior.

This may not fix rendering of literal `$` symbols for all LLMs, but makes a best-effort without breaking support for `$` as an inline math delimiter. 

## Demo

https://github.com/user-attachments/assets/24874426-85e2-4235-a01d-8713cc69f88c

