### PR TITLE
Revamped Jupyter AI

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/prompts.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/prompts.py
@@ -1,0 +1,124 @@
+CHAT_SYSTEM_PROMPT = """
+You are Jupyternaut, a conversational assistant living in JupyterLab to help users.
+You are an expert in Jupyter Notebook, Data Visualization, Data Science and Data Analysis.
+You always use Markdown to format your response.
+Code blocks must be formatted in Markdown.
+Math should be rendered with inline TeX markup, surrounded by $.
+If you do not know the answer to a question, answer truthfully by responding that you do not know.
+The following is a friendly conversation between you and a human.
+""".strip()
+
+CHAT_DEFAULT_TEMPLATE = """
+<context>
+{% if notebook_code %}
+Below is a Jupyter notebook, in jupytext "percent" format that the Human is working with:
+<notebook-code>
+{{notebook_code}}
+</notebook-code>
+{% endif %}
+{% if active_cell_id %}
+The following cell is selected currently by the user: {{active_cell_id}}
+{% endif %}
+{% if selection and selection.type == 'text' %}
+The following code is selected by the user in the active cell:
+<selected-code>
+{{selection.source}}
+</selected-code>
+{% endif %}
+{% if variable_context %}
+The kernel is currently running with some of the global variables and their values/types listed below:
+{{variable_context}}
+{% endif %}
+</context>
+Unless asked otherwise, answer all questions as concisely and directly as possible.
+That is, you directly output code, when asked, with minimal explanation.
+Avoid writing cell ids or too many comments in the code.
+"""
+
+COMPLETION_SYSTEM_PROMPT = """
+You are a python coding assistant capable of completing code.
+You should only produce code. Avoid comments in the code. Produce clean code.
+The code is written in JupyterLab, a data analysis and code development
+environment which can execute code extended with additional syntax for
+interactive features, such as magics.
+
+Here are some examples of Python code completion:
+
+Example 1:
+Input:
+def calculate_area(radius):
+    return 3.14 * [BLANK]
+
+Output:
+radius ** 2
+
+Example 2:
+Input:
+for i in range(10):
+    if i % 2 == 0:
+        [BLANK]
+
+Output:
+print(i)
+
+Example 3:
+Input:
+try:
+    result = 10 / 0
+except [BLANK]:
+    print("Division by zero!")
+
+Output:
+ZeroDivisionError
+
+Example 4:
+Input:
+import random
+
+numbers = [1, 2, 3, 4, 5]
+random[BLANK]
+
+Output:
+.shuffle(numbers)
+
+Example 5:
+Input:
+def quick_sort(arr):
+    # exp[BLANK]
+
+Output:
+lanation:
+
+Example 6:
+Input:
+import pandas as pd
+import numpy as np
+
+def create_random_dataframe(arr):
+    [BLANK]
+
+Output:
+return pd.DataFrame(arr, columns=["column1", "column2"])
+
+Example 7:
+Input:
+def get_params():
+    return (1, 2)
+
+x, y[BLANK]
+
+print(x + y)
+
+Output:
+ = get_params()
+""".strip()
+
+# only add the suffix bit if present to save input tokens/computation time
+COMPLETION_DEFAULT_TEMPLATE = """
+Now, complete the following Python code being written in {{filename}}:
+
+{{prefix}}[BLANK]{{suffix}}
+
+Fill in the blank to complete the code block.
+Your response should include only the code to replace [BLANK], without surrounding backticks.
+Do not return a linebreak at the beginning of your response."""

--- a/packages/jupyter-ai/jupyter_ai/_variable_describer.py
+++ b/packages/jupyter-ai/jupyter_ai/_variable_describer.py
@@ -1,0 +1,146 @@
+import pandas as pd
+import inspect
+import random
+import types
+from typing import Any, Callable
+import io
+from pydantic.v1 import BaseModel
+
+class VariableDescription(BaseModel):
+    name: str
+    type: str
+    value: str
+    # We cant use schema as it is an attribute of pydantic
+    structure: str | None = None
+
+    def format(self) -> str:
+        res = "<variable>\n"
+        res += f"<name>{self.name}</name>\n"
+        res += f"<type>{self.type}</type>\n"
+        if self.structure:
+            res += f"<schema>{self.structure}</schema>\n"
+        res += f"<value>{self.value}</value>\n"
+        res += "</variable>\n"
+
+        return res
+
+
+def default_handler(name: str, x: Any):
+    fqn = f"{x.__class__.__module__}.{x.__class__.__name__}"
+    return VariableDescription(
+        name=name,
+        type=fqn,
+        value=str(x)
+    )
+
+def dataframe_handler(name: str, x: pd.DataFrame):
+    info_buf = io.StringIO()
+    x.info(buf=info_buf, memory_usage=False, show_counts=False)
+
+    return VariableDescription(
+        name=name,
+        type="pandas.DataFrame",
+        value="Some random rows from the dataframe:\n" + str(x.sample(min(5, len(x)))),
+        structure=info_buf.getvalue()
+    )
+
+def function_handler(name: str, x: Callable):
+    return VariableDescription(
+        name=name,
+        type="function",
+        value=inspect.getsource(x)
+    )
+
+def basic_type_handler(name: str, x: Any):
+    return VariableDescription(
+        name=name,
+        type=type(x).__name__,
+        value=x
+    )
+
+def list_handler(name: str, x: Any):
+    return VariableDescription(
+        name=name,
+        type=type(x).__name__,
+        value=str(random.sample(list(x), 5)),
+        structure=f"Size: {len(x)}"
+    )
+
+def string_handler(name: str, x: Any):
+    val = x if len(x) < 10 else x[:10] + "..."
+    return basic_type_handler(name, val)
+
+
+class DescriberRegistry:
+    """
+    Maintains a registry of handlers for different dtypes for sending context
+    to an LLM in jupyter ai
+
+    This also accespts a _repr_llm_ that should return a dict with mapping of mime type to content.
+    Currently only application/jupyer+ai+var is supported.
+
+    Sample Usage:
+    >>> from jupyter_ai._variable_describer import DescriberRegistry, VariableDescription
+    >>> int_handler = lambda name, value: VariableDescription(name=name, type="int", value=value)
+    >>> DescriberRegistry.register(int, int_handler)
+    """
+    registry: dict[type, Callable[[str, Any], str]] = {}
+
+    @classmethod
+    def _init(cls):
+        cls.register(pd.DataFrame, dataframe_handler)
+        cls.register(types.FunctionType, function_handler)
+        cls.register(int, basic_type_handler)
+        cls.register(float, basic_type_handler)
+        cls.register(str, string_handler)
+        cls.register(list, list_handler)
+        cls.register(tuple, list_handler)
+        cls.register(set, list_handler)
+
+    @classmethod
+    def register(cls, var_type: type, handler: Callable[[str, Any], str]):
+        cls.registry[var_type] = handler
+
+    @classmethod
+    def get(cls, value: Any):
+        return cls.registry.get(type(value), None)
+
+    @classmethod
+    def _get_repr_handler(cls):
+        def _repr_handler(name: str, value: Any):
+            repr_llm = value._repr_llm_(name=name)
+            description = repr_llm.get("application/jupyer+ai+var", None)
+
+            if description is None:
+                return default_handler(name, value)
+
+            return VariableDescription.parse_obj(description)
+        return _repr_handler
+
+
+    @classmethod
+    def describe(cls, name: str, value: Any) -> str:
+        """
+        Returns a description of the variable in an XML format
+        """
+        # Priority to set handlers
+        # followed by repr_llm handlers
+        # followed by default handlers
+        handler = cls.get(value)
+
+        if handler is not None and hasattr(value, "_repr_llm_"):
+            handler = cls._get_repr_handler()
+
+        if handler is None:
+            handler = default_handler
+
+        desc = handler(name, value)
+        if not isinstance(desc, VariableDescription):
+            raise TypeError("Handler must return an instance of VariableDescription")
+
+        return desc.format()
+
+DescriberRegistry._init()
+
+def describe_var(name: str, value: Any) -> str:
+    return DescriberRegistry.describe(name, value)

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -10,7 +10,7 @@ class ClearChatHandler(BaseChatHandler):
     name = "Clear chat messages"
     help = "Clear the chat window"
     routing_type = SlashCommandRoutingType(slash_id="clear")
