### PR TITLE
Added a local identity provider.

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/auth/identity.py
+++ b/packages/jupyter-ai/jupyter_ai/auth/identity.py
@@ -18,13 +18,21 @@ def create_initials(username):
 
 
 class LocalIdentityProvider(IdentityProvider):
+    """IdentityProvider that determines username from system user."""
 
     def get_user(self, handler):
-        username = getpass.getuser()
-        user = User(
-            username=username,
-            name=username,
-            initials=create_initials(username),
-            color=None,
-        )
+        try:
+            username = getpass.getuser()
+            user = User(
+                username=username,
+                name=username,
+                initials=create_initials(username),
+                color=None,
+            )
+        except OSError:
+            self.log.warning(
+                "Could not determine username from system. "
+                "Falling back to anonymous user."
+            )
+            return super().get_user(handler)
         return user

--- a/packages/jupyter-ai/jupyter_ai/auth/identity.py
+++ b/packages/jupyter-ai/jupyter_ai/auth/identity.py
@@ -25,6 +25,6 @@ class LocalIdentityProvider(IdentityProvider):
             username=username,
             name=username,
             initials=create_initials(username),
-            color="#039BE5",
+            color=None,
         )
         return user

--- a/packages/jupyter-ai/jupyter_ai/auth/identity.py
+++ b/packages/jupyter-ai/jupyter_ai/auth/identity.py
@@ -30,7 +30,10 @@ class LocalIdentityProvider(IdentityProvider):
                 initials=create_initials(username),
                 color=None,
             )
-
             return user
-        except OSError:
-            self.log.exception("Could not determine username from system.")
+        except OSError as e:
+            self.log.debug(
+                "Could not determine username from system. Falling back to anonymous"
+                f"user."
+            )
+            return self._get_user(handler)

--- a/packages/jupyter-ai/jupyter_ai/auth/identity.py
+++ b/packages/jupyter-ai/jupyter_ai/auth/identity.py
@@ -1,3 +1,4 @@
+import asyncio
 import getpass
 
 from jupyter_server.auth.identity import IdentityProvider, User
@@ -29,10 +30,7 @@ class LocalIdentityProvider(IdentityProvider):
                 initials=create_initials(username),
                 color=None,
             )
+
+            return user
         except OSError:
-            self.log.warning(
-                "Could not determine username from system. "
-                "Falling back to anonymous user."
-            )
-            return super().get_user(handler)
-        return user
+            self.log.exception("Could not determine username from system.")

--- a/packages/jupyter-ai/jupyter_ai/auth/identity.py
+++ b/packages/jupyter-ai/jupyter_ai/auth/identity.py
@@ -4,7 +4,7 @@ from jupyter_server.auth.identity import IdentityProvider, User
 
 
 def create_initials(username):
-    """Creates initials combining first 2 constants"""
+    """Creates initials combining first 2 consonants"""
 
     username = username.lower()
 

--- a/packages/jupyter-ai/jupyter_ai/auth/identity.py
+++ b/packages/jupyter-ai/jupyter_ai/auth/identity.py
@@ -1,0 +1,30 @@
+import getpass
+
+from jupyter_server.auth.identity import IdentityProvider, User
+
+
+def create_initials(username):
+    """Creates initials combining first 2 constants"""
+
+    username = username.lower()
+
+    # Default: return first two unique consonants
+    consonants = [c for c in username if c in "bcdfghjklmnpqrstvwxyz"]
+    if len(consonants) >= 2:
+        return (consonants[0] + consonants[1]).upper()
+
+    # Fallback: first two characters
+    return username[:2].upper()
+
+
+class LocalIdentityProvider(IdentityProvider):
+
+    def get_user(self, handler):
+        username = getpass.getuser()
+        user = User(
+            username=username,
+            name=username,
+            initials=create_initials(username),
+            color="#039BE5",
+        )
+        return user

--- a/packages/jupyter-ai/jupyter_ai/tests/test_identity.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_identity.py
@@ -21,16 +21,33 @@ def handler():
 @patch("getpass.getuser")
 def test_get_user_successful(getuser, log, handler):
 
-    getuser.return_value = "johndoe"
+    getuser.return_value = "localuser"
     provider = LocalIdentityProvider(log=log)
 
     user = provider.get_user(handler)
 
     assert isinstance(user, User)
-    assert user.username == "johndoe"
-    assert user.name == "johndoe"
-    assert user.initials == "JH"
+    assert user.username == "localuser"
+    assert user.name == "localuser"
+    assert user.initials == "LC"
     assert user.color is None
