### PR TITLE
Fixes duplicate api key being passed in `openrouter.py`

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openrouter.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openrouter.py
@@ -38,7 +38,7 @@ class OpenRouterProvider(BaseProvider, ChatOpenRouter):
         )
 
         super().__init__(
-            openai_api_key=openrouter_api_key,
+            openai_api_key=kwargs.pop("openrouter_api_key"),
             openai_api_base=openrouter_api_base,
             **kwargs,
         )

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openrouter.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openrouter.py
@@ -36,9 +36,9 @@ class OpenRouterProvider(BaseProvider, ChatOpenRouter):
         openrouter_api_base = kwargs.pop(
             "openai_api_base", "https://openrouter.ai/api/v1"
         )
-
+        kwargs.pop("openrouter_api_key", None)
         super().__init__(
-            openai_api_key=kwargs.pop("openrouter_api_key"),
+            openai_api_key=openrouter_api_key,
             openai_api_base=openrouter_api_base,
             **kwargs,
         )


### PR DESCRIPTION
The api key was not being popped and as a result the chat was failing as the key was being passed in duplicate. This small bug fix resolves the problem.

The error is as follows:
```
UserWarning: WARNING! openrouter_api_key is not default parameter.
                openrouter_api_key was transferred to model_kwargs.
                Please confirm that openrouter_api_key is what you intended.
  llm = provider(**unified_parameters)
[E 2025-01-27 08:48:31.323 AiExtension] AsyncCompletions.create() got an unexpected keyword argument 'openrouter_api_key'
```

Tested with the `deepseek-chat` provider and it works well. 
![image](https://github.com/user-attachments/assets/e1a7de50-2861-4342-bcb8-5ddf18a74b81)
