### PR TITLE
Fix dev install steps in contributor docs

### DIFF
--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -47,6 +47,8 @@ cd <jupyter-ai-top>
 
 # Installs all the dependencies and sets up the dev environment
 ./scripts/install.sh
+jlpm
+jlpm build
 ```
 
 Start and launch JupyterLab in your default browser:


### PR DESCRIPTION
Added CLI : `jlpm` and `jlpm build` after the install command `./scripts/install.sh`