-
+    show_help: bool = True
     uses_llm = False
 
     def __init__(self, *args, **kwargs):

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
@@ -13,6 +13,7 @@ class ExportChatHandler(BaseChatHandler):
     name = "Export chat history"
     help = "Export chat history to a Markdown file"
     routing_type = SlashCommandRoutingType(slash_id="export")
+    show_help: bool = True
 
     uses_llm = False
 

--- a/packages/jupyter-ai/jupyter_ai/filter_autocomplete_globals.py
+++ b/packages/jupyter-ai/jupyter_ai/filter_autocomplete_globals.py
@@ -1,0 +1,43 @@
+import types
+import inspect
+
+# These globals are provided by ipython
+# and are not needed for autocomplete
+IPYTHON_GLOBALS = [
+    "In",
+    "Out",
+    "get_ipython",
+    "exit",
+    "quit",
+    "open",
+    "Err",
+    "filter_globals"
+]
+
+def _is_defined_in_main(val):
+    """
+    When a variable is defined in main, the source file path
+    is not available for it and the function throws
+
+    TODO: Find if there is a better way to filter out objects
+    that are imported. For example, when we do from datetime import datetime
+    we typically do not want to pollute autocomplete with datetime
+    """
+    try:
+        inspect.getsourcefile(val)
+        return False
+    except:
+        return True
+
+def filter_globals(data: dict):
+    """
+    Utility method to fetch autocompletes that is used by the frontend
+    when user triggers it using @ for variable context insertion
+    """
+    return [
+        key
+        for key, value in data.items()
+        if not key.startswith('_')
+        and key not in IPYTHON_GLOBALS
+        and _is_defined_in_main(value)
+    ]

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -32,11 +32,20 @@ class CellWithErrorSelection(BaseModel):
 
 Selection = Union[TextSelection, CellSelection, CellWithErrorSelection]
 
+class NotebookCell(BaseModel):
+    content: Optional[str]
+    type: Literal["raw", "markdown", "code"]
+
+class Notebook(BaseModel):
+    notebook_code: Optional[list[NotebookCell]]
+    active_cell_id: Optional[str]
+    variable_context: Optional[str]
 
 # the type of message used to chat with the agent
 class ChatRequest(BaseModel):
     prompt: str
     selection: Optional[Selection]
+    notebook: Optional[Notebook | None]
 
 
 class StopRequest(BaseModel):
@@ -139,6 +148,8 @@ class HumanChatMessage(BaseModel):
     prompt: str
     """The prompt typed into the chat input by the user."""
     selection: Optional[Selection]
+    """The current notebook and its cells"""
+    notebook: Optional[Notebook | None]
     """The selection included with the prompt, if any."""
     client: ChatClient
 
@@ -227,6 +238,10 @@ class IndexMetadata(BaseModel):
     dirs: List[IndexedDir]
 
 
+class PromptConfig(BaseModel):
+    system: Optional[str]
+    default: Optional[str]
+
 class DescribeConfigResponse(BaseModel):
     model_provider_id: Optional[str]
     embeddings_provider_id: Optional[str]
@@ -240,7 +255,8 @@ class DescribeConfigResponse(BaseModel):
     last_read: int
     completions_model_provider_id: Optional[str]
     completions_fields: Dict[str, Dict[str, Any]]
-
+    chat_prompt: Optional[PromptConfig]
+    completion_prompt: Optional[PromptConfig]
 
 def forbid_none(cls, v):
     assert v is not None, "size may not be None"
@@ -258,6 +274,8 @@ class UpdateConfigRequest(BaseModel):
     last_read: Optional[int]
     completions_model_provider_id: Optional[str]
     completions_fields: Optional[Dict[str, Dict[str, Any]]]
