### PR TITLE
Fix specifying empty list in provider and model allow/denylists

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_utils.py
@@ -12,9 +12,10 @@ KNOWN_LM_B = "huggingface_hub"
     "restrictions",
     [
         {"allowed_providers": None, "blocked_providers": None},
-        {"allowed_providers": [], "blocked_providers": []},
-        {"allowed_providers": [], "blocked_providers": [KNOWN_LM_B]},
+        {"allowed_providers": None, "blocked_providers": []},
+        {"allowed_providers": None, "blocked_providers": [KNOWN_LM_B]},
         {"allowed_providers": [KNOWN_LM_A], "blocked_providers": []},
+        {"allowed_providers": [KNOWN_LM_A], "blocked_providers": None},
     ],
 )
 def test_get_lm_providers_not_restricted(restrictions):
@@ -25,8 +26,11 @@ def test_get_lm_providers_not_restricted(restrictions):
 @pytest.mark.parametrize(
     "restrictions",
     [
+        {"allowed_providers": [], "blocked_providers": None},
         {"allowed_providers": [], "blocked_providers": [KNOWN_LM_A]},
+        {"allowed_providers": None, "blocked_providers": [KNOWN_LM_A]},
         {"allowed_providers": [KNOWN_LM_B], "blocked_providers": []},
+        {"allowed_providers": [KNOWN_LM_B], "blocked_providers": None},
     ],
 )
 def test_get_lm_providers_restricted(restrictions):

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
@@ -121,9 +121,9 @@ def get_em_provider(
 def is_provider_allowed(provider_id: str, restrictions: ProviderRestrictions) -> bool:
     allowed = restrictions["allowed_providers"]
     blocked = restrictions["blocked_providers"]
-    if blocked and provider_id in blocked:
+    if blocked is not None and provider_id in blocked:
         return False
-    if allowed and provider_id not in allowed:
+    if allowed is not None and provider_id not in allowed:
         return False
     return True
 

--- a/packages/jupyter-ai/jupyter_ai/config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/config_manager.py
@@ -325,10 +325,10 @@ class ConfigManager(Configurable):
                     "Model provider included in the provider blocklist."
                 )
 
-            if self._allowed_models and model_id not in self._allowed_models:
+            if self._allowed_models is not None and model_id not in self._allowed_models:
                 raise BlockedModelError("Model not included in the model allowlist.")
 
-            if self._blocked_models and model_id in self._blocked_models:
+            if self._blocked_models is not None and model_id in self._blocked_models:
                 raise BlockedModelError("Model included in the model blocklist.")
         except BlockedModelError as e:
             if raise_exc:

--- a/packages/jupyter-ai/jupyter_ai/config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/config_manager.py
@@ -325,7 +325,10 @@ class ConfigManager(Configurable):
                     "Model provider included in the provider blocklist."
                 )
 
-            if self._allowed_models is not None and model_id not in self._allowed_models:
+            if (
+                self._allowed_models is not None
+                and model_id not in self._allowed_models
+            ):
                 raise BlockedModelError("Model not included in the model allowlist.")
 
             if self._blocked_models is not None and model_id in self._blocked_models:


### PR DESCRIPTION
When setting `c.AiExtension.allowed_providers = []`, it acts like the default value `None` and will show all models.

We actually meant to not show any models at all. This is useful for when dynamically selecting models based on user/deployment.