### PR TITLE
Remove remaining shortcut to focus the chat input

### DIFF
--- a/packages/jupyter-ai/schema/plugin.json
+++ b/packages/jupyter-ai/schema/plugin.json
@@ -4,14 +4,6 @@
   "description": "JupyterLab generative artificial intelligence integration.",
   "jupyter.lab.setting-icon": "jupyter-ai::chat",
   "jupyter.lab.setting-icon-label": "Jupyter AI Chat",
-  "jupyter.lab.shortcuts": [
-    {
-      "command": "jupyter-ai:focus-chat-input",
-      "keys": ["Accel Shift 1"],
-      "selector": "body",
-      "preventDefault": false
-    }
-  ],
   "jupyter.lab.menus": {
     "main": [
       {


### PR DESCRIPTION
This PR removes a former shortcut to focus the chat input.
This shortcut was colliding with its equivalent in jupyter-chat.

Fixes partially https://github.com/jupyterlab/jupyter-chat/issues/139.