### PR TITLE
Update `/learn.py` to log missing vector store

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -115,12 +115,16 @@ class LearnChatHandler(BaseChatHandler):
             if not embeddings:
                 return
 
-            self.index = FAISS.load_local(
-                INDEX_SAVE_DIR,
-                embeddings,
-                index_name=self.index_name,
-                allow_dangerous_deserialization=True,
-            )
+            index_path = os.path.join(INDEX_SAVE_DIR, self.index_name + ".faiss")
+            if os.path.exists(index_path):
+                self.index = FAISS.load_local(
+                    INDEX_SAVE_DIR,
+                    embeddings,
+                    index_name=self.index_name,
+                    allow_dangerous_deserialization=True,
+                )
+            else:
+                self.log.info("No existing vector index found. You may create one using `/learn`.")
             self.load_metadata()
         except Exception as e:
             self.log.error(


### PR DESCRIPTION
Closes #1277

In 2.x, if an embedding model is set in AI Settings, but no vector index has been created, an error is logged on startup as shown below:
 
<img width="1312" alt="Screenshot 2025-03-21 at 1 55 07 PM" src="https://github.com/user-attachments/assets/6a287a92-0665-48f1-8b05-5da7a2c3aa95" />

This is resolved with changes to `learn.py` and the new log shows that the error is caught and a notice provided to the user that there is no vector index. Shown here:

<img width="968" alt="Screenshot 2025-03-21 at 1 57 11 PM" src="https://github.com/user-attachments/assets/15224b3f-a2b3-4c22-a90c-8b6fb955063e" />

In v3, while no error is thrown, it is still useful to log the missing vector index: 
![Screenshot 2025-03-24 at 8 06 45 AM](https://github.com/user-attachments/assets/690589ea-e41f-4392-90a8-b6d45e0a7771)

