### PR TITLE
Fix install step in CI

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 set -eux
 
 # Install JupyterLab
-# 
+#
 # Excludes v4.3.2 as it pins `httpx` to a very narrow range, causing `pip
 # install` to stall on package resolution.
 #

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 set -eux
-# install core packages
-pip install jupyterlab~=4.0
+
+# Install JupyterLab
+# 
+# Excludes v4.3.2 as it pins `httpx` to a very narrow range, causing `pip
+# install` to stall on package resolution.
+#
+# See: https://github.com/jupyterlab/jupyter-ai/issues/1138
+pip install jupyterlab~=4.0,!=4.3.2
+
+# Install core packages
 cp playground/config.example.py playground/config.py
 jlpm install
 jlpm dev-install


### PR DESCRIPTION
## Description

- Fixes #1138 
- Fixes CI by excluding `jupyterlab==4.3.2` from the version range in `scripts/install.sh`.

I think just excluding `4.3.2` is sufficient. I hope to work with others to get the upstream issue fixed by the next patch release of JupyterLab. 🤞 
