### PR TITLE
Added help text fields for embedding providers in the AI Setting page

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List
+from typing import ClassVar, List, Optional
 
 from jupyter_ai_magics.providers import (
     AuthStrategy,
@@ -30,6 +30,10 @@ class BaseEmbeddingsProvider(BaseModel):
     models: ClassVar[List[str]] = ...
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
+
+    help: ClassVar[Optional[str]] = None
+    """Text to display in lieu of a model list for a registry provider that does
+    not provide a list of models."""
 
     model_id_key: ClassVar[str] = ...
     """Kwarg expected by the upstream LangChain provider."""

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/ollama.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/ollama.py
@@ -24,6 +24,10 @@ class OllamaEmbeddingsProvider(BaseEmbeddingsProvider, OllamaEmbeddings):
     name = "Ollama"
     # source: https://ollama.com/library
     model_id_key = "model"
+    help = (
+        "See [https://ollama.com/search?c=embedding](https://ollama.com/search?c=embedding) for a list of models. "
+        "Pass an embedding model's name; for example, `mxbai-embed-large`."
+    )
     models = ["*"]
     registry = True
     fields = [

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -115,12 +115,16 @@ class LearnChatHandler(BaseChatHandler):
             if not embeddings:
                 return
 
-            self.index = FAISS.load_local(
-                INDEX_SAVE_DIR,
-                embeddings,
-                index_name=self.index_name,
-                allow_dangerous_deserialization=True,
-            )
+            index_path = os.path.join(INDEX_SAVE_DIR, self.index_name + ".faiss")
+            if os.path.exists(index_path):
+                self.index = FAISS.load_local(
+                    INDEX_SAVE_DIR,
+                    embeddings,
+                    index_name=self.index_name,
+                    allow_dangerous_deserialization=True,
+                )
+            else:
+                self.log.info("No existing vector index found. You may create one using `/learn`.")
             self.load_metadata()
         except Exception as e:
             self.log.error(

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -140,6 +140,7 @@ class EmbeddingsModelProviderHandler(ProviderHandler):
                     id=provider.id,
                     name=provider.name,
                     models=provider.models,
+                    help=provider.help,
                     auth_strategy=provider.auth_strategy,
                     registry=provider.registry,
                     fields=provider.fields,


### PR DESCRIPTION
When using embeddings models from a provider where the registry is being used and a model ID has to be entered, enable the presentation of a text field so that the user can be directed to a web page to look up available models and /or offer guidance on usage, base URL information, etc. This is shown here: 
![Screenshot 2025-03-24 at 1 13 32 PM](https://github.com/user-attachments/assets/4820bc8a-9336-4c33-a5e4-0fd251d2801d)
