### PR TITLE
Fix rendering of code blocks in JupyterLab 4.3.0+

### DIFF
--- a/packages/jupyter-ai/src/components/chat.tsx
+++ b/packages/jupyter-ai/src/components/chat.tsx
@@ -233,6 +233,9 @@ export function Chat(props: ChatProps): JSX.Element {
             <TelemetryContextProvider telemetryHandler={props.telemetryHandler}>
               <UserContextProvider userManager={props.userManager}>
                 <Box
+                  // Add .jp-ThemedContainer for CSS compatibility in both JL <4.3.0 and >=4.3.0.
+                  // See: https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html#css-styling
+                  className="jp-ThemedContainer"
                   // root box should not include padding as it offsets the vertical
                   // scrollbar to the left
                   sx={{

--- a/packages/jupyter-ai/style/rendermime-markdown.css
+++ b/packages/jupyter-ai/style/rendermime-markdown.css
@@ -2,7 +2,7 @@
  *
  * Selectors must be nested in `.jp-ThemedContainer` to have a higher
  * specificity than selectors in rules provided by JupyterLab.
- * 
+ *
  * See: https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html#css-styling
  * See also: https://github.com/jupyterlab/jupyter-ai/issues/1090
  */

--- a/packages/jupyter-ai/style/rendermime-markdown.css
+++ b/packages/jupyter-ai/style/rendermime-markdown.css
@@ -1,3 +1,11 @@
+/* ************************************** */
+
+/*
+ * Styles below are for JupyterLab >=4.0.0,<4.3.0.
+ */
+
+/* ************************************** */
+
 .jp-ai-rendermime-markdown .jp-RenderedHTMLCommon {
   padding-right: 0;
 }
@@ -18,5 +26,42 @@
 }
 
 .jp-ai-rendermime-markdown mjx-container {
+  font-size: 119%;
+}
+
+/* ************************************** */
+
+/*
+ * Styles below are for JupyterLab >=4.3.0.
+ *
+ * Selectors must be nested in `.jp-ThemedContainer` to have a higher
+ * specificity than selectors in rules provided by JupyterLab.
+ * 
+ * See: https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html#css-styling
+ * See also: https://github.com/jupyterlab/jupyter-ai/issues/1090
+ */
+
+/* ************************************** */
+
+.jp-ThemedContainer .jp-ai-rendermime-markdown .jp-RenderedHTMLCommon {
+  padding-right: 0;
+}
+
+.jp-ThemedContainer .jp-ai-rendermime-markdown pre {
+  background-color: var(--jp-cell-editor-background);
+  overflow-x: auto;
+  white-space: pre;
+  margin: 0;
+  padding: 4px 2px 0 6px;
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+}
+
+.jp-ThemedContainer .jp-ai-rendermime-markdown pre > code {
+  background-color: inherit;
+  overflow-x: inherit;
+  white-space: inherit;
+}
+
+.jp-ThemedContainer .jp-ai-rendermime-markdown mjx-container {
   font-size: 119%;
 }

--- a/packages/jupyter-ai/style/rendermime-markdown.css
+++ b/packages/jupyter-ai/style/rendermime-markdown.css
@@ -1,38 +1,4 @@
-/* ************************************** */
-
 /*
- * Styles below are for JupyterLab >=4.0.0,<4.3.0.
- */
-
-/* ************************************** */
-
-.jp-ai-rendermime-markdown .jp-RenderedHTMLCommon {
-  padding-right: 0;
-}
-
-.jp-ai-rendermime-markdown pre {
-  background-color: var(--jp-cell-editor-background);
-  overflow-x: auto;
-  white-space: pre;
-  margin: 0;
-  padding: 4px 2px 0 6px;
-  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
-}
-
-.jp-ai-rendermime-markdown pre > code {
-  background-color: inherit;
-  overflow-x: inherit;
-  white-space: inherit;
-}
-
-.jp-ai-rendermime-markdown mjx-container {
-  font-size: 119%;
-}
-
-/* ************************************** */
-
-/*
- * Styles below are for JupyterLab >=4.3.0.
  *
  * Selectors must be nested in `.jp-ThemedContainer` to have a higher
  * specificity than selectors in rules provided by JupyterLab.
@@ -40,8 +6,6 @@
  * See: https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html#css-styling
  * See also: https://github.com/jupyterlab/jupyter-ai/issues/1090
  */
-
-/* ************************************** */
 
 .jp-ThemedContainer .jp-ai-rendermime-markdown .jp-RenderedHTMLCommon {
   padding-right: 0;


### PR DESCRIPTION
## Description

Fixes #1090. For additional context, please review the thread there.

## Testing instructions

1. First, **on the `main` branch**, upgrade JupyterLab in your environment to v4.3.0 by running `conda update jupyterlab`.
2. Ask Jupyter AI to generate code, and verify you see the bug in #1090.
3. Then, switch to this branch, run `jlpm && jlpm build`.
4. Restart JupyterLab, and verify that the bug is fixed.
5. Downgrade JupyterLab to v4.2.0 by running `conda install jupyterlab==4.2.0`.
6. Restart JupyterLab, and verify that the bug is still fixed. This asserts that the changes don't break rendering for JupyterLab <4.3.0.

## Demo

<img width="672" alt="Screenshot 2024-11-11 at 4 15 29 PM" src="https://github.com/user-attachments/assets/2146ef6c-8f5a-4712-a94a-a398a8d1fdf6">
