### PR TITLE
Refactor Chat Handlers to Simplify Initialization

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/__init__.py
+++ b/packages/jupyter-ai/jupyter_ai/__init__.py
@@ -1,3 +1,8 @@
+# The following import is to make sure jupyter_ydoc is imported before
+# jupyterlab_chat, otherwise it leads to circular import because of the
+# YChat relying on YBaseDoc, and jupyter_ydoc registering YChat from the entry point.
+import jupyter_ydoc
+
 # expose jupyter_ai_magics ipython extension
 # DO NOT REMOVE.
 from jupyter_ai_magics import load_ipython_extension, unload_ipython_extension

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/__init__.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/__init__.py
@@ -1,8 +1,3 @@
-# The following import is to make sure jupyter_ydoc is imported before
-# jupyterlab_chat, otherwise it leads to circular import because of the
-# YChat relying on YBaseDoc, and jupyter_ydoc registering YChat from the entry point.
-import jupyter_ydoc
-
 from .ask import AskChatHandler
 from .base import BaseChatHandler, SlashCommandRoutingType
 from .default import DefaultChatHandler

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -52,7 +52,7 @@ class AskChatHandler(BaseChatHandler):
         )
         self.llm_chain = ConversationalRetrievalChain.from_llm(
             self.llm,
-            self.retriever,
+            self.chat_handlers["/learn"].retriever,
             memory=memory,
             condense_question_prompt=CONDENSE_PROMPT,
             verbose=False,

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -8,7 +8,7 @@ from langchain.memory import ConversationBufferWindowMemory
 from langchain_core.prompts import PromptTemplate
 
 from .base import BaseChatHandler, SlashCommandRoutingType
-from .learn import LearnChatHandler
+from .learn import LearnChatHandler, Retriever
 
 PROMPT_TEMPLATE = """Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question.
 
@@ -17,6 +17,16 @@ Chat History:
 Follow Up Input: {question}
 Standalone question:"""
 CONDENSE_PROMPT = PromptTemplate.from_template(PROMPT_TEMPLATE)
+
+
+class CustomLearnException(Exception):
+    """Exception raised when Jupyter AI's /ask command is used without the required /learn command."""
+
+    def __init__(self):
+        super().__init__(
+            "Jupyter AI's default /ask command requires the default /learn command. "
+            "If you are overriding /learn via the entry points API, be sure to also override or disable /ask."
+        )
 
 
 class AskChatHandler(BaseChatHandler):
@@ -39,6 +49,11 @@ class AskChatHandler(BaseChatHandler):
 
         self.parser.prog = "/ask"
         self.parser.add_argument("query", nargs=argparse.REMAINDER)
+        learn_chat_handler = self.chat_handlers.get("/learn")
+        if not isinstance(learn_chat_handler, LearnChatHandler):
+            raise CustomLearnException()
+
+        self._retriever = Retriever(learn_chat_handler=learn_chat_handler)
 
     def create_llm_chain(
         self, provider: Type[BaseProvider], provider_params: Dict[str, str]
@@ -51,14 +66,10 @@ class AskChatHandler(BaseChatHandler):
         memory = ConversationBufferWindowMemory(
             memory_key="chat_history", return_messages=True, k=2
         )
-        retriever = None
-        learn_handler = self.chat_handlers.get("/learn")
-        if isinstance(learn_handler, LearnChatHandler):
-            retriever = learn_handler.retriever
 
         self.llm_chain = ConversationalRetrievalChain.from_llm(
             self.llm,
-            retriever,
+            self._retriever,
             memory=memory,
             condense_question_prompt=CONDENSE_PROMPT,
             verbose=False,

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -33,10 +33,9 @@ class AskChatHandler(BaseChatHandler):
 
     uses_llm = True
 
-    def __init__(self, retriever, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._retriever = retriever
         self.parser.prog = "/ask"
         self.parser.add_argument("query", nargs=argparse.REMAINDER)
 
@@ -53,7 +52,7 @@ class AskChatHandler(BaseChatHandler):
         )
         self.llm_chain = ConversationalRetrievalChain.from_llm(
             self.llm,
-            self._retriever,
+            self.retriever,
             memory=memory,
             condense_question_prompt=CONDENSE_PROMPT,
             verbose=False,

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -8,6 +8,7 @@ from langchain.memory import ConversationBufferWindowMemory
 from langchain_core.prompts import PromptTemplate
 
 from .base import BaseChatHandler, SlashCommandRoutingType
+from .learn import LearnChatHandler
 
 PROMPT_TEMPLATE = """Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question.
 
@@ -50,9 +51,14 @@ class AskChatHandler(BaseChatHandler):
         memory = ConversationBufferWindowMemory(
             memory_key="chat_history", return_messages=True, k=2
         )
+        retriever = None
+        learn_handler = self.chat_handlers.get("/learn")
+        if isinstance(learn_handler, LearnChatHandler):
+            retriever = learn_handler.retriever
+
         self.llm_chain = ConversationalRetrievalChain.from_llm(
             self.llm,
-            self.chat_handlers["/learn"].retriever,
+            retriever,
             memory=memory,
             condense_question_prompt=CONDENSE_PROMPT,
             verbose=False,

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -145,7 +145,6 @@ class BaseChatHandler:
         message_interrupted: Dict[str, asyncio.Event],
         ychat: YChat,
         log_dir: Optional[str],
-        retriever: BaseRetriever,
     ):
         self.log = log
         self.config_manager = config_manager
@@ -168,7 +167,6 @@ class BaseChatHandler:
         self.message_interrupted = message_interrupted
         self.ychat = ychat
         self.log_dir = Path(log_dir) if log_dir else None
-        self.retriever = retriever
 
         self.llm: Optional[BaseProvider] = None
         self.llm_params: Optional[dict] = None

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -24,6 +24,7 @@ from jupyter_ai.constants import BOT
 from jupyter_ai_magics.providers import BaseProvider
 from jupyterlab_chat.models import Message, NewMessage, User
 from jupyterlab_chat.ychat import YChat
+from langchain.schema import BaseRetriever
 from langchain_core.messages import AIMessageChunk
 from langchain_core.runnables import Runnable
 from langchain_core.runnables.config import RunnableConfig
@@ -144,7 +145,7 @@ class BaseChatHandler:
         message_interrupted: Dict[str, asyncio.Event],
         ychat: YChat,
         log_dir: Optional[str],
-        retriever: Any,
+        retriever: BaseRetriever,
     ):
         self.log = log
         self.config_manager = config_manager

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -13,7 +13,9 @@ from typing import (
     Type,
     Union,
     cast,
+    Any
 )
+from pathlib import Path
 
 from dask.distributed import Client as DaskClient
 from jupyter_ai.callback_handlers import MetadataCallbackHandler
@@ -141,6 +143,8 @@ class BaseChatHandler:
         context_providers: Dict[str, "BaseCommandContextProvider"],
         message_interrupted: Dict[str, asyncio.Event],
         ychat: YChat,
+        log_dir: Optional[str],
+        retriever: Any
     ):
         self.log = log
         self.config_manager = config_manager
@@ -162,6 +166,8 @@ class BaseChatHandler:
         self.context_providers = context_providers
         self.message_interrupted = message_interrupted
         self.ychat = ychat
+        self.log_dir = Path(log_dir) if log_dir else None
+        self.retriever = retriever
 
         self.llm: Optional[BaseProvider] = None
         self.llm_params: Optional[dict] = None

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -3,8 +3,10 @@ import asyncio
 import contextlib
 import os
 import traceback
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     Awaitable,
     ClassVar,
     Dict,
@@ -13,9 +15,7 @@ from typing import (
     Type,
     Union,
     cast,
-    Any
 )
-from pathlib import Path
 
 from dask.distributed import Client as DaskClient
 from jupyter_ai.callback_handlers import MetadataCallbackHandler
@@ -144,7 +144,7 @@ class BaseChatHandler:
         message_interrupted: Dict[str, asyncio.Event],
         ychat: YChat,
         log_dir: Optional[str],
-        retriever: Any
+        retriever: Any,
     ):
         self.log = log
         self.config_manager = config_manager

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
@@ -253,9 +253,8 @@ class GenerateChatHandler(BaseChatHandler):
 
     uses_llm = True
 
-    def __init__(self, log_dir: Optional[str], *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.log_dir = Path(log_dir) if log_dir else None
         self.llm: Optional[BaseProvider] = None
 
     def create_llm_chain(

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -46,6 +46,10 @@ class LearnChatHandler(BaseChatHandler):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        if self.retriever:
+            self.retriever.learn_chat_handler = self
+
         excluded_dirs = ", ".join(EXCLUDE_DIRS)
         self.parser.prog = "/learn"
         self.parser.add_argument(

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -46,8 +46,6 @@ class LearnChatHandler(BaseChatHandler):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self.retriever = Retriever(learn_chat_handler=self)
         excluded_dirs = ", ".join(EXCLUDE_DIRS)
         self.parser.prog = "/learn"
         self.parser.add_argument(

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -47,9 +47,7 @@ class LearnChatHandler(BaseChatHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if self.retriever:
-            self.retriever.learn_chat_handler = self
-
+        self.retriever = Retriever(learn_chat_handler=self)
         excluded_dirs = ", ".join(EXCLUDE_DIRS)
         self.parser.prog = "/learn"
         self.parser.add_argument(

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -8,7 +8,6 @@ from typing import Dict
 import traitlets
 from dask.distributed import Client as DaskClient
 from importlib_metadata import entry_points
-from jupyter_ai.chat_handlers.learn import Retriever
 from jupyter_ai_magics import BaseProvider, JupyternautPersona
 from jupyter_ai_magics.utils import get_em_providers, get_lm_providers
 from jupyter_events import EventLogger
@@ -463,7 +462,6 @@ class AiExtension(ExtensionApp):
         chat_handler_eps = eps.select(group="jupyter_ai.chat_handlers")
         chat_handlers: Dict[str, BaseChatHandler] = {}
         llm_chat_memory = YChatHistory(ychat, k=self.default_max_chat_history)
-        retriever = Retriever()
 
         chat_handler_kwargs = {
             "log": self.log,
@@ -479,7 +477,6 @@ class AiExtension(ExtensionApp):
             "message_interrupted": self.settings["jai_message_interrupted"],
             "ychat": ychat,
             "log_dir": self.error_logs_dir,
-            "retriever": retriever,
         }
 
         default_chat_handler = DefaultChatHandler(**chat_handler_kwargs)

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -479,7 +479,7 @@ class AiExtension(ExtensionApp):
             "message_interrupted": self.settings["jai_message_interrupted"],
             "ychat": ychat,
             "log_dir": self.error_logs_dir,
-            "retriever": retriever
+            "retriever": retriever,
         }
 
         default_chat_handler = DefaultChatHandler(**chat_handler_kwargs)

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -463,6 +463,7 @@ class AiExtension(ExtensionApp):
         chat_handler_eps = eps.select(group="jupyter_ai.chat_handlers")
         chat_handlers: Dict[str, BaseChatHandler] = {}
         llm_chat_memory = YChatHistory(ychat, k=self.default_max_chat_history)
+        retriever = Retriever()
 
         chat_handler_kwargs = {
             "log": self.log,
@@ -477,15 +478,14 @@ class AiExtension(ExtensionApp):
             "context_providers": self.settings["jai_context_providers"],
             "message_interrupted": self.settings["jai_message_interrupted"],
             "ychat": ychat,
+            "log_dir": self.error_logs_dir,
+            "retriever": retriever
         }
+
         default_chat_handler = DefaultChatHandler(**chat_handler_kwargs)
-        generate_chat_handler = GenerateChatHandler(
-            **chat_handler_kwargs,
-            log_dir=self.error_logs_dir,
-        )
+        generate_chat_handler = GenerateChatHandler(**chat_handler_kwargs)
         learn_chat_handler = LearnChatHandler(**chat_handler_kwargs)
-        retriever = Retriever(learn_chat_handler=learn_chat_handler)
-        ask_chat_handler = AskChatHandler(**chat_handler_kwargs, retriever=retriever)
+        ask_chat_handler = AskChatHandler(**chat_handler_kwargs)
 
         chat_handlers["default"] = default_chat_handler
         chat_handlers["/ask"] = ask_chat_handler

--- a/packages/jupyter-ai/jupyter_ai/tests/test_handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_handlers.py
@@ -67,6 +67,8 @@ class TestDefaultChatHandler(DefaultChatHandler):
             message_interrupted={},
             llm_chat_memory=self.ychat_history,
             ychat=self.ychat,
+            log_dir="",
+            retriever=None,
         )
 
     @property

--- a/packages/jupyter-ai/jupyter_ai/tests/test_handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_handlers.py
@@ -68,7 +68,6 @@ class TestDefaultChatHandler(DefaultChatHandler):
             llm_chat_memory=self.ychat_history,
             ychat=self.ychat,
             log_dir="",
-            retriever=None,
         )
 
     @property


### PR DESCRIPTION
## Fixes #1256 

### Description
Refactored `BaseChatHandler` to include `logs_dir` and `retriever` as required arguments, simplifying the initialization of `/ask`, `/generate`, and `/learn` handlers. This removes the need for custom arguments in `AskChatHandler` and `GenerateChatHandler`.

`LearnChatHandler` now automatically binds itself to `self.retriever`, allowing `/ask` to perform RAG without extra logic.

Looking for feedback on any potential edge cases this might introduce!