### PR TITLE
Updating embeddings config fields from prespecified custom config file

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -350,22 +350,13 @@ class AiExtension(ExtensionApp):
         self.settings["model_parameters"] = self.model_parameters
         self.log.info(f"Configured model parameters: {self.model_parameters}")
 
-        # Collect embeddings model parameters and fields
-        if self.default_embeddings_model:
-            self.em_parameters = {
-                self.default_embeddings_model: self.model_parameters[
-                    self.default_embeddings_model
-                ]
-            }
-        else:
-            self.em_parameters = {}
-
         defaults = {
             "model_provider_id": self.default_language_model,
             "embeddings_provider_id": self.default_embeddings_model,
             "api_keys": self.default_api_keys,
             "fields": self.model_parameters,
-            "embeddings_fields": self.em_parameters,
+            "embeddings_fields": self.model_parameters,
+            "completions_fields": self.model_parameters,
         }
 
         # Fetch LM & EM providers

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -347,15 +347,21 @@ class AiExtension(ExtensionApp):
         self.log.info(f"Configured provider blocklist: {self.blocked_providers}")
         self.log.info(f"Configured model allowlist: {self.allowed_models}")
         self.log.info(f"Configured model blocklist: {self.blocked_models}")
-
         self.settings["model_parameters"] = self.model_parameters
         self.log.info(f"Configured model parameters: {self.model_parameters}")
+
+        # Collect embeddings model parameters and fields
+        if self.default_embeddings_model:
+            self.em_parameters = {self.default_embeddings_model: self.model_parameters[self.default_embeddings_model]}
+        else:
+            self.em_parameters = {}
 
         defaults = {
             "model_provider_id": self.default_language_model,
             "embeddings_provider_id": self.default_embeddings_model,
             "api_keys": self.default_api_keys,
             "fields": self.model_parameters,
+            "embeddings_fields": self.em_parameters,
         }
 
         # Fetch LM & EM providers

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -352,7 +352,11 @@ class AiExtension(ExtensionApp):
 
         # Collect embeddings model parameters and fields
         if self.default_embeddings_model:
-            self.em_parameters = {self.default_embeddings_model: self.model_parameters[self.default_embeddings_model]}
+            self.em_parameters = {
+                self.default_embeddings_model: self.model_parameters[
+                    self.default_embeddings_model
+                ]
+            }
         else:
             self.em_parameters = {}
 


### PR DESCRIPTION
## Description

Fixes #1296 

Users can specify a pre-specified configuration file titled `jupyter_jupyter_ai_config.json` in any of the paths shown when running `jupyter --paths` (see the documentation [here](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#configuration)). A sample of this file is shown in Issue #1296.

As of now, the `config.json` file is written based on this pre-specified configuration file. However, the base url attribute within the `embeddings_fields` attribute is not being written. This PR corrects this problem. 

## For reviewers

To test this: 
1. Create a new file titled `jupyter_jupyter_ai_config.json` in the path `~/.jupyter/` (or any other path seen from running `jupyter --paths`). Edit in the content of the file in the Issue #1296 "Reproduce" section. 
2. Delete the `config.json` file at path `~/Library/Jupyter/jupyter-ai/`
3. Start `jupyter lab` from the CLI
4. Look at the `config.json` file to make sure it is also correctly showing the `embeddings_fields` with the required content from the pre-specified config file. 
5. Open the AI setting pane to see all the fields are populated with the content from the file `jupyter_jupyter_ai_config.json`
6. Try the `/learn` and `/ask` commands to ensure that the embeddings functionality is not impacted. 

