### PR TITLE
Added new `gpt-4.1` models

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
@@ -51,6 +51,10 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
         "gpt-4.1",
         "gpt-4.1-mini",
         "gpt-4.1-nano",
+        "o1",
+        "o3-mini",
+        "o4-mini",
+
     ]
     model_id_key = "model_name"
     pypi_package_deps = ["langchain_openai"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
@@ -54,7 +54,6 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
         "o1",
         "o3-mini",
         "o4-mini",
-
     ]
     model_id_key = "model_name"
     pypi_package_deps = ["langchain_openai"]

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openai.py
@@ -48,6 +48,9 @@ class ChatOpenAIProvider(BaseProvider, ChatOpenAI):
         "gpt-4o-2024-11-20",
         "gpt-4o-mini",
         "chatgpt-4o-latest",
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano",
     ]
     model_id_key = "model_name"
     pypi_package_deps = ["langchain_openai"]


### PR DESCRIPTION
Three new models from OpenAI, updated `openai.py` accordingly:
- gpt-4.1
- gpt-4.1-mini
- gpt-4.1-nano
- o1
- o3-mini
- o4-mini

All these models have been tested and work in chat and magics as intended. 


