### PR TITLE
Fix Amazon Nova support (use `StrOutputParser`)

### DIFF
--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -492,7 +492,7 @@ def create_llm_chain(
         prompt_template = FIX_PROMPT_TEMPLATE
         self.prompt_template = prompt_template
 
-        runnable = prompt_template | llm  # type:ignore
+        runnable = prompt_template | llm | StrOutputParser()  # type:ignore
         self.llm_chain = runnable
 ```
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -3,8 +3,8 @@ from typing import Dict, Type
 
 from jupyter_ai_magics.providers import BaseProvider
 from jupyterlab_chat.models import Message
-from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain_core.output_parsers import StrOutputParser
+from langchain_core.runnables.history import RunnableWithMessageHistory
 
 from ..context_providers import ContextProviderException, find_commands
 from .base import BaseChatHandler, SlashCommandRoutingType

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -4,6 +4,7 @@ from typing import Dict, Type
 from jupyter_ai_magics.providers import BaseProvider
 from jupyterlab_chat.models import Message
 from langchain_core.runnables.history import RunnableWithMessageHistory
+from langchain_core.output_parsers import StrOutputParser
 
 from ..context_providers import ContextProviderException, find_commands
 from .base import BaseChatHandler, SlashCommandRoutingType
@@ -36,7 +37,7 @@ class DefaultChatHandler(BaseChatHandler):
         self.llm = llm
         self.prompt_template = prompt_template
 
-        runnable = prompt_template | llm  # type:ignore
+        runnable = prompt_template | llm | StrOutputParser()  # type:ignore
         if not llm.manages_history:
             runnable = RunnableWithMessageHistory(
                 runnable=runnable,  #  type:ignore[arg-type]


### PR DESCRIPTION
## Description

- Closes #1198.
- Appends `StrOutputParser` to the runnable defined in `DefaultChatHandler`.
  - The original issue was caused by the runnable yielding `AIMessageChunk` objects with a unique structure that we did not expect. This only happens when Amazon Nova is used through `ChatBedrock`, as far I'm aware.
  - By adding `StrOutputParser` to the runnable, the runnable now yields primitive strings when streamed, which we already handle in `BaseChatHandler.stream_reply()`.

## Demo

https://github.com/user-attachments/assets/4a3703ec-a38a-40f3-8bb5-9a9b61d4062e

## Open questions

(mainly for @3coins)

1. Do you know why this change fixes the original issue?
2. Are you aware of any risk this change introduces?
    - I've verified that these changes do not break support for OpenAI & Anthropic models.