+    chat_prompt: Optional[PromptConfig]
+    completion_prompt: Optional[PromptConfig]
 
     _validate_send_wse = validator("send_with_shift_enter", allow_reuse=True)(
         forbid_none
@@ -277,6 +295,8 @@ class GlobalConfig(BaseModel):
     api_keys: Dict[str, str]
     completions_model_provider_id: Optional[str]
     completions_fields: Dict[str, Dict[str, Any]]
+    chat_prompt: Optional[PromptConfig]
+    completion_prompt: Optional[PromptConfig]
 
 
 class ListSlashCommandsEntry(BaseModel):

--- a/packages/jupyter-ai/schema/plugin.json
+++ b/packages/jupyter-ai/schema/plugin.json
@@ -7,7 +7,7 @@
   "jupyter.lab.shortcuts": [
     {
       "command": "jupyter-ai:focus-chat-input",
-      "keys": ["Accel Shift 1"],
+      "keys": ["Accel Shift K"],
       "selector": "body",
       "preventDefault": false
     }

--- a/packages/jupyter-ai/src/completions/plugin.ts
+++ b/packages/jupyter-ai/src/completions/plugin.ts
@@ -2,6 +2,7 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
+import { INotebookTracker } from '@jupyterlab/notebook';
 import { ICompletionProviderManager } from '@jupyterlab/completer';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import {
@@ -54,7 +55,8 @@ export const completionPlugin: JupyterFrontEndPlugin<JaiCompletionToken> = {
   requires: [
     ICompletionProviderManager,
     IEditorLanguageRegistry,
-    ISettingRegistry
+    ISettingRegistry,
+    INotebookTracker
   ],
   optional: [IJaiStatusItem],
   provides: IJaiCompletionProvider,
@@ -63,6 +65,7 @@ export const completionPlugin: JupyterFrontEndPlugin<JaiCompletionToken> = {
     completionManager: ICompletionProviderManager,
     languageRegistry: IEditorLanguageRegistry,
     settingRegistry: ISettingRegistry,
+    notebookTracker: INotebookTracker,
     statusItem: IJaiStatusItem | null
   ): Promise<JaiCompletionToken> => {
     if (typeof completionManager.registerInlineProvider === 'undefined') {
@@ -76,7 +79,8 @@ export const completionPlugin: JupyterFrontEndPlugin<JaiCompletionToken> = {
     const completionHandler = new CompletionWebsocketHandler();
     const provider = new JaiInlineProvider({
       completionHandler,
-      languageRegistry
+      languageRegistry,
+      notebookTracker
     });
 
     await completionHandler.initialize();

--- a/packages/jupyter-ai/src/components/chat-input/send-button.tsx
+++ b/packages/jupyter-ai/src/components/chat-input/send-button.tsx
@@ -1,20 +1,15 @@
-import React, { useCallback, useState } from 'react';
-import { Box, Menu, MenuItem, Typography } from '@mui/material';
-import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
+import React from 'react';
+import { Box } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 import StopIcon from '@mui/icons-material/Stop';
 
 import { TooltippedButton } from '../mui-extras/tooltipped-button';
-import { includeSelectionIcon } from '../../icons';
-import { useActiveCellContext } from '../../contexts/active-cell-context';
-import { useSelectionContext } from '../../contexts/selection-context';
-import { AiService } from '../../handler';
 
 const FIX_TOOLTIP = '/fix requires an active code cell with an error';
 
 export type SendButtonProps = {
-  onSend: (selection?: AiService.Selection) => unknown;
   onStop: () => unknown;
+  onSend: () => unknown;
   sendWithShiftEnter: boolean;
   currSlashCommand: string | null;
   inputExists: boolean;
@@ -27,20 +22,6 @@ export type SendButtonProps = {
 };
 
 export function SendButton(props: SendButtonProps): JSX.Element {
-  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [textSelection] = useSelectionContext();
-  const activeCell = useActiveCellContext();
-
-  const openMenu = useCallback((el: HTMLElement | null) => {
-    setMenuAnchorEl(el);
-    setMenuOpen(true);
-  }, []);
-
-  const closeMenu = useCallback(() => {
-    setMenuOpen(false);
-  }, []);
-
   let action: 'send' | 'stop' | 'fix' = props.inputExists
     ? 'send'
     : props.streamingReplyHere
@@ -58,17 +39,6 @@ export function SendButton(props: SendButtonProps): JSX.Element {
     disabled = true;
   }
 
-  const includeSelectionDisabled = !(activeCell.exists || textSelection);
-
-  const includeSelectionTooltip =
-    action === 'fix'
-      ? FIX_TOOLTIP
-      : textSelection
-      ? `${textSelection.text.split('\n').length} lines selected`
-      : activeCell.exists
-      ? 'Code from 1 active cell'
-      : 'No selection or active cell';
-
   const defaultTooltip = props.sendWithShiftEnter
     ? 'Send message (SHIFT+ENTER)'
     : 'Send message (ENTER)';
@@ -82,37 +52,6 @@ export function SendButton(props: SendButtonProps): JSX.Element {
       ? 'Message must not be empty'
       : defaultTooltip;
 
-  function sendWithSelection() {
-    // if the current slash command is `/fix`, `props.onSend()` should always
-    // include the code cell with error output, so the `selection` argument does
-    // not need to be defined.
-    if (action === 'fix') {
-      props.onSend();
-      closeMenu();
-      return;
-    }
-
-    // otherwise, parse the text selection or active cell, with the text
-    // selection taking precedence.
-    if (textSelection?.text) {
-      props.onSend({
-        type: 'text',
-        source: textSelection.text
-      });
-      closeMenu();
-      return;
-    }
-
-    if (activeCell.exists) {
-      props.onSend({
-        type: 'cell',
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        source: activeCell.manager.getContent(false)!.source
-      });
-      closeMenu();
-      return;
-    }
-  }
 
   return (
     <Box sx={{ display: 'flex', flexWrap: 'nowrap' }}>
@@ -132,73 +71,6 @@ export function SendButton(props: SendButtonProps): JSX.Element {
       >
         {action === 'stop' ? <StopIcon /> : <SendIcon />}
       </TooltippedButton>
-      <TooltippedButton
-        onClick={e => {
-          openMenu(e.currentTarget);
-        }}
-        disabled={disabled}
-        tooltip=""
-        buttonProps={{
-          variant: 'contained',
-          onKeyDown: e => {
-            if (e.key !== 'Enter' && e.key !== ' ') {
-              return;
-            }
-            openMenu(e.currentTarget);
-            // stopping propagation of this event prevents the prompt from being
-            // sent when the dropdown button is selected and clicked via 'Enter'.
-            e.stopPropagation();
-          }
-        }}
-        sx={{
-          minWidth: 'unset',
-          padding: '4px 0px',
-          borderRadius: '0px 2px 2px 0px',
-          borderLeft: '1px solid white'
-        }}
-      >
-        <KeyboardArrowDown />
-      </TooltippedButton>
-      <Menu
-        open={menuOpen}
-        onClose={closeMenu}
-        anchorEl={menuAnchorEl}
-        anchorOrigin={{
-          vertical: 'top',
-          horizontal: 'right'
-        }}
-        transformOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right'
-        }}
-        sx={{
-          '& .MuiMenuItem-root': {
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px'
-          },
-          '& svg': {
-            lineHeight: 0
-          }
-        }}
-      >
-        <MenuItem
-          onClick={e => {
-            sendWithSelection();
-            // prevent sending second message with no selection
-            e.stopPropagation();
-          }}
-          disabled={includeSelectionDisabled}
-        >
-          <includeSelectionIcon.react />
-          <Box>
-            <Typography display="block">Send message with selection</Typography>
-            <Typography display="block" sx={{ opacity: 0.618 }}>
-              {includeSelectionTooltip}
-            </Typography>
-          </Box>
-        </MenuItem>
-      </Menu>
     </Box>
   );
 }

--- a/packages/jupyter-ai/src/components/chat-messages/chat-message-menu.tsx
+++ b/packages/jupyter-ai/src/components/chat-messages/chat-message-menu.tsx
@@ -1,11 +1,12 @@
-import React, { useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 
 import { IconButton, Menu, MenuItem, SxProps } from '@mui/material';
 import { MoreVert } from '@mui/icons-material';
 import {
   addAboveIcon,
   addBelowIcon,
-  copyIcon
+  copyIcon,
+  deleteIcon
 } from '@jupyterlab/ui-components';
 
 import { AiService } from '../../handler';
@@ -13,24 +14,17 @@ import { CopyStatus, useCopy } from '../../hooks/use-copy';
 import { useReplace } from '../../hooks/use-replace';
 import { useActiveCellContext } from '../../contexts/active-cell-context';
 import { replaceCellIcon } from '../../icons';
+import { ChatHandler } from '../../chat_handler';
 
-type ChatMessageMenuProps = {
-  message: AiService.ChatMessage;
-
-  /**
-   * Styles applied to the menu icon button.
-   */
-  sx?: SxProps;
+type ChatMessageMenuBaseProps = {
+  menuItems: {
+    onClick: () => void;
+    children?: React.ReactNode;
+  }[];
 };
 
-export function ChatMessageMenu(props: ChatMessageMenuProps): JSX.Element {
+export function ChatMessageMenuBase(props: ChatMessageMenuBaseProps): JSX.Element {
   const menuButtonRef = useRef<HTMLButtonElement | null>(null);
-  const { copy, copyLabel } = useCopy({
-    labelOverrides: { [CopyStatus.None]: 'Copy response' }
-  });
-  const { replace, replaceLabel } = useReplace();
-  const activeCell = useActiveCellContext();
-
   const [menuOpen, setMenuOpen] = useState(false);
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -39,14 +33,6 @@ export function ChatMessageMenu(props: ChatMessageMenuProps): JSX.Element {
     setMenuOpen(true);
   };
 
-  const insertAboveLabel = activeCell.exists
-    ? 'Insert response above active cell'
-    : 'Insert response above active cell (no active cell)';
-
-  const insertBelowLabel = activeCell.exists
-    ? 'Insert response below active cell'
-    : 'Insert response below active cell (no active cell)';
-
   const menuItemSx: SxProps = {
     display: 'flex',
     alignItems: 'center',
@@ -54,9 +40,16 @@ export function ChatMessageMenu(props: ChatMessageMenuProps): JSX.Element {
     lineHeight: 0
   };
 
+  const onClickHandler = (callback: () => void) => {
+    return () => {
+        callback();
+        setMenuOpen(false);
+    }
+  }
+
   return (
     <>
-      <IconButton onClick={openMenu} ref={menuButtonRef} sx={props.sx}>
+      <IconButton onClick={openMenu} ref={menuButtonRef} sx={{ marginRight: -2 }}>
         <MoreVert />
       </IconButton>
       <Menu
@@ -64,31 +57,127 @@ export function ChatMessageMenu(props: ChatMessageMenuProps): JSX.Element {
         onClose={() => setMenuOpen(false)}
         anchorEl={anchorEl}
       >
-        <MenuItem onClick={() => copy(props.message.body)} sx={menuItemSx}>
-          <copyIcon.react />
-          {copyLabel}
-        </MenuItem>
-        <MenuItem onClick={() => replace(props.message.body)} sx={menuItemSx}>
-          <replaceCellIcon.react />
-          {replaceLabel}
-        </MenuItem>
-        <MenuItem
-          onClick={() => activeCell.manager.insertAbove(props.message.body)}
-          disabled={!activeCell.exists}
-          sx={menuItemSx}
-        >
-          <addAboveIcon.react />
-          {insertAboveLabel}
-        </MenuItem>
-        <MenuItem
-          onClick={() => activeCell.manager.insertBelow(props.message.body)}
-          disabled={!activeCell.exists}
-          sx={menuItemSx}
-        >
-          <addBelowIcon.react />
-          {insertBelowLabel}
-        </MenuItem>
+        {
+            props.menuItems.map(menuItemProps => (
+                <MenuItem onClick={onClickHandler(menuItemProps.onClick)} sx={menuItemSx}>
+                    {menuItemProps.children}
+                </MenuItem>
+            ))
+        }
       </Menu>
     </>
   );
+}
+
+
+interface ChatMessageMenuProps {
+    message: AiService.ChatMessage;
+    chatHandler: ChatHandler;
+}
+
+export const AIMessageMenu = (props: ChatMessageMenuProps) => {
+    const { copy, copyLabel } = useCopy({
+        labelOverrides: { [CopyStatus.None]: 'Copy response' }
+      });
+      const { replace, replaceLabel } = useReplace();
+      const activeCell = useActiveCellContext();
+
+  const menuItems: ChatMessageMenuBaseProps["menuItems"] = useMemo(() => {
+    const res = [{
+        onClick: () => copy(props.message.body),
+        children: (
+            <>
+                <copyIcon.react />
+                {copyLabel}
+            </>
+        )
+    }, {
+        onClick: () => replace(props.message.body),
+        children: (
+            <>
+                <replaceCellIcon.react />
+                {replaceLabel}
+            </>
+        )
+    }];
+
+    if (activeCell.exists) {
+        res.push({
+            onClick: () => activeCell.manager.insertAbove(props.message.body),
+            children: (
+                <>
+                    <addAboveIcon.react />
+                    Insert response above active cell
+                </>
+            )
+        })
+
+        res.push({
+            onClick: () => activeCell.manager.insertBelow(props.message.body),
+            children: (
+                <>
+                    <addBelowIcon.react />
+                    Insert response below active cell
+                </>
+            )
+        })
+    }
+
+    return res;
+  }, [activeCell]);
+
+  return (
+    <ChatMessageMenuBase
+        menuItems={menuItems}
+    />
+  )
+}
+
+export const HumanMessageMenu = (props: ChatMessageMenuProps) => {
+    const { copy, copyLabel } = useCopy();
+
+    // We replace back all the content of the form `var` to @var
+    const messageToCopy = props.message.body.replace(/`([^`]*)`/g, '@$1');
+
+  const menuItems: ChatMessageMenuBaseProps["menuItems"] = useMemo(() => {
+    const res = [{
+        onClick: () => copy(messageToCopy),
+        children: (
+            <>
+                <copyIcon.react />
+                {copyLabel}
+            </>
+        )
+    }, {
+        onClick: () => props.chatHandler.sendMessage({
+            type: 'clear',
+            target: props.message.id
+        }),
+        children: (
+            <>
+                <deleteIcon.react />
+                Delete This Exchange
+            </>
+        )
+    }];
+
+
+    return res;
+  }, []);
+
+  return (
+    <ChatMessageMenuBase
+        menuItems={menuItems}
+    />
+  )
+}
+
+export const ChatMessageMenu = (props: ChatMessageMenuProps) => {
+    switch (props.message.type) {
+        case "human":
+            return <HumanMessageMenu {...props} />
+        case "agent":
+        case "agent-stream":
+            return <AIMessageMenu {...props} />
+    }
 }

--- a/packages/jupyter-ai/src/components/rendermime-markdown.tsx
+++ b/packages/jupyter-ai/src/components/rendermime-markdown.tsx
@@ -21,6 +21,11 @@ type RendermimeMarkdownProps = {
    * `AgentStreamMessage`, in which case this should be set to `false`.
    */
   complete: boolean;
+  /**
+   * Hides the code toolbar. We require it in cases when we
+   * are rendering code blocks in prompts
+   */
+  hideCodeToolbar?: boolean;
 };
 
 /**
@@ -63,7 +68,7 @@ function RendermimeMarkdownBase(props: RendermimeMarkdownProps): JSX.Element {
   useEffect(() => {
     const renderContent = async () => {
       // initialize mime model
-      const mdStr = escapeLatexDelimiters(props.markdownStr);
+        const mdStr = escapeLatexDelimiters(props.markdownStr);
       const model = props.rmRegistry.createModel({
         data: { [MD_MIME_TYPE]: mdStr }
       });
@@ -126,7 +131,7 @@ function RendermimeMarkdownBase(props: RendermimeMarkdownProps): JSX.Element {
         // Render a `CodeToolbar` element underneath each code block.
         // We use ReactDOM.createPortal() so each `CodeToolbar` element is able
         // to use the context in the main React tree.
-        codeToolbarDefns.map(codeToolbarDefn => {
+        !props.hideCodeToolbar && codeToolbarDefns.map(codeToolbarDefn => {
           const [codeToolbarRoot, codeToolbarProps] = codeToolbarDefn;
           return createPortal(
             <CodeToolbar {...codeToolbarProps} />,

--- a/packages/jupyter-ai/src/contexts/active-cell-context.tsx
+++ b/packages/jupyter-ai/src/contexts/active-cell-context.tsx
@@ -74,6 +74,11 @@ export class ActiveCellManager {
     return this._activeCellErrorChanged;
   }
 
+  getActiveCellId() {
+    const sharedModel = this._activeCell?.model.sharedModel;
+    return sharedModel?.id;
+  }
+
   /**
    * Returns an `ActiveCellContent` object that describes the current active
    * cell. If no active cell exists, this method returns `null`.

--- a/packages/jupyter-ai/src/contexts/notebook-tracker-context.tsx
+++ b/packages/jupyter-ai/src/contexts/notebook-tracker-context.tsx
@@ -1,0 +1,19 @@
+import { INotebookTracker } from '@jupyterlab/notebook';
+import React, { useContext } from 'react';
+
+/**
+ * NotebookTrackerContext is a React context that holds an INotebookTracker instance or null.
+ * It is used to provide access to the notebook tracker object throughout the React component tree.
+ */
+export const NotebookTrackerContext = React.createContext<INotebookTracker | null>(null);
+
+/**
+ * useNotebookTrackerContext is a custom hook that provides access to the current value of the NotebookTrackerContext.
+ * This hook allows components to easily access the notebook tracker without directly using the context API.
+ *
+ * @returns The current value of the NotebookTrackerContext, which is either an INotebookTracker instance or null.
+ */
+export const useNotebookTrackerContext = () => {
+    const tracker =  useContext(NotebookTrackerContext);
+    return tracker;
+}

--- a/packages/jupyter-ai/src/contexts/utils-context.tsx
+++ b/packages/jupyter-ai/src/contexts/utils-context.tsx
@@ -1,0 +1,20 @@
+import React, { useContext } from 'react';
+
+/**
+ * UtilsContext is a React context that holds an object with an optional goBackToNotebook function.
+ * It is used to provide utility functions throughout the React component tree.
+ */
+export const UtilsContext = React.createContext<{
+    goBackToNotebook?: () => void;
+}>({});
+
+/**
+ * useUtilsContext is a custom hook that provides access to the current value of the UtilsContext.
+ * This hook allows components to easily access the utility functions without directly using the context API.
+ *
+ * @returns The current value of the UtilsContext, which is an object that may contain a goBackToNotebook function.
+ */
+export const useUtilsContext = () => {
+    const utils = useContext(UtilsContext);
+    return utils;
+}

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -78,9 +78,21 @@ export namespace AiService {
     | CellSelection
     | CellWithErrorSelection;
 
+  export type NotebookCell = {
+    content?: string;
+    type: string;
+  }
+
+  export type ChatNotebookContent = {
+    notebook_code?: NotebookCell[];
+    active_cell_id?: number;
+    variable_context?: string;
+  }
+
   export type ChatRequest = {
     prompt: string;
-    selection?: Selection;
+    selection?: Selection | null;
+    notebook?: ChatNotebookContent | null;
   };
 
   export type ClearRequest = {
@@ -201,6 +213,11 @@ export namespace AiService {
     pending_messages: PendingMessage[];
   };
 
+  export type PromptConfig = {
+    system: string;
+    default: string;
+  }
+
   export type DescribeConfigResponse = {
     model_provider_id: string | null;
     embeddings_provider_id: string | null;
@@ -209,6 +226,8 @@ export namespace AiService {
     fields: Record<string, Record<string, any>>;
     last_read: number;
     completions_model_provider_id: string | null;
+    chat_prompt: PromptConfig;
+    completion_prompt: PromptConfig
   };
 
   export type UpdateConfigRequest = {
@@ -220,6 +239,8 @@ export namespace AiService {
     last_read?: number;
     completions_model_provider_id?: string | null;
     completions_fields?: Record<string, Record<string, any>>;
+    chat_prompt?: PromptConfig;
+    completion_prompt?: PromptConfig
   };
 
   export async function getConfig(): Promise<DescribeConfigResponse> {
@@ -299,6 +320,12 @@ export namespace AiService {
     return requestAPI<void>('config', {
       method: 'POST',
       body: JSON.stringify(config)
+    });
+  }
+
+  export async function deleteConfig(): Promise<void> {
+    return requestAPI<void>('config', {
+      method: 'DELETE'
     });
   }
 

--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -3,7 +3,7 @@ import {
   JupyterFrontEndPlugin,
   ILayoutRestorer
 } from '@jupyterlab/application';
-
+import { INotebookTracker } from '@jupyterlab/notebook';
 import {
   IWidgetTracker,
   ReactWidget,
@@ -51,7 +51,8 @@ const plugin: JupyterFrontEndPlugin<IJaiCore> = {
     IThemeManager,
     IJaiCompletionProvider,
     IJaiMessageFooter,
-    IJaiTelemetryHandler
+    IJaiTelemetryHandler,
+    INotebookTracker
   ],
   provides: IJaiCore,
   activate: async (
@@ -62,7 +63,8 @@ const plugin: JupyterFrontEndPlugin<IJaiCore> = {
     themeManager: IThemeManager | null,
     completionProvider: IJaiCompletionProvider | null,
     messageFooter: IJaiMessageFooter | null,
-    telemetryHandler: IJaiTelemetryHandler | null
+    telemetryHandler: IJaiTelemetryHandler | null,
+    notebookTracker: INotebookTracker | null
   ) => {
     /**
      * Initialize selection watcher singleton
@@ -85,6 +87,10 @@ const plugin: JupyterFrontEndPlugin<IJaiCore> = {
       });
     };
 
+    const goBackToNotebook = () => {
+        app.commands.execute('notebook:enter-edit-mode');
+    }
+
     const focusInputSignal = new Signal<unknown, void>({});
 
     let chatWidget: ReactWidget;
@@ -102,7 +108,9 @@ const plugin: JupyterFrontEndPlugin<IJaiCore> = {
         focusInputSignal,
         messageFooter,
         telemetryHandler,
-        app.serviceManager.user
+        app.serviceManager.user,
+        notebookTracker,
+        goBackToNotebook
       );
     } catch (e) {
       chatWidget = buildErrorWidget(themeManager);

--- a/packages/jupyter-ai/src/utils.ts
+++ b/packages/jupyter-ai/src/utils.ts
@@ -1,10 +1,13 @@
 /**
  * Contains various utility functions shared throughout the project.
  */
-import { Notebook } from '@jupyterlab/notebook';
+import { INotebookTracker, Notebook } from '@jupyterlab/notebook';
 import { FileEditor } from '@jupyterlab/fileeditor';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { Widget } from '@lumino/widgets';
+import { IKernelConnection } from '@jupyterlab/services/lib/kernel/kernel';
+import { IIOPubMessage } from '@jupyterlab/services/lib/kernel/messages';
+import { CellModel } from '@jupyterlab/cells';
 
 /**
  * Get text selection from an editor widget (DocumentWidget#content).
@@ -71,3 +74,175 @@ export function getModelLocalId(globalModelId: string): string | null {
   const components = globalModelId.split(':').slice(1);
   return components.join(':');
 }
+
+/**
+ * Executes a given code string in the provided Jupyter Notebook kernel and retrieves the output.
+ *
+ * @param kernel - The kernel connection to execute the code.
+ * @param code - The code string to be executed.
+ * @returns A promise that resolves with the output of the executed code or null if the execution fails.
+ */
+export async function executeCode(kernel: IKernelConnection, code: string): Promise<string | null> {
+    const executeRequest = kernel.requestExecute({ code });
+    let variableValue: string | null = null;
+
+    kernel.registerMessageHook(executeRequest.msg.header.msg_id, (msg: IIOPubMessage) => {
+      if (
+        msg.header.msg_type === 'stream' &&
+        // @ts-expect-error tserror
+        msg.content.name === 'stdout'
+      ) {
+        // @ts-expect-error tserror
+        variableValue = msg.content.text.trim();
+      }
+      return true;
+    });
+
+    const reply = await executeRequest.done;
+    if (reply && reply.content.status === 'ok') {
+      return variableValue;
+    } else {
+      console.error('Failed to retrieve variable value');
+      return null;
+    }
+}
+
+/**
+ * Generates the code to describe a variable using a Jupyter AI utility.
+ *
+ * @param name - The name of the variable to describe.
+ * @returns The generated code as a string.
+ */
+const getCode = (name: string) => `
+from jupyter_ai._variable_describer import describe_var
+print(describe_var('${name}', ${name}))
+`
+
+/**
+ * Retrieves the description of a variable from the current Jupyter Notebook kernel.
+ *
+ * @param variableName - The name of the variable to describe.
+ * @param notebookTracker - The notebook tracker to get the current notebook and kernel.
+ * @returns A promise that resolves with the variable description or null if retrieval fails.
+ */
+export async function getVariableDescription(
+    variableName: string,
+    notebookTracker: INotebookTracker
+): Promise<string | null> {
+    const notebook = notebookTracker.currentWidget;
+    if (notebook && notebook.sessionContext.session?.kernel) {
+        const kernel = notebook.sessionContext.session.kernel;
+        try {
+        return await executeCode(kernel, getCode(variableName));
+        } catch (error) {
+        console.error('Error retrieving variable value:', error);
+        return null;
+        }
+    } else {
+        console.error('No active kernel found');
+        return null;
+    }
+}
+
+/**
+ * Processes variables in the user input by replacing them with their descriptions from the Jupyter Notebook kernel.
+ *
+ * @param userInput - The user input string containing variables to process.
+ * @param notebookTracker - The notebook tracker to get the current notebook and kernel.
+ * @returns A promise that resolves with an object containing the processed input and variable values.
+ */
+export async function processVariables(
+    userInput: string,
+    notebookTracker: INotebookTracker | null
+  ): Promise<{
+    processedInput: string,
+    varValues: string
+  }> {
+    if (!notebookTracker) {
+        return {
+            processedInput: userInput,
+            varValues: ""
+        }
+    }
+
+    const variablePattern = / @([a-zA-Z_][a-zA-Z0-9_]*(\[[^\]]+\]|(\.[a-zA-Z_][a-zA-Z0-9_]*)?)*)[\s,\-]?/g;
+    let match;
+    let variablesProcessed: string[] = [];
+    let varValues = '';
+    let processedInput = userInput;
+
+    while ((match = variablePattern.exec(userInput)) !== null) {
+      const variableName = match[1];
+      if (variablesProcessed.includes(variableName)) {
+        continue;
+      }
+      variablesProcessed.push(variableName);
+      try {
+        const varDescription = await getVariableDescription(variableName, notebookTracker);
+        varValues += `${varDescription}`;
+        processedInput = processedInput.replace(`@${variableName}`, `\`${variableName}\``);
+    } catch (error) {
+        console.error(`Error accessing variable ${variableName}:`, error);
+      }
+    }
+
+    return { processedInput, varValues}
+  }
+
+/**
+ * Code to retrieve the global variables from the Jupyter Notebook kernel.
+ */
+const GLOBALS_CODE = `
+from jupyter_ai.filter_autocomplete_globals import filter_globals
+print(filter_globals(globals()))
+`
+
+/**
+ * Retrieves completion suggestions for a given prefix from the current Jupyter Notebook kernel's global variables.
+ *
+ * @param prefix - The prefix to match global variables against.
+ * @param notebookTracker - The notebook tracker to get the current notebook and kernel.
+ * @returns A promise that resolves with an array of matching global variable names.
+ */
+export async function getCompletion(
+    prefix: string,
+    notebookTracker: INotebookTracker | null
+): Promise<string[]> {
+    const notebook = notebookTracker?.currentWidget;
+    if (notebook?.sessionContext?.session?.kernel) {
+        const kernel = notebook.sessionContext.session.kernel;
+        const globalsString = await executeCode(kernel, GLOBALS_CODE);
+
+        if (!globalsString) return [];
+
+        const globals: string[] = JSON.parse(globalsString.replace(/'/g, '"'));
+        const filteredGlobals = globals.filter(x => x.startsWith(prefix))
+
+
+        return filteredGlobals;
+    }
+
+    return [];
+}
+
+/**
+ * Formats code for a Jupyter Notebook cell, adding appropriate annotations based on cell type.
+ *
+ * @param cell - The cell model containing the code to format.
+ * @param index - Optional index of the cell for annotation.
+ * @returns The formatted code as a string.
+ */
+export const formatCodeForCell = (cell: CellModel["sharedModel"], index?: number) => {
+    const cellNumber = index !== undefined ? `Cell ${index}` : '';
+
+    switch (cell.cell_type) {
+        case "code":
+            return `# %% ${cellNumber}\n${cell.source}`
+        case "markdown":
+        case "raw":
+            const source = cell.source.split("\n").map(line => `# ${line}`).join("\n")
+            return `# %% [markdown] ${cellNumber}\n${source}`
+        default:
+            return ""
+    }
+  }

--- a/packages/jupyter-ai/src/widgets/chat-sidebar.tsx
+++ b/packages/jupyter-ai/src/widgets/chat-sidebar.tsx
@@ -4,7 +4,7 @@ import { ReactWidget } from '@jupyterlab/apputils';
 import type { IThemeManager } from '@jupyterlab/apputils';
 import type { User } from '@jupyterlab/services';
 import type { Awareness } from 'y-protocols/awareness';
-
+import { INotebookTracker } from '@jupyterlab/notebook';
 import { Chat } from '../components/chat';
 import { chatIcon } from '../icons';
 import { SelectionWatcher } from '../selection-watcher';
@@ -29,7 +29,9 @@ export function buildChatSidebar(
   focusInputSignal: ISignal<unknown, void>,
   messageFooter: IJaiMessageFooter | null,
   telemetryHandler: IJaiTelemetryHandler | null,
-  userManager: User.IManager
+  userManager: User.IManager,
+  notebookTracker: INotebookTracker | null,
+  goBackToNotebook: () => void
 ): ReactWidget {
   const ChatWidget = ReactWidget.create(
     <Chat
@@ -45,6 +47,8 @@ export function buildChatSidebar(
       messageFooter={messageFooter}
       telemetryHandler={telemetryHandler}
       userManager={userManager}
+      notebookTracker={notebookTracker}
+      goBackToNotebook={goBackToNotebook}
     />
   );
   ChatWidget.id = 'jupyter-ai::chat';


### PR DESCRIPTION
## Revamped Jupyter AI

Hi team,

We at D.E. Shaw have forked Jupyter AI and made a significant number of changes to greatly enhance the user experience. Our goal was to align Jupyter AI with the capabilities offered by leading AI-based IDEs such as Cursor, Copilot etc. This pull request includes the majority of the changes we implemented.

This proposal is intended to outline these changes and may require some deliberation. We anticipate that this PR will need to be broken down into several smaller PRs, with some design changes to ensure smooth integration. Additionally, we are planning further enhancements, including per notebook chat and inline code generation, details of which are included in this proposal.

The demo showcases the powerful capabilities of Jupyter AI by incorporating notebook context, leveraging the kernel, and enhancing keyboard accessibility (I did not use my mouse at all while creating this).


https://github.com/user-attachments/assets/95fa74f3-316f-4fae-b18d-b37a9166af7e



Point of contact: @govinda18 @mlucool 

### Philosophy

Unlike in JupyterAI, IDEs like [Cursor](https://www.cursor.com/) or [Copilot](https://github.com/features/copilot) have gone towards anything in the IDE is fair to be used. We believe this is the correct user experience for sharing context with the LLM. For Jupyter AI to be effective, it should always provide context automatically, further allowing quick code iterations through insertions and replacements.

We also want to leverage the one major difference that sets notebooks and JupyterLab apart from any other IDE - a runtime kernel. This opens up possibilities where you can include any context of any variable declared in your notebook and further inspect methods and objects to understand their usage. Checkout https://github.com/jupyter/enhancement-proposals/issues/128 for our pre-proposal on streamlining the same.

For autocompletion to be helpful, it needs to be aware of the context in previous cells to provide a Copilot-like experience. For both chat and inline completion, we automatically let it send the entire context of the notebook. We further optimize for context window of the LLM. Checkout the current limitations section for more details.

Lastly, we felt that the chat interface feels a little distant and difficult to access. Most power users of JupyterLab would not use a mouse while working with a notebook, but it's currently not easy to use Jupyter AI without mouse intervention.

Overall, we want to bring the chat and the notebook close enough such that the LLM intelligently understands what the user is talking about without the need to manually decide what context needs to be added. This should further integrate into the natural workflow of the user by providing inline code generation and keyboard accessibility.

### What has changed?

This proposal aims to make Jupyter AI much more powerful and accessible, bringing a host of new features designed to enhance user productivity and streamline their data science workflows. 

#### Major Features
- **Inline Code Completion**: The Jupyter AI inline completer is now context-aware, utilizing code from both preceding and succeeding cells to provide more accurate suggestions.

	Currently, changes are sent from the frontend ([reference](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-bfad2a46ab3f1f84b82e9aab0ae3ed2328fc66a7d17d7171946e1367d7c4f0b4)), but we believe that [jupyter_ydoc](https://github.com/jupyter-server/jupyter_ydoc) should handle this more effectively. We encountered some issues related to [jupyter-collaboration issue #202](https://github.com/jupyterlab/jupyter-collaboration/issues/202) and did not want to wait for it.

- **Notebook Aware Chat**: The chat model is now aware of your active notebook, current cell, and text selection. You can directly ask it to perform actions like "Refactor this code" and it will refactor your notebook or active cell accordingly, saving you valuable time. This was also proposed in https://github.com/jupyterlab/jupyter-ai/issues/1037.

	Again, while currently this is being sent from the frontend, we believe that [jupyter_ydoc](https://github.com/jupyter-server/jupyter_ydoc) should handle this more effectively. Refer [this prompt](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-92ef021e1a29881b1223f1e8ff6cd34e8cf1c1e6ec345c300069c67c44b104feR11) to understand more.

	Further, we have added the ability to [modify prompts](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-13da8c062d7261467d1a223cf6d4978919b46cd66fe281ce916237ef5e9f9f83R514) directly from the Jupyter AI settings, enabling quicker iterations. Users can also view the exact prompt sent to the LLM by using the [View Prompt](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-9eae5a98f936ebb60c18bfcc24130f49b5ec02b2856548f9ef210b597e2b9fa7R178) call-to-action (CTA) in the chat interface.

- ****Keyboard Accessibility****: Navigate Jupyter AI with ease using keyboard shortcuts. Use `Ctrl + Shift + K` to enter chat mode (this is inline with the eventual `Ctrl + K` for inline code generation) and `Escape` to exit([ref](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-a7f1f2fa2da09a2b6b84cbedca17dcb6317d1a383f16bcd3c3ad146f60f7efd9R233)). You can easily add generated code to your notebook by navigating with `Shift + Tab`.

	For enhanced user experience, we have
	- Changed the order of the cell toolbar to be Copy, Replace, Add before, Add after as we anticipate most people would want to add the code after the active cell, so it's just a `Shift Tab` away. ([ref](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-12499da09c61ec827137beb351716e471e579d2871f44f4ad39f3a98c523211bR54))
	- Goes back to the notebook directly after any action which would be the typical next step. ([ref](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-12499da09c61ec827137beb351716e471e579d2871f44f4ad39f3a98c523211bR68))

- **Variable Insertion**: Make the Large Language Model (LLM) aware of your variables effortlessly by inserting them into the chat using the `@` symbol. This helps the model better understands your context and provides more accurate suggestions by asking the kernel for runtime information. We felt this should work directly without using a prefix like @var:var_name as it is one of the most powerful benefits of having a live kernel.

	This functionality is driven by a [variable description registry](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-6487765219e0f1943fe5439d26fc9bca49f78a6ed6a6f9c5a3c66cecf0073a81) that knows how to describe any object to an LLM. Additionally, we are working on drafting a proposal to IPython for a generic `__llm__` method that can be used by any Python class to describe itself to an LLM. More details in https://github.com/jupyter/enhancement-proposals/issues/128.

	This also enhances user experience by providing an autocomplete of the variables declared in the currently active notebook. ([ref](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-e718532c89938cd76d2f1d6faa55361d89277c99fd35755e21ddcc4de75ab8c7))

	The current implementation is also pluggable as documented [here](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-6487765219e0f1943fe5439d26fc9bca49f78a6ed6a6f9c5a3c66cecf0073a81R82).

#### Dropped Features

We suppressed some of the existing features as well. There are different reasons though but we feel each of these features needs to be given a bit more thought before we can allow them generically.

Note that these features still work but are not shown in the autocomplete ([ref](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-c141a2aa703325b0807350e7c8381dc0acecee57cdedc534f1c3da5e8e1287afR65)) or help message ([ref](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-e164ea9ccdd1b4c56ee5e6cdf7d4bc838cccd88f7fdb7f447332a21565d2803fR146)).

- Support for `@file`: We believe that adding an entire file in a context needs to be given a bit more thought. Most users would want to add the current notebook in the context which we now do by default. For adding different types of files, there should be some pre-processing. For example, adding a python file would be siginficiantly different that how a csv should be added. 
- Support for `/learn` and `/ask`: There are some fundamental issues with the current implementation:
	- The embedding generation occurs in the main thread (last we checked, not sure if it has changed now) thereby blocking the kernel. We often found users shooting themselves in the foot while trying to make the LLM learn a big folder.
	- Embedding generation of notebooks would not work great as semantic search on code fails more often than not. A better approach may be to use an LLM based text description of code in case of notebooks. 
	- `/learn` and `/ask` don't scale to a large number of files as accuracy greatly decreases as you add more embeddings. This is just a problem with semantic search in general. Things like hybrid search, reranking and metadata filtering should be researched and added. We found for our internal data that it was too easy to add too much for it to be accurate (adding smaller amount of data was useful but not very practical).
- `/fix` should be replaced with an eventual `Fix with AI` button that we plan to have whenever an error occurs in the notebook. 

#### Enhancements

- Support for resetting the jupyter AI config from the UI ([ref](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-13da8c062d7261467d1a223cf6d4978919b46cd66fe281ce916237ef5e9f9f83R195))
- Support for settings the default completion model from the config ([ref](https://github.com/deshaw/jupyter-ai/pull/1/files))
- Change the delete icon for human message to be a menu similar to AI message for scalability with support to copy the prompt sent by the user ([ref](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-e3231d4a516eb98d61cb603da41d82e434215affe617533a88ed4fe56afb78beR136))
- Updated the default prompts for chat input ([ref](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-92ef021e1a29881b1223f1e8ff6cd34e8cf1c1e6ec345c300069c67c44b104fe))
 

### Current Limitations
- To avoid exceeding the context window when including the entire notebook, we have introduced an abstraction called [`process_notebook_for_context`](https://github.com/deshaw/jupyter-ai/pull/1/files#diff-4acc36e575071d8c6ba60a5930c43b681fb30d4c269e2b12606e043ee656ac6dR301). Individual providers can implement a method like the one below to optimize the context window:

	<details>
	  <summary>View Code</summary>
		<code>

		def process_notebook_for_context(model_id: str, code_cells: list[str], active_cell: int | None) -> str:
	    """
	    Processes the notebook to prepare context-aware code for LLM-based completion.
	    
	    This method respects the token limit for the notebook context by strategically selecting 
	    code from surrounding cells (both prefix and suffix) to ensure the current active cell 
	    has the most relevant context.
	    
	    Steps:
	    1. The current active cell is taken entirely as the initial context.
	    2. Tokens are allocated for suffix cells and added until the token limit is reached.
	    3. Remaining tokens are allocated to prefix cells and added similarly.
	    4. Any remaining tokens are used to extend the suffix further if the prefix is fully utilized.
	    5. Comments are added to indicate the number of cells hidden above and below the context.
	    
	    Parameters:
	    - model_id (str): The identifier for the LLM model being used.
	    - code_cells (list[str]): The list of code cells in the notebook.
	    - active_cell (int | None): The index of the currently active cell in the notebook. 
	                                Defaults to 0 if not provided.
	    
	    Returns:
	    - str: The context-aware code string, including the active cell, prefix, and suffix 
	           code cells, along with comments indicating hidden cells.
	    """
	    active_cell = active_cell or 0
	    code_context = code_cells[active_cell]
	    prefix_idx = active_cell - 1
	    suffix_idx = active_cell + 1

	    total_tokens = get_max_token(model_id) * MAX_NOTEBOOK_TOKENS_PCT

	    model_for_counting = model_id
	    rem_tokens = total_tokens - get_token_count_by_model(
	        code_context, model_for_counting
	    )

	    max_suffix_tokens = int(total_tokens * PREFIX_SUFFIX_RATIO)
	    suffix_code: list[str] = []
	    while suffix_idx < len(code_cells):
	        token_to_be_used = get_token_count_by_model(
	            code_cells[suffix_idx], model_for_counting
	        )
	        if max_suffix_tokens - token_to_be_used < 0:
	            break

	        max_suffix_tokens -= token_to_be_used
	        suffix_code.append(code_cells[suffix_idx])
	        suffix_idx += 1

	    rem_tokens += max_suffix_tokens

	    prefix_code: list[str] = []
	    while prefix_idx > 0:
	        token_to_be_used = get_token_count_by_model(
	            code_cells[prefix_idx], model_for_counting
	        )
	        if rem_tokens - token_to_be_used < 0:
	            break

	        rem_tokens -= token_to_be_used
	        prefix_code.append(code_cells[prefix_idx])
	        prefix_idx -= 1

	    # If any tokens are remaining, add them to the suffix
	    while rem_tokens > 0 and suffix_idx < len(code_cells):
	        token_to_be_used = get_token_count_by_model(
	            code_cells[suffix_idx], model_for_counting
	        )
	        if rem_tokens - token_to_be_used < 0:
	            break

	        rem_tokens -= token_to_be_used
	        suffix_code.append(code_cells[suffix_idx])
	        suffix_idx += 1

	    if prefix_idx != -1:
	        prefix_code.append(
	            f"# Hiding {prefix_idx + 1} more cells above the context provided."
	        )

	    if suffix_idx != len(code_cells):
	        suffix_code.append(
	            f"# Hiding {len(code_cells) - suffix_idx} more cells below the context provided."
	        )

	    return "\n\n".join(prefix_code[::-1] + [code_context] + suffix_code)
	</code>
	</details>
- This PR has only been tested for the models that stream but it should be easy to extend support for those who do not as well.
- Variable Context is limited to basic data types and pandas only. While we default to `__str__` for any object, we further aim to expand support for these.

### Other ideas we are working on 
-   **Inline Code Generation**: Inspired by Cursor, we are developing an inline code generation feature in Jupyter AI. Although still in development, here is a GIF demonstrating our vision for this feature (note that some major UI changes are still pending):
![jai-2](https://github.com/user-attachments/assets/a4fb8542-49e8-421d-a40c-691c6e664604)
   

-   **Per Notebook Chat**: Currently, the chat is shared across notebooks, which creates a poor user experience as chat history becomes irrelevant when switching notebooks. We are working on adding support for maintaining a per-notebook chat to address this issue.
    
-   **Fix with AI Button**: Each error in JupyterLab will have a "Fix with AI" button, which essentially implements an inline version of the `/fix` command, making it easier for users to resolve errors directly within their workflow.