### PR TITLE
Demo: Fix MUI theme in Jupyter AI Settings

### DIFF
--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -55,6 +55,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     let settingsWidget: ReactWidget;
     try {
       settingsWidget = buildAiSettings(
+        themeManager,
         rmRegistry,
         completionProvider,
         openInlineCompleterSettings

--- a/packages/jupyter-ai/src/widgets/settings-widget.tsx
+++ b/packages/jupyter-ai/src/widgets/settings-widget.tsx
@@ -1,23 +1,27 @@
 import React from 'react';
-import { ReactWidget } from '@jupyterlab/apputils';
+import { IThemeManager, ReactWidget } from '@jupyterlab/apputils';
 import { settingsIcon } from '@jupyterlab/ui-components';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 import { IJaiCompletionProvider } from '../tokens';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ChatSettings } from '../components/chat-settings';
+import { JlThemeProvider } from '../components/jl-theme-provider';
 
 export function buildAiSettings(
+  themeManager: IThemeManager | null,
   rmRegistry: IRenderMimeRegistry,
   completionProvider: IJaiCompletionProvider | null,
   openInlineCompleterSettings: () => void
 ): ReactWidget {
   const SettingsWidget = ReactWidget.create(
-    <ChatSettings
-      rmRegistry={rmRegistry}
-      completionProvider={completionProvider}
-      openInlineCompleterSettings={openInlineCompleterSettings}
-      inputOptions={false}
-    />
+    <JlThemeProvider themeManager={themeManager}>
+      <ChatSettings
+        rmRegistry={rmRegistry}
+        completionProvider={completionProvider}
+        openInlineCompleterSettings={openInlineCompleterSettings}
+        inputOptions={false}
+      />
+    </JlThemeProvider>
   );
   SettingsWidget.id = 'jupyter-ai::settings';
   SettingsWidget.title.icon = settingsIcon;


### PR DESCRIPTION
# Description

- A proposed alternative implementation to PR #1210 (thank you @muffanuj for taking the initiative on this!)
- Closes #1175.
- Uses the existing `JlThemeProvider` React context provider to style the JAI settings page. This is a wrapper around Material UI's `ThemeProvider` context provider, which automatically styles all MUI components passed as children. This component was implemented in v2, but its use was dropped by accident during the initial v2 => v3 migration.

# Demo

https://github.com/user-attachments/assets/c52d85d6-d8b3-4d6d-a6c5-215e67b2a296

