### PR TITLE
Update `faiss-cpu` version range

### DIFF
--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -29,7 +29,9 @@ dependencies = [
     "importlib_metadata>=5.2.0",
     "jupyter_ai_magics>=2.13.0",
     "dask[distributed]",
-    "faiss-cpu<=1.8.0",          # Not distributed by official repo
+    # faiss-cpu is not distributed by the official repo.
+    # v1.8.0.post0 should be excluded as it lacks macOS x86 wheels.
+    "faiss-cpu>=1.8.0,<2.0.0,!=1.8.0.post0",
     "typing_extensions>=4.5.0",
     "traitlets>=5.0",
     "deepmerge>=2.0,<3",


### PR DESCRIPTION
## Description

- Required by https://github.com/jupyterlab/jupyter-ai/issues/1096

This PR updates the version range of `faiss-cpu` to:

1. Include all versions with Python 3.12 support (https://github.com/jupyterlab/jupyter-ai/issues/538)
2. Exclude versions lacking wheels for all supported platforms (https://github.com/jupyterlab/jupyter-ai/issues/858)
3. Allow for newer minor releases of `faiss-cpu~=1.0`, notably `faiss-cpu==1.9.0`.

After this PR is merged and released in a patch version, we can [update the dependency in the Conda Forge recipe](https://github.com/conda-forge/jupyter-ai-feedstock/pull/47) similarly to close #1096.

## Testing instructions

1. Run `jlpm dev-uninstall && jlpm dev-install`.
2. Run `pip install -U faiss-cpu`.
3. Run `pip show faiss-cpu`, then verify that the latest release v1.9.0 is installed.
4. Verify `/learn` and `/ask` still work in Jupyter AI.