### PR TITLE
Use `User.bot` parameter

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/constants.py
+++ b/packages/jupyter-ai/jupyter_ai/constants.py
@@ -5,5 +5,5 @@ BOT = {
     "name": "Jupyternaut",
     "display_name": "Jupyternaut",
     "initials": "J",
-    "bot": True
+    "bot": True,
 }

--- a/packages/jupyter-ai/jupyter_ai/constants.py
+++ b/packages/jupyter-ai/jupyter_ai/constants.py
@@ -5,4 +5,5 @@ BOT = {
     "name": "Jupyternaut",
     "display_name": "Jupyternaut",
     "initials": "J",
+    "bot": True
 }

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     # traitlets>=5.6 is required in JL4
     "traitlets>=5.6",
     "deepmerge>=2.0,<3",
-    "jupyterlab-chat>=0.8.1,<0.9.0",
+    "jupyterlab-chat>=0.11.0,<0.12.0",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]


### PR DESCRIPTION
### Description

Sets `BOT.bot` parameter to `True`. `User.bot` parameter was introduced in https://github.com/jupyterlab/jupyter-chat/pull/214 to identify bots to allow deletion of their messages by any user.

This PR requires next version of `jupyterlab-chat` to be released first, see https://github.com/jupyterlab/jupyter-chat/issues/215 for discussion.

Partial fix to #1173.