### PR TITLE
Simplify markdown table generation in magic command - %ai list

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/aws.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/aws.py
@@ -124,8 +124,8 @@ class BedrockCustomProvider(BaseProvider, ChatBedrock):
         ),
     ]
     help = (
-        "- For Cross-Region Inference use the appropriate `Inference profile ID` (Model ID with a region prefix, e.g., `us.meta.llama3-2-11b-instruct-v1:0`). See the [inference profiles documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html). \n"
-        "- For custom/provisioned models, specify the model ARN (Amazon Resource Name) as the model ID. For more information, see the [Amazon Bedrock model IDs documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).\n\n"
+        "<ul><li> For Cross-Region Inference use the appropriate `Inference profile ID` (Model ID with a region prefix, e.g., `us.meta.llama3-2-11b-instruct-v1:0`). See the [inference profiles documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html).</li></ul>"
+        "<ul><li> For custom/provisioned models, specify the model ARN (Amazon Resource Name) as the model ID. For more information, see the [Amazon Bedrock model IDs documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).</li></ul>"
         "The model provider must also be specified below. This is the provider of your foundation model *in lowercase*, e.g., `amazon`, `anthropic`, `cohere`, `meta`, or `mistral`."
     )
     registry = True

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "typing_extensions>=4.5.0",
     "click~=8.0",
     "jsonpath-ng>=1.5.3,<2",
+    "py_markdown_table>=1.3.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION

Issue Reference: [Issue-118](https://github.com/jupyterlab/jupyter-ai/issues/118)

**Description**

Refactored the code responsible for generating markdown tables by replacing custom imperative logic with the [py-markdown-table](https://github.com/hvalev/py-markdown-table) library.

**Changes**

- Updated the `_ai_list_command_markdown` method in `magics.py` to generate markdown tables using the [py-markdown-table](https://github.com/hvalev/py-markdown-table) library.
- Modified the `_ai_env_status_for_provider_markdown` method to return the `env_variable` alongside its status in emoji form, replacing the previous approach where the emoji was appended to the `env_variable` string.
- Added the `py-markdown-table` library as a dependency in `pyproject.toml`.
- Updated the help text in the `aws.py` file to address an issue where markdown was not rendering correctly within a markdown table cell. To resolve this, markdown syntax was replaced with HTML tags to ensure proper rendering.

**Testing**

- Verified the changes by running Jupyter Lab in a local environment setup.
- Attached screenshots from the local environment for reference.

<img width="1085" alt="Screenshot 2025-02-19 at 6 43 35 PM" src="https://github.com/user-attachments/assets/54856ad9-7168-4dba-a198-a791a03066bb" />

<img width="1085" alt="Screenshot 2025-02-19 at 6 43 44 PM" src="https://github.com/user-attachments/assets/f30d1f38-e0af-47e3-b3df-989dfac14d68" />

<img width="1085" alt="Screenshot 2025-02-19 at 6 43 55 PM" src="https://github.com/user-attachments/assets/6ec02d6d-0dcf-4edb-a2cd-2dbac96ab63b" />
