### PR TITLE
Catch error on non plaintext files in `@file` and reply gracefully in chat

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/context_providers/file.py
+++ b/packages/jupyter-ai/jupyter_ai/context_providers/file.py
@@ -67,7 +67,7 @@ class FileContextProvider(BaseCommandContextProvider):
         try:
             with open(filepath, "rb") as file:
                 file_header = file.read(4)
-                if file_header == b"\x89PNG":
+                if file_header == b"\x89PNG" or file_header == b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a":
                     return ".png"
                 elif file_header == b"\xff\xd8\xff\xe0":
                     return ".jpg"
@@ -77,6 +77,8 @@ class FileContextProvider(BaseCommandContextProvider):
                     return ".gz"
                 elif file_header == b"\x50\x4b\x03\x04":
                     return ".zip"
+                elif file_header == b"\x75\x73\x74\x61\x72":
+                    return ".tar"
                 elif file_header == b"\x25\x50\x44\x46":
                     return ".pdf"
                 else:
@@ -128,10 +130,16 @@ class FileContextProvider(BaseCommandContextProvider):
             )
         except UnicodeDecodeError:
             file_extension = self.get_file_type(filepath)
-            raise ContextProviderException(
-                f"The `{file_extension}` file format is not supported for passing context to the LLM. "
-                f"The `@file` command only supports plaintext files."
-            )
+            if file_extension:
+                raise ContextProviderException(
+                    f"The `{file_extension}` file format is not supported for passing context to the LLM. "
+                    f"The `@file` command only supports plaintext files."
+                )
+            else:
+                raise ContextProviderException(
+                    f"This file format is not supported for passing context to the LLM. "
+                    f"The `@file` command only supports plaintext files."
+                )
         return FILE_CONTEXT_TEMPLATE.format(
             filepath=filepath,
             content=self._process_file(content, filepath),

--- a/packages/jupyter-ai/jupyter_ai/context_providers/file.py
+++ b/packages/jupyter-ai/jupyter_ai/context_providers/file.py
@@ -93,6 +93,12 @@ class FileContextProvider(BaseCommandContextProvider):
                 f"Permission denied while trying to read '{filepath}' "
                 f"triggered by `{command}`."
             )
+        except UnicodeDecodeError:
+            file_extension = os.path.splitext(filepath)[1]
+            raise ContextProviderException(
+                f"The `{file_extension}` file format is not supported for passing context to the LLM. "
+                f"The `@file` command only supports plaintext files."
+            )
         return FILE_CONTEXT_TEMPLATE.format(
             filepath=filepath,
             content=self._process_file(content, filepath),

--- a/packages/jupyter-ai/jupyter_ai/context_providers/file.py
+++ b/packages/jupyter-ai/jupyter_ai/context_providers/file.py
@@ -50,7 +50,7 @@ class FileContextProvider(BaseCommandContextProvider):
         if is_dir:
             path += "/"
         return path
-    
+
     import os
 
     def get_file_type(self, filepath):
@@ -67,20 +67,20 @@ class FileContextProvider(BaseCommandContextProvider):
 
         # Check if the file is a binary blob
         try:
-            with open(filepath, 'rb') as file:
+            with open(filepath, "rb") as file:
                 file_header = file.read(4)
-                if file_header == b'\x89PNG':
-                    return '.png'
-                elif file_header == b'\xff\xd8\xff\xe0':
-                    return '.jpg'
-                elif file_header == b'GIF87a' or file_header == b'GIF89a':
-                    return '.gif'
-                elif file_header == b'\x1f\x8b\x08':
-                    return '.gz'
-                elif file_header == b'\x50\x4b\x03\x04':
-                    return '.zip'
-                elif file_header == b'\x25\x50\x44\x46':
-                    return '.pdf'
+                if file_header == b"\x89PNG":
+                    return ".png"
+                elif file_header == b"\xff\xd8\xff\xe0":
+                    return ".jpg"
+                elif file_header == b"GIF87a" or file_header == b"GIF89a":
+                    return ".gif"
+                elif file_header == b"\x1f\x8b\x08":
+                    return ".gz"
+                elif file_header == b"\x50\x4b\x03\x04":
+                    return ".zip"
+                elif file_header == b"\x25\x50\x44\x46":
+                    return ".pdf"
                 else:
                     return file_extension
         except:

--- a/packages/jupyter-ai/jupyter_ai/context_providers/file.py
+++ b/packages/jupyter-ai/jupyter_ai/context_providers/file.py
@@ -50,7 +50,7 @@ class FileContextProvider(BaseCommandContextProvider):
         if is_dir:
             path += "/"
         return path
-    
+
     def get_file_type(self, filepath):
         """
         Determine the file type of the given file path.

--- a/packages/jupyter-ai/jupyter_ai/context_providers/file.py
+++ b/packages/jupyter-ai/jupyter_ai/context_providers/file.py
@@ -50,9 +50,7 @@ class FileContextProvider(BaseCommandContextProvider):
         if is_dir:
             path += "/"
         return path
-
-    import os
-
+    
     def get_file_type(self, filepath):
         """
         Determine the file type of the given file path.

--- a/packages/jupyter-ai/jupyter_ai/context_providers/file.py
+++ b/packages/jupyter-ai/jupyter_ai/context_providers/file.py
@@ -67,7 +67,10 @@ class FileContextProvider(BaseCommandContextProvider):
         try:
             with open(filepath, "rb") as file:
                 file_header = file.read(4)
-                if file_header == b"\x89PNG" or file_header == b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a":
+                if (
+                    file_header == b"\x89PNG"
+                    or file_header == b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"
+                ):
                     return ".png"
                 elif file_header == b"\xff\xd8\xff\xe0":
                     return ".jpg"


### PR DESCRIPTION
Fixes #1044 

If the file format (e.g. PDF) cannot be read in plaintext by `file.read()` the error messages appear in chat. This PR emands toe code to make sure the error is trapped and a message is sent to the user in chat explaining that `@file` cannot handle context files that are not plaintext. 
![image](https://github.com/user-attachments/assets/f9d3ea57-d026-47c0-a805-961be8074aff)


Additional work is needed to handle files that can be converted to plaintext and then used in context. Next step: convert PDF files into plaintext to expand the set of file formats in `@file`.