### PR TITLE
Enforce modern Python code using `pre-commit`, `pyupgrade --py39-plus`, and GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,10 @@ jobs:
         run: jlpm
       - name: Lint TypeScript source
         run: jlpm lerna run lint:check
+  pre-commit:
+    name: Run pre-commit on all files
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
       - id: check-builtin-literals
       - id: trailing-whitespace
 
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.3.1
+    hooks:
+      - id: autoflake
+
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:
@@ -33,7 +38,7 @@ repos:
     rev: v3.19.1
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py39-plus]
 
   - repo: https://github.com/pycqa/flake8
     rev: 7.1.1

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/completion_utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/completion_utils.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from .models.completion import InlineCompletionRequest
 
 
@@ -9,7 +7,7 @@ def token_from_request(request: InlineCompletionRequest, suggestion: int):
     return f"t{request.number}s{suggestion}"
 
 
-def template_inputs_from_request(request: InlineCompletionRequest) -> Dict:
+def template_inputs_from_request(request: InlineCompletionRequest) -> dict:
     suffix = request.suffix.strip()
     filename = request.path.split("/")[-1] if request.path else "untitled"
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/embedding_providers.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List, Optional
+from typing import ClassVar, Optional
 
 from jupyter_ai_magics.providers import (
     AuthStrategy,
@@ -27,7 +27,7 @@ class BaseEmbeddingsProvider(BaseModel):
     name: ClassVar[str] = ...
     """User-facing name of this provider."""
 
-    models: ClassVar[List[str]] = ...
+    models: ClassVar[list[str]] = ...
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 
@@ -38,7 +38,7 @@ class BaseEmbeddingsProvider(BaseModel):
     model_id_key: ClassVar[str] = ...
     """Kwarg expected by the upstream LangChain provider."""
 
-    pypi_package_deps: ClassVar[List[str]] = []
+    pypi_package_deps: ClassVar[list[str]] = []
     """List of PyPi package dependencies."""
 
     auth_strategy: ClassVar[AuthStrategy] = None
@@ -50,7 +50,7 @@ class BaseEmbeddingsProvider(BaseModel):
     registry: ClassVar[bool] = False
     """Whether this provider is a registry provider."""
 
-    fields: ClassVar[List[Field]] = []
+    fields: ClassVar[list[Field]] = []
     """Fields expected by this provider in its constructor. Each `Field` `f`
     should be passed as a keyword argument, keyed by `f.key`."""
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/exception.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/exception.py
@@ -1,5 +1,3 @@
-import traceback
-
 from IPython.core.magic import register_line_magic
 from IPython.core.ultratb import ListTB
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/models/completion.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/models/completion.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel
 
@@ -50,7 +50,7 @@ class CompletionError(BaseModel):
 class InlineCompletionList(BaseModel):
     """Reflection of JupyterLab's `IInlineCompletionList`."""
 
-    items: List[InlineCompletionItem]
+    items: list[InlineCompletionItem]
 
 
 class InlineCompletionReply(BaseModel):

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/aws.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/aws.py
@@ -1,6 +1,7 @@
 import copy
 import json
-from typing import Any, Coroutine, Dict
+from collections.abc import Coroutine
+from typing import Any
 
 from jsonpath_ng import parse
 from langchain_aws import BedrockEmbeddings, BedrockLLM, ChatBedrock, SagemakerEndpoint
@@ -155,7 +156,7 @@ class JsonContentHandler(LLMContentHandler):
         self.response_path = response_path
         self.response_parser = parse(response_path)
 
-    def replace_values(self, old_val, new_val, d: Dict[str, Any]):
+    def replace_values(self, old_val, new_val, d: dict[str, Any]):
         """Replaces values of a dictionary recursively."""
         for key, val in d.items():
             if val == old_val:
@@ -165,7 +166,7 @@ class JsonContentHandler(LLMContentHandler):
 
         return d
 
-    def transform_input(self, prompt: str, model_kwargs: Dict) -> bytes:
+    def transform_input(self, prompt: str, model_kwargs: dict) -> bytes:
         request_obj = copy.deepcopy(self.request_schema)
         self.replace_values("<prompt>", prompt, request_obj)
         request = json.dumps(request_obj).encode("utf-8")

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openrouter.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/partner_providers/openrouter.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from jupyter_ai_magics import BaseProvider
 from jupyter_ai_magics.providers import EnvAuthStrategy, TextField
 from langchain_core.utils import get_from_dict_or_env
@@ -8,7 +6,7 @@ from langchain_openai import ChatOpenAI
 
 class ChatOpenRouter(ChatOpenAI):
     @property
-    def lc_secrets(self) -> Dict[str, str]:
+    def lc_secrets(self) -> dict[str, str]:
         return {"openai_api_key": "OPENROUTER_API_KEY"}
 
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -3,15 +3,12 @@ import base64
 import functools
 import io
 import json
+from collections.abc import AsyncIterator, Coroutine
 from concurrent.futures import ThreadPoolExecutor
 from types import MappingProxyType
 from typing import (
     Any,
-    AsyncIterator,
     ClassVar,
-    Coroutine,
-    Dict,
-    List,
     Literal,
     Optional,
     Union,
@@ -127,7 +124,7 @@ class MultiEnvAuthStrategy(BaseModel):
     """Require multiple auth tokens via multiple environment variables."""
 
     type: Literal["multienv"] = "multienv"
-    names: List[str]
+    names: list[str]
 
 
 class AwsAuthStrategy(BaseModel):
@@ -183,7 +180,7 @@ class BaseProvider(BaseModel):
     name: ClassVar[str] = ...
     """User-facing name of this provider."""
 
-    models: ClassVar[List[str]] = ...
+    models: ClassVar[list[str]] = ...
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 
@@ -207,7 +204,7 @@ class BaseProvider(BaseModel):
     If unset, the label shown in the UI defaults to "Model ID".
     """
 
-    pypi_package_deps: ClassVar[List[str]] = []
+    pypi_package_deps: ClassVar[list[str]] = []
     """List of PyPi package dependencies."""
 
     auth_strategy: ClassVar[AuthStrategy] = None
@@ -217,7 +214,7 @@ class BaseProvider(BaseModel):
     registry: ClassVar[bool] = False
     """Whether this provider is a registry provider."""
 
-    fields: ClassVar[List[Field]] = []
+    fields: ClassVar[list[Field]] = []
     """User inputs expected by this provider when initializing it. Each `Field` `f`
     should be passed in the constructor as a keyword argument, keyed by `f.key`."""
 
@@ -266,7 +263,7 @@ class BaseProvider(BaseModel):
     # instance attrs
     #
     model_id: str
-    prompt_templates: Dict[str, PromptTemplate]
+    prompt_templates: dict[str, PromptTemplate]
     """Prompt templates for each output type. Can be overridden with
     `update_prompt_template`. The function `prompt_template`, in the base class,
     refers to this."""
@@ -599,7 +596,7 @@ class HfHubProvider(BaseProvider, HuggingFaceEndpoint):
 
     # Handle text and image outputs
     def _call(
-        self, prompt: str, stop: Optional[List[str]] = None, **kwargs: Any
+        self, prompt: str, stop: Optional[list[str]] = None, **kwargs: Any
     ) -> str:
         """Call out to Hugging Face Hub's inference endpoint.
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_magics.py
@@ -119,5 +119,5 @@ def test_reset(ip):
     ip.extension_manager.load_extension("jupyter_ai_magics")
     ai_magics = ip.magics_manager.registry["AiMagics"]
     ai_magics.transcript = [AI1, H1, AI2, H2, AI3]
-    result = ip.run_line_magic("ai", "reset")
+    ip.run_line_magic("ai", "reset")
     assert ai_magics.transcript == []

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Literal, Optional, Tuple, Type, Union
+from typing import Literal, Optional, Union
 
 from importlib_metadata import entry_points
 from jupyter_ai_magics.aliases import MODEL_ID_ALIASES
@@ -7,12 +7,12 @@ from jupyter_ai_magics.embedding_providers import BaseEmbeddingsProvider
 from jupyter_ai_magics.providers import BaseProvider
 
 Logger = Union[logging.Logger, logging.LoggerAdapter]
-LmProvidersDict = Dict[str, BaseProvider]
-EmProvidersDict = Dict[str, BaseEmbeddingsProvider]
+LmProvidersDict = dict[str, BaseProvider]
+EmProvidersDict = dict[str, BaseEmbeddingsProvider]
 AnyProvider = Union[BaseProvider, BaseEmbeddingsProvider]
-ProviderDict = Dict[str, AnyProvider]
-ProviderRestrictions = Dict[
-    Literal["allowed_providers", "blocked_providers"], Optional[List[str]]
+ProviderDict = dict[str, AnyProvider]
+ProviderRestrictions = dict[
+    Literal["allowed_providers", "blocked_providers"], Optional[list[str]]
 ]
 
 
@@ -80,8 +80,8 @@ def get_em_providers(
 
 
 def decompose_model_id(
-    model_id: str, providers: Dict[str, BaseProvider]
-) -> Tuple[str, str]:
+    model_id: str, providers: dict[str, BaseProvider]
+) -> tuple[str, str]:
     """Breaks down a model ID into a two-tuple (provider_id, local_model_id). Returns (None, None) if indeterminate."""
     if model_id in MODEL_ID_ALIASES:
         model_id = MODEL_ID_ALIASES[model_id]
@@ -104,7 +104,7 @@ def decompose_model_id(
 
 def get_lm_provider(
     model_id: str, lm_providers: LmProvidersDict
-) -> Tuple[str, Type[BaseProvider]]:
+) -> tuple[str, type[BaseProvider]]:
     """Gets a two-tuple (<local-model-id>, <provider-class>) specified by a
     global model ID."""
     return _get_provider(model_id, lm_providers)
@@ -112,7 +112,7 @@ def get_lm_provider(
 
 def get_em_provider(
     model_id: str, em_providers: EmProvidersDict
-) -> Tuple[str, Type[BaseEmbeddingsProvider]]:
+) -> tuple[str, type[BaseEmbeddingsProvider]]:
     """Gets a two-tuple (<local-model-id>, <provider-class>) specified by a
     global model ID."""
     return _get_provider(model_id, em_providers)

--- a/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.root_dir_name}}/{{cookiecutter.python_name}}/llm.py
+++ b/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.root_dir_name}}/{{cookiecutter.python_name}}/llm.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
@@ -14,7 +14,7 @@ class TestLLM(LLM):
     def _call(
         self,
         prompt: str,
-        stop: Optional[List[str]] = None,
+        stop: Optional[list[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:

--- a/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.root_dir_name}}/{{cookiecutter.python_name}}/provider.py
+++ b/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.root_dir_name}}/{{cookiecutter.python_name}}/provider.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List
+from typing import ClassVar
 
 from jupyter_ai import AuthStrategy, BaseProvider, Field
 
