### PR TITLE
Downgrade spurious 'error' logs

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
@@ -36,10 +36,7 @@ def get_lm_providers(
             )
             continue
         except Exception as e:
-            log.error(
-                f"Unable to load model provider `{provider_ep.name}`. Printing full exception below."
-            )
-            log.exception(e)
+            log.warning(f"Unable to load model provider `{provider_ep.name}`", exc_info=e)
             continue
 
         if not is_provider_allowed(provider.id, restrictions):
@@ -66,7 +63,7 @@ def get_em_providers(
         try:
             provider = model_provider_ep.load()
         except Exception as e:
-            log.error(
+            log.warning(
                 f"Unable to load embeddings model provider class from entry point `{model_provider_ep.name}`: %s.",
                 e,
             )

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
@@ -36,7 +36,9 @@ def get_lm_providers(
             )
             continue
         except Exception as e:
-            log.warning(f"Unable to load model provider `{provider_ep.name}`", exc_info=e)
+            log.warning(
+                f"Unable to load model provider `{provider_ep.name}`", exc_info=e
+            )
             continue
 
         if not is_provider_allowed(provider.id, restrictions):


### PR DESCRIPTION
Since it is expected that not all embeddings model providers will be loadable, it is wrong to log the case that one cannot be loaded with level 'error'.

Resolves #839.