### PR TITLE
Fix: Enable up and down arrow keys in chat input

### DIFF
--- a/packages/jupyter-ai/src/components/chat-input.tsx
+++ b/packages/jupyter-ai/src/components/chat-input.tsx
@@ -235,6 +235,11 @@ export function ChatInput(props: ChatInputProps): JSX.Element {
 
   const inputExists = !!input.trim();
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (['ArrowDown', 'ArrowUp'].includes(event.key) && !open) {
+      event.stopPropagation();
+      return;
+    }
+
     if (event.key !== 'Enter') {
       return;
     }


### PR DESCRIPTION
Issue: [Issue-939](https://github.com/jupyterlab/jupyter-ai/issues/939)

- Closes #939

**Problem Statement**
The up and down arrow keys are not working to navigate the AI extension chat input.

**Description** 
The fix has already been implemented in V3. The current changes are for porting the fix to the 2.X branch.

**Expected behavior**
The up and down arrow keys should work for keyboard accessibility.

**Testing**
* Tested in local environment

https://github.com/user-attachments/assets/2f99563c-3bb1-4606-8eb3-bca2bfe7e67c

