### PR TITLE
Backport PR #1303 on branch 2.x (Add `default_completions_model` trait)

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -1087,6 +1087,11 @@ Specify default embedding model
 jupyter lab --AiExtension.default_embeddings_model=bedrock:amazon.titan-embed-text-v1
 ```
 
+Specify default completions model
+```bash
+jupyter lab --AiExtension.default_completions_model=bedrock-chat:anthropic.claude-v2
+```
+
 Specify default API keys
 ```bash
 jupyter lab --AiExtension.default_api_keys={'OPENAI_API_KEY': 'sk-abcd'}

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -115,12 +115,16 @@ class LearnChatHandler(BaseChatHandler):
             if not embeddings:
                 return
 
-            self.index = FAISS.load_local(
-                INDEX_SAVE_DIR,
-                embeddings,
-                index_name=self.index_name,
-                allow_dangerous_deserialization=True,
-            )
+            index_path = os.path.join(INDEX_SAVE_DIR, self.index_name + ".faiss")
+            if os.path.exists(index_path):
+                self.index = FAISS.load_local(
+                    INDEX_SAVE_DIR,
+                    embeddings,
+                    index_name=self.index_name,
+                    allow_dangerous_deserialization=True,
+                )
+            else:
+                self.log.info("No existing vector index found. You may create one using `/learn`.")
             self.load_metadata()
         except Exception as e:
             self.log.error(

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -3,7 +3,6 @@ import re
 import time
 import types
 
-import traitlets
 from dask.distributed import Client as DaskClient
 from importlib_metadata import entry_points
 from jupyter_ai_magics import BaseProvider, JupyternautPersona
@@ -162,7 +161,7 @@ class AiExtension(ExtensionApp):
         config=True,
     )
 
-    default_api_keys = traitlets.Dict(
+    default_api_keys = Dict(
         key_trait=Unicode(),
         value_trait=Unicode(),
         default_value=None,

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -2,8 +2,8 @@ import os
 import re
 import time
 import types
-import traitlets
 
+import traitlets
 from dask.distributed import Client as DaskClient
 from importlib_metadata import entry_points
 from jupyter_ai_magics import BaseProvider, JupyternautPersona

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import types
+import traitlets
 
 from dask.distributed import Client as DaskClient
 from importlib_metadata import entry_points
@@ -151,7 +152,17 @@ class AiExtension(ExtensionApp):
         config=True,
     )
 
-    default_api_keys = Dict(
+    default_completions_model = Unicode(
+        default_value=None,
+        allow_none=True,
+        help="""
+        Default completions model to use, as string in the format
+        <provider-id>:<model-id>, defaults to None.
+        """,
+        config=True,
+    )
+
+    default_api_keys = traitlets.Dict(
         key_trait=Unicode(),
         value_trait=Unicode(),
         default_value=None,
@@ -215,6 +226,7 @@ class AiExtension(ExtensionApp):
         defaults = {
             "model_provider_id": self.default_language_model,
             "embeddings_provider_id": self.default_embeddings_model,
+            "completions_model_provider_id": self.default_completions_model,
             "api_keys": self.default_api_keys,
             "fields": self.model_parameters,
         }


### PR DESCRIPTION
Refers to PR #1303 

Users can specify a pre-specified configuration file titled jupyter_jupyter_ai_config.json in any of the paths shown when running jupyter --paths (see the documentation [here](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#configuration)). 

Fixes merge conflicts in PR 1303. 
