### PR TITLE
Fix code output format in IPython

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -482,13 +482,7 @@ class AiMagics(Magics):
             lang_indicator = r"^```[a-zA-Z0-9]*\n"
             output = re.sub(lang_indicator, "", output)
             output = re.sub(r"\n```$", "", output)
-            new_cell_payload = dict(
-                source="set_next_input",
-                text=output,
-                replace=False,
-            )
-            ip = self.shell
-            ip.payload_manager.write_payload(new_cell_payload)
+            self.shell.set_next_input(output, replace=False)
             return HTML(
                 "AI generated code inserted below &#11015;&#65039;", metadata=md
             )


### PR DESCRIPTION
In an IPython terminal, using `code` format doesn't copy the code to the output cell but this works in a JupyterLab cell. Removing the payload_manager and using the `set_next_input` method directly fixes this behavior in IPython while maintaining the functionality in JupyterLab