### PR TITLE
Upgrade to `actions/cache@v4`

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,7 +35,7 @@ jobs:
         run: jlpm install
 
       - name: Set up browser cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/pw-browsers


### PR DESCRIPTION
## Description

- Fixes #1227.
- Fixes CI by upgrading to `actions/cache@v4` in CI workflows.