### PR TITLE
Bump LangChain minimum versions

### DIFF
--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -24,8 +24,8 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 dependencies = [
     "ipython",
     "importlib_metadata>=5.2.0",
-    "langchain>=0.1.0,<0.3.0",
-    "langchain_community>=0.1.0,<0.3.0",
+    "langchain>=0.2.17,<0.3.0",
+    "langchain_community>=0.2.19,<0.3.0",
     "typing_extensions>=4.5.0",
     "click~=8.0",
     "jsonpath-ng>=1.5.3,<2",


### PR DESCRIPTION
## Description

- Bumps `langchain` and `langchain-community` version floors to patch `CVE-2024-8309`. 

- See: https://github.com/jupyterlab/jupyter-ai/issues/1108

- Version floor for `langchain` was determined by the minimum version required by `langchain-community==0.2.19`: https://github.com/langchain-ai/langchain/blob/langchain-community%3D%3D0.2.19/libs/community/pyproject.toml#L34