@@ -41,7 +41,7 @@ class TestProvider(BaseProvider, TestLLM):
     name: ClassVar[str] = "Test Provider"
     """User-facing name of this provider."""
 
-    models: ClassVar[List[str]] = ["test-model-1"]
+    models: ClassVar[list[str]] = ["test-model-1"]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 
@@ -55,7 +55,7 @@ class TestProvider(BaseProvider, TestLLM):
     model_id_label: ClassVar[str] = "Model ID"
     """Human-readable label of the model ID."""
 
-    pypi_package_deps: ClassVar[List[str]] = []
+    pypi_package_deps: ClassVar[list[str]] = []
     """List of PyPi package dependencies."""
 
     auth_strategy: ClassVar[AuthStrategy] = None
@@ -65,6 +65,6 @@ class TestProvider(BaseProvider, TestLLM):
     registry: ClassVar[bool] = False
     """Whether this provider is a registry provider."""
 
-    fields: ClassVar[List[Field]] = []
+    fields: ClassVar[list[Field]] = []
     """User inputs expected by this provider when initializing it. Each `Field` `f`
     should be passed in the constructor as a keyword argument, keyed by `f.key`."""

--- a/packages/jupyter-ai-test/jupyter_ai_test/test_llms.py
+++ b/packages/jupyter-ai-test/jupyter_ai_test/test_llms.py
@@ -1,5 +1,6 @@
 import time
