### PR TITLE
Add `default_completions_model` trait

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -1087,6 +1087,11 @@ Specify default embedding model
 jupyter lab --AiExtension.default_embeddings_model=bedrock:amazon.titan-embed-text-v1
 ```
 
+Specify default completions model
+```bash
+jupyter lab --AiExtension.default_completions_model=bedrock-chat:anthropic.claude-v2
+```
+
 Specify default API keys
 ```bash
 jupyter lab --AiExtension.default_api_keys={'OPENAI_API_KEY': 'sk-abcd'}

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -175,7 +175,7 @@ class AiExtension(ExtensionApp):
         default_value=None,
         allow_none=True,
         help="""
-        Default embeddings model to use, as string in the format
+        Default completions model to use, as string in the format
         <provider-id>:<model-id>, defaults to None.
         """,
         config=True,

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -171,6 +171,16 @@ class AiExtension(ExtensionApp):
         config=True,
     )
 
+    default_completions_model = Unicode(
+        default_value=None,
+        allow_none=True,
+        help="""
+        Default embeddings model to use, as string in the format
+        <provider-id>:<model-id>, defaults to None.
+        """,
+        config=True,
+    )
+
     default_api_keys = traitlets.Dict(
         key_trait=Unicode(),
         value_trait=Unicode(),
@@ -353,6 +363,7 @@ class AiExtension(ExtensionApp):
         defaults = {
             "model_provider_id": self.default_language_model,
             "embeddings_provider_id": self.default_embeddings_model,
+            "completions_model_provider_id": self.default_completions_model,
             "api_keys": self.default_api_keys,
             "fields": self.model_parameters,
             "embeddings_fields": self.model_parameters,


### PR DESCRIPTION
## Description

- Addresses comment in #1296.
- Fixes #781 (11 upvotes!).
- Follow-up to #1298.

Users can specify a pre-specified configuration file titled jupyter_jupyter_ai_config.json in any of the paths shown when running jupyter --paths (see the documentation [here](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#configuration)). A sample of this file is shown below:
```
{
  "AiExtension": {
    "default_language_model": "openrouter:microsoft/phi-4",
    "default_embeddings_model": "openai-custom:BAAI/bge-m3",
    "default_completions_model": "ollama:llama3.2",
    "default_api_keys": {
      "OPENROUTER_API_KEY": "sk-XXXX",
      "OPENAI_API_KEY": "sk-YYYY"
    },
    "model_parameters": {
      "openrouter:microsoft/phi-4": {
        "openai_api_base": "https://chat.example.com"
      },
      "openai-custom:BAAI/bge-m3": {
        "openai_api_base": "https://chat.example.com"
      },
      "ollama:llama3.2": {
        "base_url": "http://localhost:11434"
      }
    }
  }
}
```

Issue: Currently, the `default_completions_model` is not being updated in `config.json` as this is not handled. This PR enables completions models config in a manner consistent with that done for language models and embedding models. 

## For reviewers

To test this:

1. Create a new file titled jupyter_jupyter_ai_config.json in the path ~/.jupyter/ (or any other path seen from running jupyter --paths). Edit in the content of the file above. 
2. Delete the config.json file at path ~/Library/Jupyter/jupyter-ai/
3. Start jupyter lab from the CLI
4. Look at the config.json file to make sure it is also correctly showing the `completions_model_provider_id` and the `completions_fields` with the required content from the pre-specified config file.
5. Open the AI setting pane to see all the fields are automatically populated with the content from the file `jupyter_jupyter_ai_config.json`
