### PR TITLE
Removes outdated OpenAI models and adds new ones

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
@@ -37,22 +37,17 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
     name = "OpenAI"
     models = [
         "gpt-3.5-turbo",
-        "gpt-3.5-turbo-0125",
-        "gpt-3.5-turbo-0301",  # Deprecated as of 2024-06-13
-        "gpt-3.5-turbo-0613",  # Deprecated as of 2024-06-13
         "gpt-3.5-turbo-1106",
-        "gpt-3.5-turbo-16k",
-        "gpt-3.5-turbo-16k-0613",  # Deprecated as of 2024-06-13
         "gpt-4",
         "gpt-4-turbo",
         "gpt-4-turbo-preview",
         "gpt-4-0613",
-        "gpt-4-32k",
-        "gpt-4-32k-0613",
         "gpt-4-0125-preview",
         "gpt-4-1106-preview",
         "gpt-4o",
+        "gpt-4o-2024-11-20",
         "gpt-4o-mini",
+        "chatgpt-4o-latest",
     ]
     model_id_key = "model_name"
     pypi_package_deps = ["langchain_openai"]


### PR DESCRIPTION
Fixes #836 

	1.	Removed `gpt-3.5-turbo-0125` as it points to `gpt-3.5-turbo`.
	2.	Removed `gpt-3.5-turbo-0301`,  deprecated as of 2024-06-13
	3.	Removed `gpt-3.5-turbo-0613",  deprecated as of 2024-06-13
	4.	Removed `gpt-3.5-turbo-16k`, not offered any more
	5.	Removed `gpt-3.5-turbo-16k-0613`,  deprecated as of 2024-06-13
	6.	Removed `gpt-4-32k`, no longer offered
	7.	Removed `gpt-4-32k-0613`, no longer offered
	8.	Added `gpt-4o-2024-11-20`, `chatgpt-4o-latest`
	9.	Will add `o1-preview`, `o1-mini` later as this is not widely available as yet

While `gpt-3.5-turbo` is still offered, OpenAI recommends using `gpt-4o` instead: “As of July 2024, gpt-4o-mini should be used in place of gpt-3.5-turbo, as it is cheaper, more capable, multimodal, and just as fast. gpt-3.5-turbo is still available for use in the API.”

There are no changes to the embedding models from OpenAI.