-from typing import Any, Iterator, List, Optional
+from collections.abc import Iterator
+from typing import Any, Optional
 
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
@@ -16,7 +17,7 @@ class TestLLM(LLM):
     def _call(
         self,
         prompt: str,
-        stop: Optional[List[str]] = None,
+        stop: Optional[list[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:
@@ -34,7 +35,7 @@ class TestLLMWithStreaming(LLM):
     def _call(
         self,
         prompt: str,
-        stop: Optional[List[str]] = None,
+        stop: Optional[list[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:
@@ -44,7 +45,7 @@ class TestLLMWithStreaming(LLM):
     def _stream(
         self,
         prompt: str,
-        stop: Optional[List[str]] = None,
+        stop: Optional[list[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> Iterator[GenerationChunk]:

--- a/packages/jupyter-ai-test/jupyter_ai_test/test_providers.py
+++ b/packages/jupyter-ai-test/jupyter_ai_test/test_providers.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List
+from typing import ClassVar
 
 from jupyter_ai import AuthStrategy, BaseProvider, Field
 
@@ -12,7 +12,7 @@ class TestProvider(BaseProvider, TestLLM):
     name: ClassVar[str] = "Test Provider"
     """User-facing name of this provider."""
 
-    models: ClassVar[List[str]] = ["test"]
+    models: ClassVar[list[str]] = ["test"]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 
@@ -26,7 +26,7 @@ class TestProvider(BaseProvider, TestLLM):
     model_id_label: ClassVar[str] = "Model ID"
     """Human-readable label of the model ID."""
 
-    pypi_package_deps: ClassVar[List[str]] = []
+    pypi_package_deps: ClassVar[list[str]] = []
     """List of PyPi package dependencies."""
 
     auth_strategy: ClassVar[AuthStrategy] = None
@@ -36,7 +36,7 @@ class TestProvider(BaseProvider, TestLLM):
     registry: ClassVar[bool] = False
     """Whether this provider is a registry provider."""
 
-    fields: ClassVar[List[Field]] = []
+    fields: ClassVar[list[Field]] = []
     """User inputs expected by this provider when initializing it. Each `Field` `f`
     should be passed in the constructor as a keyword argument, keyed by `f.key`."""
 
@@ -48,7 +48,7 @@ class TestProviderWithStreaming(BaseProvider, TestLLMWithStreaming):
     name: ClassVar[str] = "Test Provider (streaming)"
     """User-facing name of this provider."""
 
-    models: ClassVar[List[str]] = ["test"]
+    models: ClassVar[list[str]] = ["test"]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 
@@ -62,7 +62,7 @@ class TestProviderWithStreaming(BaseProvider, TestLLMWithStreaming):
     model_id_label: ClassVar[str] = "Model ID"
     """Human-readable label of the model ID."""
 
-    pypi_package_deps: ClassVar[List[str]] = []
+    pypi_package_deps: ClassVar[list[str]] = []
     """List of PyPi package dependencies."""
 
     auth_strategy: ClassVar[AuthStrategy] = None
@@ -72,7 +72,7 @@ class TestProviderWithStreaming(BaseProvider, TestLLMWithStreaming):
     registry: ClassVar[bool] = False
     """Whether this provider is a registry provider."""
 
-    fields: ClassVar[List[Field]] = []
+    fields: ClassVar[list[Field]] = []
     """User inputs expected by this provider when initializing it. Each `Field` `f`
     should be passed in the constructor as a keyword argument, keyed by `f.key`."""
 
@@ -84,7 +84,7 @@ class TestProviderAskLearnUnsupported(BaseProvider, TestLLMWithStreaming):
     name: ClassVar[str] = "Test Provider (/learn and /ask unsupported)"
     """User-facing name of this provider."""
 
-    models: ClassVar[List[str]] = ["test"]
+    models: ClassVar[list[str]] = ["test"]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 
@@ -98,7 +98,7 @@ class TestProviderAskLearnUnsupported(BaseProvider, TestLLMWithStreaming):
     model_id_label: ClassVar[str] = "Model ID"
     """Human-readable label of the model ID."""
 
-    pypi_package_deps: ClassVar[List[str]] = []
+    pypi_package_deps: ClassVar[list[str]] = []
     """List of PyPi package dependencies."""
 
     auth_strategy: ClassVar[AuthStrategy] = None
@@ -108,7 +108,7 @@ class TestProviderAskLearnUnsupported(BaseProvider, TestLLMWithStreaming):
     registry: ClassVar[bool] = False
     """Whether this provider is a registry provider."""
 
-    fields: ClassVar[List[Field]] = []
+    fields: ClassVar[list[Field]] = []
     """User inputs expected by this provider when initializing it. Each `Field` `f`
     should be passed in the constructor as a keyword argument, keyed by `f.key`."""
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Dict, Type
 
 from jupyter_ai_magics.providers import BaseProvider
 from jupyterlab_chat.models import Message
@@ -65,7 +64,7 @@ class AskChatHandler(BaseChatHandler):
         return self._retriever  # Return cached instance
 
     def create_llm_chain(
-        self, provider: Type[BaseProvider], provider_params: Dict[str, str]
+        self, provider: type[BaseProvider], provider_params: dict[str, str]
     ):
         unified_parameters = {
             **provider_params,

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -3,16 +3,13 @@ import asyncio
 import contextlib
 import os
 import traceback
+from collections.abc import Awaitable
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
-    Any,
-    Awaitable,
     ClassVar,
-    Dict,
     Literal,
     Optional,
-    Type,
     Union,
     cast,
 )
@@ -117,16 +114,16 @@ class BaseChatHandler:
     """Format string template that is used to build the help message. Specified
     from traitlets configuration."""
 
-    chat_handlers: Dict[str, "BaseChatHandler"]
+    chat_handlers: dict[str, "BaseChatHandler"]
     """Dictionary of chat handlers. Allows one chat handler to reference other
     chat handlers, which is necessary for some use-cases like printing the help
     message."""
 
-    context_providers: Dict[str, "BaseCommandContextProvider"]
+    context_providers: dict[str, "BaseCommandContextProvider"]
     """Dictionary of context providers. Allows chat handlers to reference
     context providers, which can be used to provide context to the LLM."""
 
-    message_interrupted: Dict[str, asyncio.Event]
+    message_interrupted: dict[str, asyncio.Event]
     """Dictionary mapping an agent message identifier to an asyncio Event
     which indicates if the message generation/streaming was interrupted."""
 
@@ -134,15 +131,15 @@ class BaseChatHandler:
         self,
         log: Logger,
         config_manager: ConfigManager,
-        model_parameters: Dict[str, Dict],
+        model_parameters: dict[str, dict],
         llm_chat_memory: "BaseChatMessageHistory",
         root_dir: str,
         preferred_dir: Optional[str],
         dask_client_future: Awaitable[DaskClient],
         help_message_template: str,
-        chat_handlers: Dict[str, "BaseChatHandler"],
-        context_providers: Dict[str, "BaseCommandContextProvider"],
-        message_interrupted: Dict[str, asyncio.Event],
+        chat_handlers: dict[str, "BaseChatHandler"],
+        context_providers: dict[str, "BaseCommandContextProvider"],
+        message_interrupted: dict[str, asyncio.Event],
         ychat: YChat,
         log_dir: Optional[str],
     ):
@@ -318,14 +315,14 @@ class BaseChatHandler:
         return self.llm_chain
 
     def get_model_parameters(
-        self, provider: Type[BaseProvider], provider_params: Dict[str, str]
+        self, provider: type[BaseProvider], provider_params: dict[str, str]
     ):
         return self.model_parameters.get(
             f"{provider.id}:{provider_params['model_id']}", {}
         )
 
     def create_llm_chain(
-        self, provider: Type[BaseProvider], provider_params: Dict[str, str]
+        self, provider: type[BaseProvider], provider_params: dict[str, str]
     ):
         raise NotImplementedError("Should be implemented by subclasses")
 
@@ -441,7 +438,6 @@ class BaseChatHandler:
         assert self.llm_chain
         assert isinstance(self.llm_chain, Runnable)
 
-        received_first_chunk = False
         metadata_handler = MetadataCallbackHandler()
         base_config: RunnableConfig = {
             "callbacks": [metadata_handler],

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -1,5 +1,4 @@
 import asyncio
-from typing import Dict, Type
 
 from jupyter_ai_magics.providers import BaseProvider
 from jupyterlab_chat.models import Message
@@ -24,7 +23,7 @@ class DefaultChatHandler(BaseChatHandler):
         self.prompt_template = None
 
     def create_llm_chain(
-        self, provider: Type[BaseProvider], provider_params: Dict[str, str]
+        self, provider: type[BaseProvider], provider_params: dict[str, str]
     ):
         unified_parameters = {
             "verbose": True,

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
@@ -4,7 +4,7 @@ import os
 import time
 import traceback
 from pathlib import Path
-from typing import Dict, List, Optional, Type
+from typing import Optional
 
 import nbformat
 from jupyter_ai.chat_handlers import BaseChatHandler, SlashCommandRoutingType
@@ -25,7 +25,7 @@ class OutlineSection(BaseModel):
 
 class Outline(BaseModel):
     description: Optional[str] = None
-    sections: List[OutlineSection]
+    sections: list[OutlineSection]
 
 
 class NotebookOutlineChain(LLMChain):
@@ -258,7 +258,7 @@ class GenerateChatHandler(BaseChatHandler):
         self.llm: Optional[BaseProvider] = None
 
     def create_llm_chain(
-        self, provider: Type[BaseProvider], provider_params: Dict[str, str]
+        self, provider: type[BaseProvider], provider_params: dict[str, str]
     ):
         unified_parameters = {
             **provider_params,

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -1,8 +1,9 @@
 import argparse
 import json
 import os
+from collections.abc import Coroutine
 from glob import iglob
-from typing import Any, Coroutine, List, Optional, Tuple
+from typing import Any, Optional
 
 from dask.distributed import Client as DaskClient
 from jupyter_ai.document_loaders.directory import (
@@ -350,8 +351,8 @@ class LearnChatHandler(BaseChatHandler):
 
     def create(
         self,
-        embedding_records: List[Tuple[str, List[float]]],
-        metadatas: Optional[List[dict]] = None,
+        embedding_records: list[tuple[str, list[float]]],
+        metadatas: Optional[list[dict]] = None,
     ):
         embeddings = self.get_embedding_model()
         if not embeddings:
@@ -381,7 +382,7 @@ class LearnChatHandler(BaseChatHandler):
 
     async def aget_relevant_documents(
         self, query: str
-    ) -> Coroutine[Any, Any, List[Document]]:
+    ) -> Coroutine[Any, Any, list[Document]]:
         if not self.index:
             return []  # type:ignore[return-value]
 
@@ -405,11 +406,11 @@ class Retriever(BaseRetriever):
 
     def _get_relevant_documents(  # type:ignore[override]
         self, query: str
-    ) -> List[Document]:
+    ) -> list[Document]:
         raise NotImplementedError()
 
     async def _aget_relevant_documents(  # type:ignore[override]
         self, query: str
-    ) -> Coroutine[Any, Any, List[Document]]:
+    ) -> Coroutine[Any, Any, list[Document]]:
         docs = await self.learn_chat_handler.aget_relevant_documents(query)
         return docs

--- a/packages/jupyter-ai/jupyter_ai/completions/handlers/model_mixin.py
+++ b/packages/jupyter-ai/jupyter_ai/completions/handlers/model_mixin.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Any, Dict, Optional, Type
+from typing import Any, Optional
 
 from jupyter_ai.config_manager import ConfigManager
 from jupyter_ai_magics.providers import BaseProvider
@@ -17,7 +17,7 @@ class CompletionsModelMixin:
         return self.settings["jai_config_manager"]
 
     @property
-    def model_parameters(self) -> Dict[str, Dict[str, Any]]:
+    def model_parameters(self) -> dict[str, dict[str, Any]]:
         return self.settings["model_parameters"]
 
     def __init__(self, *args, **kwargs) -> None:
@@ -60,14 +60,14 @@ class CompletionsModelMixin:
         return self._llm
 
     def get_model_parameters(
-        self, provider: Type[BaseProvider], provider_params: Dict[str, str]
+        self, provider: type[BaseProvider], provider_params: dict[str, str]
     ):
         return self.model_parameters.get(
             f"{provider.id}:{provider_params['model_id']}", {}
         )
 
     def create_llm(
-        self, provider: Type[BaseProvider], provider_params: Dict[str, str]
+        self, provider: type[BaseProvider], provider_params: dict[str, str]
     ) -> BaseProvider:
         unified_parameters = {
             **provider_params,

--- a/packages/jupyter-ai/jupyter_ai/config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/config_manager.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 from copy import deepcopy
-from typing import List, Optional, Type, Union
+from typing import Optional, Union
 
 from deepmerge import Merger, always_merger
 from jsonschema import Draft202012Validator as Validator
@@ -60,7 +60,7 @@ class BlockedModelError(Exception):
     pass
 
 
-def _validate_provider_authn(config: GlobalConfig, provider: Type[AnyProvider]):
+def _validate_provider_authn(config: GlobalConfig, provider: type[AnyProvider]):
     # TODO: handle non-env auth strategies
     if not provider.auth_strategy or provider.auth_strategy.type != "env":
         return
@@ -107,10 +107,10 @@ class ConfigManager(Configurable):
         lm_providers: LmProvidersDict,
         em_providers: EmProvidersDict,
         defaults: dict,
-        allowed_providers: Optional[List[str]] = None,
-        blocked_providers: Optional[List[str]] = None,
-        allowed_models: Optional[List[str]] = None,
-        blocked_models: Optional[List[str]] = None,
+        allowed_providers: Optional[list[str]] = None,
+        blocked_providers: Optional[list[str]] = None,
+        allowed_models: Optional[list[str]] = None,
+        blocked_models: Optional[list[str]] = None,
         *args,
         **kwargs,
     ):

--- a/packages/jupyter-ai/jupyter_ai/context_providers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/context_providers/base.py
@@ -1,7 +1,8 @@
 import abc
 import os
 import re
-from typing import Awaitable, ClassVar, Dict, List, Optional
+from collections.abc import Awaitable
+from typing import ClassVar, Optional
 
 from dask.distributed import Client as DaskClient
 from jupyter_ai.chat_handlers.base import get_preferred_dir
@@ -23,11 +24,11 @@ class _BaseContextProvider(abc.ABC):
         *,
         log: Logger,
         config_manager: ConfigManager,
-        model_parameters: Dict[str, Dict],
+        model_parameters: dict[str, dict],
         root_dir: str,
         preferred_dir: Optional[str],
         dask_client_future: Awaitable[DaskClient],
-        context_providers: Dict[str, "BaseCommandContextProvider"],
+        context_providers: dict[str, "BaseCommandContextProvider"],
     ):
         preferred_dir = preferred_dir or ""
         self.log = log
@@ -45,7 +46,6 @@ class _BaseContextProvider(abc.ABC):
         """Returns a context prompt for all commands of the context provider
         command.
         """
-        pass
 
     def replace_prompt(self, prompt: str) -> str:
         """Modifies the prompt before sending it to the LLM."""
@@ -151,10 +151,9 @@ class BaseCommandContextProvider(_BaseContextProvider):
 
     @abc.abstractmethod
     async def _make_context_prompt(
-        self, message: Message, commands: List[ContextCommand]
+        self, message: Message, commands: list[ContextCommand]
     ) -> str:
         """Returns a context prompt for the given commands."""
-        pass
 
     def replace_prompt(self, prompt: str) -> str:
         """Cleans up commands from the prompt before sending it to the LLM"""
@@ -166,7 +165,7 @@ class BaseCommandContextProvider(_BaseContextProvider):
 
         return re.sub(self.pattern, replace, prompt)
 
-    def get_arg_options(self, arg_prefix: str) -> List[ListOptionsEntry]:
+    def get_arg_options(self, arg_prefix: str) -> list[ListOptionsEntry]:
         """Returns a list of autocomplete options for arguments to the command
         based on the prefix.
         Only triggered if ':' is present after the command id (e.g. '@file:').
@@ -200,7 +199,7 @@ class BaseCommandContextProvider(_BaseContextProvider):
 
 def find_commands(
     context_provider: BaseCommandContextProvider, text: str
-) -> List[ContextCommand]:
+) -> list[ContextCommand]:
     # finds commands of the context provider in the text
     matches = list(re.finditer(context_provider.pattern, text))
     if context_provider.only_start:

--- a/packages/jupyter-ai/jupyter_ai/context_providers/file.py
+++ b/packages/jupyter-ai/jupyter_ai/context_providers/file.py
@@ -1,6 +1,5 @@
 import glob
 import os
-from typing import List
 
 import nbformat
 from jupyter_ai.document_loaders.directory import SUPPORTED_EXTS
@@ -28,7 +27,7 @@ class FileContextProvider(BaseCommandContextProvider):
     requires_arg = True
     header = "Following are contents of files referenced:"
 
-    def get_arg_options(self, arg_prefix: str) -> List[ListOptionsEntry]:
+    def get_arg_options(self, arg_prefix: str) -> list[ListOptionsEntry]:
         is_abs = not os.path.isabs(arg_prefix)
         path_prefix = arg_prefix if is_abs else os.path.join(self.base_dir, arg_prefix)
         path_prefix = path_prefix
@@ -91,7 +90,7 @@ class FileContextProvider(BaseCommandContextProvider):
             return file_extension
 
     async def _make_context_prompt(
-        self, message: Message, commands: List[ContextCommand]
+        self, message: Message, commands: list[ContextCommand]
     ) -> str:
         context = "\n\n".join(
             [
@@ -160,7 +159,7 @@ class FileContextProvider(BaseCommandContextProvider):
         filepath = command.arg or ""
         return f"'{filepath}'"
 
-    def get_filepaths(self, message: Message) -> List[str]:
+    def get_filepaths(self, message: Message) -> list[str]:
         filepaths = []
         for command in find_commands(self, message.body):
             filepath = command.arg or ""

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/directory.py
@@ -5,7 +5,6 @@ import tarfile
 from datetime import datetime
 from glob import iglob
 from pathlib import Path
-from typing import List
 
 import dask
 from langchain.schema import Document
@@ -104,7 +103,7 @@ SUPPORTED_EXTS = {
 }
 
 
-def split_document(document, splitter: TextSplitter) -> List[Document]:
+def split_document(document, splitter: TextSplitter) -> list[Document]:
     return splitter.split_documents([document])
 
 

--- a/packages/jupyter-ai/jupyter_ai/document_loaders/splitter.py
+++ b/packages/jupyter-ai/jupyter_ai/document_loaders/splitter.py
@@ -1,5 +1,5 @@
 import copy
-from typing import List, Optional
+from typing import Optional
 
 from langchain.schema import Document
 from langchain.text_splitter import (
@@ -22,8 +22,8 @@ class ExtensionSplitter(TextSplitter):
         return splitter.split_text(text)
 
     def create_documents(
-        self, texts: List[str], metadatas: Optional[List[dict]] = None
-    ) -> List[Document]:
+        self, texts: list[str], metadatas: Optional[list[dict]] = None
+    ) -> list[Document]:
         _metadatas = metadatas or [{}] * len(texts)
         documents = []
         for i, text in enumerate(texts):

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -3,7 +3,6 @@ import re
 import time
 import types
 from functools import partial
-from typing import Dict
 
 import traitlets
 from dask.distributed import Client as DaskClient
@@ -227,7 +226,7 @@ class AiExtension(ExtensionApp):
     def initialize(self):
         super().initialize()
 
-        self.chat_handlers_by_room: Dict[str, Dict[str, BaseChatHandler]] = {}
+        self.chat_handlers_by_room: dict[str, dict[str, BaseChatHandler]] = {}
         """
         Nested dictionary that returns the dedicated chat handler instance that
         should be used, given the room ID and command ID respectively.
@@ -236,7 +235,7 @@ class AiExtension(ExtensionApp):
         handlers dedicated to the room identified by `<room_id>`.
         """
 
-        self.ychats_by_room: Dict[str, YChat] = {}
+        self.ychats_by_room: dict[str, YChat] = {}
         """Cache of YChat instances, indexed by room ID."""
 
         self.event_logger = self.serverapp.web_app.settings["event_logger"]
@@ -454,7 +453,7 @@ class AiExtension(ExtensionApp):
             await dask_client.close()
             self.log.debug("Closed Dask client.")
 
-    def _init_chat_handlers(self, ychat: YChat) -> Dict[str, BaseChatHandler]:
+    def _init_chat_handlers(self, ychat: YChat) -> dict[str, BaseChatHandler]:
         """
         Initializes a set of chat handlers. May accept a YChat instance for
         collaborative chats.
@@ -475,7 +474,7 @@ class AiExtension(ExtensionApp):
             seen[ep.name] = ep
         chat_handler_eps = list(seen.values())
 
-        chat_handlers: Dict[str, BaseChatHandler] = {}
+        chat_handlers: dict[str, BaseChatHandler] = {}
         llm_chat_memory = YChatHistory(ychat, k=self.default_max_chat_history)
 
         chat_handler_kwargs = {

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, Optional, Type, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 from jupyter_ai.chat_handlers import (
     AskChatHandler,
@@ -50,22 +50,22 @@ class ProviderHandler(BaseAPIHandler):
     """
 
     @property
-    def lm_providers(self) -> Dict[str, "BaseProvider"]:
+    def lm_providers(self) -> dict[str, "BaseProvider"]:
         return self.settings["lm_providers"]
 
     @property
-    def em_providers(self) -> Dict[str, "BaseEmbeddingsProvider"]:
+    def em_providers(self) -> dict[str, "BaseEmbeddingsProvider"]:
         return self.settings["em_providers"]
 
     @property
-    def allowed_models(self) -> Optional[List[str]]:
+    def allowed_models(self) -> Optional[list[str]]:
         return self.settings["allowed_models"]
 
     @property
-    def blocked_models(self) -> Optional[List[str]]:
+    def blocked_models(self) -> Optional[list[str]]:
         return self.settings["blocked_models"]
 
-    def _filter_blocked_models(self, providers: List[ListProvidersEntry]):
+    def _filter_blocked_models(self, providers: list[ListProvidersEntry]):
         """
         Satisfy the model-level allow/blocklist by filtering models accordingly.
         The provider-level allow/blocklist is already handled in
@@ -79,7 +79,7 @@ class ProviderHandler(BaseAPIHandler):
             if self.blocked_models:
                 return model_id not in self.blocked_models
             else:
-                return model_id in cast(List, self.allowed_models)
+                return model_id in cast(list, self.allowed_models)
 
         # filter out every model w/ model ID according to allow/blocklist
         for provider in providers:
@@ -212,7 +212,7 @@ class SlashCommandsInfoHandler(BaseAPIHandler):
         return self.settings["jai_config_manager"]
 
     @property
-    def chat_handlers(self) -> Dict[str, Type["BaseChatHandler"]]:
+    def chat_handlers(self) -> dict[str, type["BaseChatHandler"]]:
         return CHAT_HANDLER_DICT
 
     @web.authenticated
@@ -261,11 +261,11 @@ class AutocompleteOptionsHandler(BaseAPIHandler):
         return self.settings["jai_config_manager"]
 
     @property
-    def context_providers(self) -> Dict[str, "BaseCommandContextProvider"]:
+    def context_providers(self) -> dict[str, "BaseCommandContextProvider"]:
         return self.settings["jai_context_providers"]
 
     @property
-    def chat_handlers(self) -> Dict[str, Type["BaseChatHandler"]]:
+    def chat_handlers(self) -> dict[str, type["BaseChatHandler"]]:
         return CHAT_HANDLER_DICT
 
     @web.authenticated
@@ -302,7 +302,7 @@ class AutocompleteOptionsHandler(BaseAPIHandler):
             )
         self.finish(response.model_dump_json())
 
-    def _get_slash_command_options(self) -> List[ListOptionsEntry]:
+    def _get_slash_command_options(self) -> list[ListOptionsEntry]:
         options = []
         for id, chat_handler in self.chat_handlers.items():
             # filter out any chat handler that is not a slash command
@@ -332,7 +332,7 @@ class AutocompleteOptionsHandler(BaseAPIHandler):
         options.sort(key=lambda opt: opt.id)
         return options
 
-    def _get_context_provider_options(self) -> List[ListOptionsEntry]:
+    def _get_context_provider_options(self) -> list[ListOptionsEntry]:
         options = [
             self._make_autocomplete_option(
                 id=context_provider.command_id,

--- a/packages/jupyter-ai/jupyter_ai/history.py
+++ b/packages/jupyter-ai/jupyter_ai/history.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from jupyter_ai.constants import BOT
 from jupyterlab_chat.models import Message as JChatMessage
@@ -22,7 +22,7 @@ class YChatHistory(BaseChatMessageHistory):
         self.k = k
 
     @property
-    def messages(self) -> List[BaseMessage]:  # type:ignore[override]
+    def messages(self) -> list[BaseMessage]:  # type:ignore[override]
         """
         Returns the last `2 * k` messages preceding the latest message. If
         `k` is set to `None`, return all preceding messages.
@@ -35,16 +35,16 @@ class YChatHistory(BaseChatMessageHistory):
         # we exclude the last message since that is the human message just
         # submitted by a user.
         start_idx = 0 if self.k is None else -2 * self.k - 1
-        recent_messages: List[JChatMessage] = all_messages[start_idx:-1]
+        recent_messages: list[JChatMessage] = all_messages[start_idx:-1]
 
         return self._convert_to_langchain_messages(recent_messages)
 
-    def _convert_to_langchain_messages(self, jchat_messages: List[JChatMessage]):
+    def _convert_to_langchain_messages(self, jchat_messages: list[JChatMessage]):
         """
         Accepts a list of Jupyter Chat messages, and returns them as a list of
         LangChain messages.
         """
-        messages: List[BaseMessage] = []
+        messages: list[BaseMessage] = []
         for jchat_message in jchat_messages:
             if jchat_message.sender == BOT["username"]:
                 messages.append(AIMessage(content=jchat_message.body))

--- a/packages/jupyter-ai/jupyter_ai/models.py
+++ b/packages/jupyter-ai/jupyter_ai/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 # unused import: exports Persona from this module
 from jupyter_ai_magics.models.persona import Persona
@@ -17,17 +17,17 @@ class ListProvidersEntry(BaseModel):
     id: str
     name: str
     model_id_label: Optional[str] = None
-    models: List[str]
+    models: list[str]
     help: Optional[str] = None
     auth_strategy: AuthStrategy
     registry: bool
-    fields: List[Field]
-    chat_models: Optional[List[str]] = None
-    completion_models: Optional[List[str]] = None
+    fields: list[Field]
+    chat_models: Optional[list[str]] = None
+    completion_models: Optional[list[str]] = None
 
 
 class ListProvidersResponse(BaseModel):
-    providers: List[ListProvidersEntry]
+    providers: list[ListProvidersEntry]
 
 
 class IndexedDir(BaseModel):
@@ -37,23 +37,23 @@ class IndexedDir(BaseModel):
 
 
 class IndexMetadata(BaseModel):
-    dirs: List[IndexedDir]
+    dirs: list[IndexedDir]
 
 
 class DescribeConfigResponse(BaseModel):
     model_provider_id: Optional[str] = None
     embeddings_provider_id: Optional[str] = None
     send_with_shift_enter: bool
-    fields: Dict[str, Dict[str, Any]]
+    fields: dict[str, dict[str, Any]]
     # when sending config over REST API, do not include values of the API keys,
     # just the names.
-    api_keys: List[str]
+    api_keys: list[str]
     # timestamp indicating when the configuration file was last read. should be
     # passed to the subsequent UpdateConfig request.
     last_read: int
     completions_model_provider_id: Optional[str] = None
-    completions_fields: Dict[str, Dict[str, Any]]
-    embeddings_fields: Dict[str, Dict[str, Any]]
+    completions_fields: dict[str, dict[str, Any]]
+    embeddings_fields: dict[str, dict[str, Any]]
 
 
 class UpdateConfigRequest(BaseModel):
@@ -61,13 +61,13 @@ class UpdateConfigRequest(BaseModel):
     embeddings_provider_id: Optional[str] = None
     completions_model_provider_id: Optional[str] = None
     send_with_shift_enter: Optional[bool] = None
-    api_keys: Optional[Dict[str, str]] = None
+    api_keys: Optional[dict[str, str]] = None
     # if passed, this will raise an Error if the config was written to after the
     # time specified by `last_read` to prevent write-write conflicts.
     last_read: Optional[int] = None
-    fields: Optional[Dict[str, Dict[str, Any]]] = None
-    completions_fields: Optional[Dict[str, Dict[str, Any]]] = None
-    embeddings_fields: Optional[Dict[str, Dict[str, Any]]] = None
+    fields: Optional[dict[str, dict[str, Any]]] = None
+    completions_fields: Optional[dict[str, dict[str, Any]]] = None
+    embeddings_fields: Optional[dict[str, dict[str, Any]]] = None
 
     @field_validator("send_with_shift_enter", "api_keys", "fields", mode="before")
     @classmethod
@@ -86,11 +86,11 @@ class GlobalConfig(BaseModel):
     model_provider_id: Optional[str] = None
     embeddings_provider_id: Optional[str] = None
     send_with_shift_enter: bool
-    fields: Dict[str, Dict[str, Any]]
-    api_keys: Dict[str, str]
+    fields: dict[str, dict[str, Any]]
+    api_keys: dict[str, str]
     completions_model_provider_id: Optional[str] = None
-    completions_fields: Dict[str, Dict[str, Any]]
-    embeddings_fields: Dict[str, Dict[str, Any]]
+    completions_fields: dict[str, dict[str, Any]]
+    embeddings_fields: dict[str, dict[str, Any]]
 
 
 class ListSlashCommandsEntry(BaseModel):
@@ -99,7 +99,7 @@ class ListSlashCommandsEntry(BaseModel):
 
 
 class ListSlashCommandsResponse(BaseModel):
-    slash_commands: List[ListSlashCommandsEntry] = []
+    slash_commands: list[ListSlashCommandsEntry] = []
 
 
 class ListOptionsEntry(BaseModel):
@@ -117,4 +117,4 @@ class ListOptionsEntry(BaseModel):
 
 
 class ListOptionsResponse(BaseModel):
-    options: List[ListOptionsEntry] = []
+    options: list[ListOptionsEntry] = []

--- a/packages/jupyter-ai/jupyter_ai/tests/static/file2.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/static/file2.py
@@ -1,3 +1,1 @@
-import os
-
 print("Hello World")

--- a/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 from pathlib import Path
-from unittest.mock import mock_open, patch
 
 import pytest
 from jupyter_ai.config_manager import (
@@ -74,9 +73,6 @@ def common_cm_kwargs(config_path, schema_path):
 @pytest.fixture
 def cm_kargs_with_defaults(config_path, schema_path, common_cm_kwargs):
     """Kwargs that are commonly used when initializing the CM."""
-    log = logging.getLogger()
-    lm_providers = get_lm_providers()
-    em_providers = get_em_providers()
     return {
         **common_cm_kwargs,
         "defaults": {
@@ -308,9 +304,6 @@ def test_init_with_default_values(
 
     del cm_with_defaults
 
-    log = logging.getLogger()
-    lm_providers = get_lm_providers()
-    em_providers = get_em_providers()
     kwargs = {
         **common_cm_kwargs,
         "defaults": {"model_provider_id": "bedrock-chat:anthropic.claude-v2"},
@@ -540,7 +533,7 @@ def test_config_manager_updates_schema(jp_data_dir, common_cm_kwargs):
 
     cm_kwargs = {**common_cm_kwargs, "schema_path": schema_path}
 
-    cm = ConfigManager(**cm_kwargs)
+    ConfigManager(**cm_kwargs)
     with open(schema_path) as f:
         new_schema = json.loads(f.read())
         assert "custom_field" in new_schema["properties"]

--- a/packages/jupyter-ai/jupyter_ai/tests/test_directory.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_directory.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 from jupyter_ai.document_loaders.directory import collect_filepaths

--- a/packages/jupyter-ai/jupyter_ai/tests/test_handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_handlers.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import stat
-from typing import List, Optional
+from typing import Optional
 from unittest import mock
 
 from jupyter_ai.chat_handlers import DefaultChatHandler, learn
@@ -71,7 +71,7 @@ class TestDefaultChatHandler(DefaultChatHandler):
         )
 
     @property
-    def messages(self) -> List[BaseMessage]:
+    def messages(self) -> list[BaseMessage]:
         """
         Test helper method for getting the complete message history, including
         the last message.


### PR DESCRIPTION
Closes #1326.

Update `pyupgrade` in `pre-commit` to `--py39-plus` to enforce PEP 585. Also add `autoflake` to `pre-commit` to remove unused imports after switching to PEP 585.

Run `pre-commit` GitHub Action to enforce modern Python in PRs.

An alternative would be replace most `pre-commit` rules with `ruff` (https://docs.astral.sh/ruff/), however I wanted to move gradually. I am open opening a PR with introducing `ruff`.
