### PR TITLE
Handle missing field in config.json on version upgrade

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/config_manager.py
@@ -318,6 +318,8 @@ class ConfigManager(Configurable):
         with open(self.config_path, encoding="utf-8") as f:
             self._last_read = time.time_ns()
             raw_config = json.loads(f.read())
+            if "embeddings_fields" not in raw_config:
+                raw_config["embeddings_fields"] = {}
             config = GlobalConfig(**raw_config)
             self._validate_config(config)
             return config

--- a/packages/jupyter-ai/jupyter_ai/config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/config_manager.py
@@ -213,6 +213,8 @@ class ConfigManager(Configurable):
     def _process_existing_config(self, default_config):
         with open(self.config_path, encoding="utf-8") as f:
             existing_config = json.loads(f.read())
+            if "embeddings_fields" not in existing_config:
+                existing_config["embeddings_fields"] = {}
             merged_config = always_merger.merge(
                 default_config,
                 {k: v for k, v in existing_config.items() if v is not None},


### PR DESCRIPTION
The structure of the `config.json` file was corrected when refactoring `config_manager.py` in release 2.31, by adding a new `embeddings_field`. But starting up with the old config file in place without the new field results in a breaking change. Either the old config file needs to be deleted, or the instantiation of the settings requires adding in the `embeddings_field` when it is missing in `_process_existing_config`. This PR includes the latter fix. 

To test, replace the config file `~/Library/Jupyter/jupyter-ai/config.json` with this test file:
```
{
    "model_provider_id": "ollama:llama3.2",
    "embeddings_provider_id": null,
    "send_with_shift_enter": false,
    "fields": {
        "ollama:llama3.2": {
            "base_url": "http://localhost:11434"
        }
    },
    "api_keys": {},
    "completions_model_provider_id": null,
    "completions_fields": {}
}
```
Then start up Jupyter Lab (with jupyter AI extension). Check that the new file has the following extra field at the end as shown:
```
{
    "model_provider_id": "ollama:llama3.2",
    "embeddings_provider_id": null,
    "send_with_shift_enter": false,
    "fields": {
        "ollama:llama3.2": {
            "base_url": "http://localhost:11434"
        }
    },
    "api_keys": {},
    "completions_model_provider_id": null,
    "completions_fields": {},
    "embeddings_fields": {}
}
```

Further, check that the AI Settings panel is now available as shown:
<img width="686" alt="image" src="https://github.com/user-attachments/assets/40aa2764-9edc-4e6c-95c4-ee7bd037ebd5" />

Then add in an embedding model also to make sure it works:
<img width="681" alt="image" src="https://github.com/user-attachments/assets/57bbebb9-74b5-44d7-af30-b182defb3d06" />

Check that this is in the `config.json` file. 

Also tested with Ollama and API URL:
```
    "model_provider_id": "ollama:llama3.2",
    "embeddings_provider_id": "ollama:mxbai-embed-large",
    "send_with_shift_enter": false,
    "fields": {
        "ollama:llama3.2": {
            "base_url": "http://localhost:11434"
        }
    },
    "api_keys": {},
    "completions_model_provider_id": null,
    "completions_fields": {},
    "embeddings_fields": {
        "ollama:mxbai-embed-large": {
            "base_url": "http://localhost:11434"
        }
    }
}
```