+
+
+@patch("getpass.getuser")
+@pytest.mark.asyncio
+async def test_get_user_with_error(getuser, log, handler):
+
+    getuser.return_value = "localuser"
+    getuser.side_effect = OSError("Could not get username")
+    handler._jupyter_current_user = User(username="jupyteruser")
+
+    provider = LocalIdentityProvider(log=log)
+
+    user = provider.get_user(handler)
+    user = await user
+
+    assert isinstance(user, User)
+    assert user.username == "jupyteruser"
 
 
 @pytest.mark.parametrize(

--- a/packages/jupyter-ai/jupyter_ai/tests/test_identity.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_identity.py
@@ -1,0 +1,61 @@
+import logging
+from unittest.mock import Mock, patch
+
+import pytest
+from jupyter_ai.auth.identity import LocalIdentityProvider, create_initials
+from jupyter_server.auth.identity import User
+
+
+@pytest.fixture
+def log():
+    log = logging.getLogger()
+    log.addHandler(logging.NullHandler())
+    return log
+
+
+@pytest.fixture
+def handler():
+    return Mock()
+
+
+@patch("getpass.getuser")
+def test_get_user_successful(getuser, log, handler):
+
+    getuser.return_value = "johndoe"
+    provider = LocalIdentityProvider(log=log)
+
+    user = provider.get_user(handler)
+
+    assert isinstance(user, User)
+    assert user.username == "johndoe"
+    assert user.name == "johndoe"
+    assert user.initials == "JH"
+    assert user.color is None
+
+
+@patch("getpass.getuser")
+def test_get_user_oserror(getuser, log, handler):
+
+    getuser.side_effect = OSError("Cannot get username")
+    provider = LocalIdentityProvider(log=log)
+    user = provider.get_user(handler)
+
+    assert user is not None
+
+
+@pytest.mark.parametrize(
+    "username,expected_initials",
+    [
+        ("johndoe", "JH"),
+        ("alice", "LC"),
+        ("xy", "XY"),
+        ("a", "A"),
+        ("SARAH", "SR"),
+        ("john-smith", "JH"),
+        ("john123", "JH"),
+        ("", ""),
+    ],
+)
+def test_create_initials(username, expected_initials):
+    """Test various initials generation scenarios."""
+    assert create_initials(username) == expected_initials.upper()

--- a/packages/jupyter-ai/jupyter_ai/tests/test_identity.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_identity.py
@@ -33,16 +33,6 @@ def test_get_user_successful(getuser, log, handler):
     assert user.color is None
 
 
-@patch("getpass.getuser")
-def test_get_user_oserror(getuser, log, handler):
-
-    getuser.side_effect = OSError("Cannot get username")
-    provider = LocalIdentityProvider(log=log)
-    user = provider.get_user(handler)
-
-    assert user is not None
-
-
 @pytest.mark.parametrize(
     "username,expected_initials",
     [


### PR DESCRIPTION
Partially fixes #1181, long term we might want to make an update to jupyter-server for local installations.

This PR adds a local identity provider to switch user identity to local host credentials. The identity provider is only appropriate for local installations of Jupyter.

```shell
jupyter lab --ServerApp.identity_provider_class=jupyter_ai.auth.identity.LocalIdentityProvider
```

| Before  | After |
| ------- | ----- |
| <img alt="Screenshot 2025-04-28 at 8 03 27 AM" src="https://github.com/user-attachments/assets/67ebc23f-1c7a-44e9-a676-1397e2f506cd" />  | <img alt="Screenshot 2025-04-28 at 8 05 16 AM" src="https://github.com/user-attachments/assets/c24d9832-0ee2-43be-9d25-09263c4f13ae" /> |


**Note**: Excluding the change to jupyter_ai.json, as I wasn't able to get this working, even though it is being copied to a directory in jupyter --paths. 

```
(jupyter-ai) pijain@bcd07462b5c2 jupyter-ai % jupyter --paths
config:
    /Users/pijain/.jupyter
    /Users/pijain/.local/etc/jupyter
    /Users/pijain/miniforge3/envs/jupyter-ai/etc/jupyter
    /usr/local/etc/jupyter
    /etc/jupyter
data:
    /Users/pijain/Library/Jupyter
    /Users/pijain/.local/share/jupyter
    /Users/pijain/miniforge3/envs/jupyter-ai/share/jupyter
    /usr/local/share/jupyter
    /usr/share/jupyter
runtime:
    /Users/pijain/Library/Jupyter/runtime

(jupyter-ai) pijain@bcd07462b5c2 jupyter-ai % cat /Users/pijain/miniforge3/envs/jupyter-ai/etc/jupyter/jupyter_server_config.d/jupyter_ai.json
{
  "ServerApp": {
    "jpserver_extensions": {
      "jupyter_ai": true
    },
    "identity_provider_class": "jupyter_ai.auth.identity.LocalIdentityProvider"
  }
}%  
``` 
