### PR TITLE
Migrate old config schemas, fix v2.31.0 regression

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
@@ -508,3 +508,42 @@ def test_config_manager_does_not_write_to_defaults(
     )
 
     assert defaults == expected_defaults
+
+
+def test_config_manager_updates_schema(jp_data_dir, common_cm_kwargs):
+    """
+    Asserts that the ConfigManager adds new keys to the user's config schema
+    which are present in Jupyter AI's schema on init. Asserts that #1291 does
+    not occur again in the future.
+    """
+    schema_path = str(jp_data_dir / "config_schema.json")
+    with open(schema_path, "w") as file:
+        json.dump(
+            {
+                "title": "CUSTOM SCHEMA TITLE",
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$comment": "Default values are sourced from `config_manager.py`.",
+                "type": "object",
+                "properties": {
+                    "custom_field": {
+                        "$comment": "Custom field added by some developer.",
+                        "type": ["string", "null"],
+                        "default": None,
+                        "readOnly": False,
+                    },
+                    # missing all other properties in config_schema.json
+                },
+            },
+            file,
+        )
+
+    cm_kwargs = {**common_cm_kwargs, "schema_path": schema_path}
+
+    cm = ConfigManager(**cm_kwargs)
+    with open(schema_path) as f:
+        new_schema = json.loads(f.read())
+        assert "custom_field" in new_schema["properties"]
+        assert "model_provider_id" in new_schema["properties"]
+        assert "fields" in new_schema["properties"]
+        assert "embeddings_fields" in new_schema["properties"]
+        assert "completions_fields" in new_schema["properties"]


### PR DESCRIPTION
## Description

- Fixes #1291 by migrating old config schemas automatically.
- Adds a unit test that catches the original issue to ensure this doesn't happen again for future 2.x releases.
- We are planning to release this as part of v2.31.1 ASAP.

## Context

#1291 describes an issue where a user cannot use Jupyter AI after upgrading to v2.31.0. I determined that this was caused by #1264 adding the new `'embeddings_fields'` key to the config schema.

Config schemas are used to validate the config, and we copy our config schema to `jupyter_data_dir()/jupyter_ai/config_schema.json` on init. Previously however, we only did so if there was not a file at that path, since we did not want to override a user's custom config schema. Therefore, the schema file did not get updated when a user upgraded Jupyter AI. This causes the issue described in #1291.

This PR fixes the original issue by merging the existing config schema into our default config schema on init. This ensures that the user's config schema will always have new keys added in future releases.

This sounds needlessly complex because it is. We allowed users to have a custom config schema in case they wanted to add new keys to the Jupyter AI config, but we never provided any developer documentation on how to do so. We should probably remove this when we simplify the config in v3.

## Review instructions

1. Clone this branch.
2. Switch to the first commit which adds the failing test. Run `pytest` and verify that the test fails.
3. Switch back to the head of this branch, and re-run `pytest`. Verify that the test now passes.
4. Open `~/Library/Jupyter/jupyter_ai/config_schema.json` and remove the `"embeddings_fields"` key if present.
5. Start JupyterLab, and verify that the key now exists in `config_schema.json` after the Jupyter AI server extension finishes initializing.