### PR TITLE
Implement stop streaming button in v3

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -454,7 +454,11 @@ class BaseChatHandler:
             stream_interrupted = False
             stream_id = None
             async for chunk in chunk_generator:
-                if stream_id and stream_id in self.message_interrupted.keys() and self.message_interrupted[stream_id].is_set():
+                if (
+                    stream_id
+                    and stream_id in self.message_interrupted.keys()
+                    and self.message_interrupted[stream_id].is_set()
+                ):
                     try:
                         # notify the model provider that streaming was interrupted
                         # (this is essential to allow the model to stop generating)
@@ -478,7 +482,6 @@ class BaseChatHandler:
 
                 if not received_first_chunk:
                     # when receiving the first chunk, start the stream.
-                    received_first_chunk = True
                     self.message_interrupted[stream_id] = asyncio.Event()
 
             # if stream was interrupted, add a tombstone

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -453,6 +453,7 @@ class BaseChatHandler:
             # TODO v3: re-implement stream interrupt
             stream_interrupted = False
             stream_id = None
+            received_first_chunk = False
             async for chunk in chunk_generator:
                 if (
                     stream_id
@@ -482,6 +483,7 @@ class BaseChatHandler:
 
                 if not received_first_chunk:
                     # when receiving the first chunk, start the stream.
+                    received_first_chunk = True
                     self.message_interrupted[stream_id] = asyncio.Event()
 
             # if stream was interrupted, add a tombstone

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -633,12 +633,15 @@ class AiExtension(ExtensionApp):
             config_manager = self.settings.get("jai_config_manager", None)
             assert config_manager and isinstance(config_manager, ConfigManager)
 
+            message_interrupted = self.settings.get("jai_message_interrupted", None)
+            assert message_interrupted and isinstance(message_interrupted, dict)
+
             persona_manager = PersonaManager(
                 ychat=ychat,
                 config_manager=config_manager,
                 event_loop=self.event_loop,
                 log=self.log,
-                message_interrupted=self.settings.get("jai_message_interrupted"),
+                message_interrupted=message_interrupted,
             )
         except Exception as e:
             # TODO: how to stop the extension when this fails

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -28,6 +28,7 @@ from .handlers import (
     AutocompleteOptionsHandler,
     EmbeddingsModelProviderHandler,
     GlobalConfigHandler,
+    InterruptStreamingHandler,
     ModelProviderHandler,
     SlashCommandsInfoHandler,
 )
@@ -77,6 +78,7 @@ class AiExtension(ExtensionApp):
         (r"api/ai/config/?", GlobalConfigHandler),
         (r"api/ai/chats/slash_commands?", SlashCommandsInfoHandler),
         (r"api/ai/chats/autocomplete_options?", AutocompleteOptionsHandler),
+        (r"api/ai/chats/stop_streaming?", InterruptStreamingHandler),
         (r"api/ai/providers?", ModelProviderHandler),
         (r"api/ai/providers/embeddings?", EmbeddingsModelProviderHandler),
         (r"api/ai/completion/inline/?", DefaultInlineCompletionHandler),
@@ -636,6 +638,7 @@ class AiExtension(ExtensionApp):
                 config_manager=config_manager,
                 event_loop=self.event_loop,
                 log=self.log,
+                message_interrupted=self.settings.get("jai_message_interrupted"),
             )
         except Exception as e:
             # TODO: how to stop the extension when this fails

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -627,14 +627,16 @@ class AiExtension(ExtensionApp):
         This method should not raise an exception. Upon encountering an
         exception, this method will catch it, log it, and return `None`.
         """
-        persona_manager: Optional[PersonaManager]
+        persona_manager: Optional[PersonaManager] = None
 
         try:
             config_manager = self.settings.get("jai_config_manager", None)
             assert config_manager and isinstance(config_manager, ConfigManager)
 
             message_interrupted = self.settings.get("jai_message_interrupted", None)
-            assert message_interrupted and isinstance(message_interrupted, dict)
+            assert message_interrupted is not None and isinstance(
+                message_interrupted, dict
+            )
 
             persona_manager = PersonaManager(
                 ychat=ychat,

--- a/packages/jupyter-ai/jupyter_ai/handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/handlers.py
@@ -204,6 +204,17 @@ class ApiKeysHandler(BaseAPIHandler):
             raise HTTPError(500, str(e))
 
 
+class InterruptStreamingHandler(BaseAPIHandler):
+    """Interrupt a current message streaming"""
+
+    @web.authenticated
+    def post(self):
+        message_id = self.get_json_body().get("message_id")
+        message_interrupted = self.settings.get("jai_message_interrupted")
+        if message_id and message_id in message_interrupted.keys():
+            message_interrupted[message_id].set()
+
+
 class SlashCommandsInfoHandler(BaseAPIHandler):
     """List slash commands that are currently available to the user."""
 

--- a/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
@@ -1,5 +1,5 @@
-from abc import ABC, abstractmethod
 import asyncio
+from abc import ABC, abstractmethod
 from dataclasses import asdict
 from logging import Logger
 from time import time
@@ -232,7 +232,11 @@ class BasePersona(ABC):
         try:
             self.awareness.set_local_state_field("isWriting", True)
             async for chunk in reply_stream:
-                if stream_id and stream_id in self.message_interrupted.keys() and self.message_interrupted[stream_id].is_set():
+                if (
+                    stream_id
+                    and stream_id in self.message_interrupted.keys()
+                    and self.message_interrupted[stream_id].is_set()
+                ):
                     try:
                         # notify the model provider that streaming was interrupted
                         # (this is essential to allow the model to stop generating)

--- a/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import asyncio
 from dataclasses import asdict
 from logging import Logger
 from time import time
@@ -82,6 +83,10 @@ class BasePersona(ABC):
     Automatically set by `BasePersona`.
     """
 
+    message_interrupted: dict[str, asyncio.Event]
+    """Dictionary mapping an agent message identifier to an asyncio Event
+    which indicates if the message generation/streaming was interrupted."""
+
     ################################################
     # constructor
     ################################################
@@ -92,11 +97,13 @@ class BasePersona(ABC):
         manager: "PersonaManager",
         config: ConfigManager,
         log: Logger,
+        message_interrupted: dict[str, asyncio.Event],
     ):
         self.ychat = ychat
         self.manager = manager
         self.config = config
         self.log = log
+        self.message_interrupted = message_interrupted
         self.awareness = PersonaAwareness(
             ychat=self.ychat, log=self.log, user=self.as_user()
         )
@@ -221,14 +228,30 @@ class BasePersona(ABC):
         - Automatically manages its awareness state to show writing status.
         """
         stream_id: Optional[str] = None
-
+        stream_interrupted = False
         try:
             self.awareness.set_local_state_field("isWriting", True)
             async for chunk in reply_stream:
+                if stream_id and stream_id in self.message_interrupted.keys() and self.message_interrupted[stream_id].is_set():
+                    try:
+                        # notify the model provider that streaming was interrupted
+                        # (this is essential to allow the model to stop generating)
+                        await reply_stream.athrow(  # type:ignore[attr-defined]
+                            GenerationInterrupted()
+                        )
+                    except GenerationInterrupted:
+                        # do not let the exception bubble up in case if
+                        # the provider did not handle it
+                        pass
+                    stream_interrupted = True
+                    break
+
                 if not stream_id:
                     stream_id = self.ychat.add_message(
                         NewMessage(body="", sender=self.id)
                     )
+                    self.message_interrupted[stream_id] = asyncio.Event()
+                    self.awareness.set_local_state_field("isWriting", stream_id)
 
                 assert stream_id
                 self.ychat.update_message(
@@ -248,9 +271,28 @@ class BasePersona(ABC):
             self.log.exception(e)
         finally:
             self.awareness.set_local_state_field("isWriting", False)
+            # if stream was interrupted, add a tombstone
+            if stream_interrupted:
+                stream_tombstone = "\n\n(AI response stopped by user)"
+                self.ychat.update_message(
+                    Message(
+                        id=stream_id,
+                        body=stream_tombstone,
+                        time=time(),
+                        sender=self.id,
+                        raw_time=False,
+                    ),
+                    append=True,
+                )
+            if stream_id and stream_id in self.message_interrupted.keys():
+                del self.message_interrupted[stream_id]
 
     def send_message(self, body: str) -> None:
         """
         Sends a new message to the chat from this persona.
         """
         self.ychat.add_message(NewMessage(body=body, sender=self.id))
+
+
+class GenerationInterrupted(asyncio.CancelledError):
+    """Exception raised when streaming is cancelled by the user"""

--- a/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
@@ -275,21 +275,22 @@ class BasePersona(ABC):
             self.log.exception(e)
         finally:
             self.awareness.set_local_state_field("isWriting", False)
-            # if stream was interrupted, add a tombstone
-            if stream_interrupted:
-                stream_tombstone = "\n\n(AI response stopped by user)"
-                self.ychat.update_message(
-                    Message(
-                        id=stream_id,
-                        body=stream_tombstone,
-                        time=time(),
-                        sender=self.id,
-                        raw_time=False,
-                    ),
-                    append=True,
-                )
-            if stream_id and stream_id in self.message_interrupted.keys():
-                del self.message_interrupted[stream_id]
+            if stream_id:
+                # if stream was interrupted, add a tombstone
+                if stream_interrupted:
+                    stream_tombstone = "\n\n(AI response stopped by user)"
+                    self.ychat.update_message(
+                        Message(
+                            id=stream_id,
+                            body=stream_tombstone,
+                            time=time(),
+                            sender=self.id,
+                            raw_time=False,
+                        ),
+                        append=True,
+                    )
+                if stream_id in self.message_interrupted.keys():
+                    del self.message_interrupted[stream_id]
 
     def send_message(self, body: str) -> None:
         """

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 from logging import Logger
 from time import time_ns
 from typing import TYPE_CHECKING, ClassVar, Optional
@@ -37,11 +38,13 @@ class PersonaManager:
         config_manager: ConfigManager,
         event_loop: "AbstractEventLoop",
         log: Logger,
+        message_interrupted: dict[str, asyncio.Event],
     ):
         self.ychat = ychat
         self.config_manager = config_manager
         self.event_loop = event_loop
         self.log = log
+        self.message_interrupted = message_interrupted
 
         if not isinstance(PersonaManager._persona_classes, list):
             self._init_persona_classes()
@@ -125,6 +128,7 @@ class PersonaManager:
                     manager=self,
                     config=self.config_manager,
                     log=self.log,
+                    message_interrupted=self.message_interrupted,
                 )
             except Exception:
                 self.log.exception(

--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -62,7 +62,7 @@
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@jupyter-notebook/application": "^7.2.0",
-    "@jupyter/chat": "^0.11.0",
+    "@jupyter/chat": "^0.12.0",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.2.0",
     "@jupyterlab/codeeditor": "^4.2.0",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     # traitlets>=5.6 is required in JL4
     "traitlets>=5.6",
     "deepmerge>=2.0,<3",
-    "jupyterlab-chat>=0.11.0,<0.12.0",
+    "jupyterlab-chat>=0.12.0,<0.13.0",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]

--- a/packages/jupyter-ai/src/components/message-footer/stop-button.tsx
+++ b/packages/jupyter-ai/src/components/message-footer/stop-button.tsx
@@ -1,0 +1,70 @@
+import {
+  IChatModel,
+  MessageFooterSectionProps,
+  TooltippedButton
+} from '@jupyter/chat';
+import StopIcon from '@mui/icons-material/Stop';
+import React, { useEffect, useState } from 'react';
+import { requestAPI } from '../../handler';
+
+/**
+ * The stop button.
+ */
+export function StopButton(props: MessageFooterSectionProps): JSX.Element {
+  const { message, model } = props;
+  const [visible, setVisible] = useState<boolean>(false);
+  const tooltip = 'Stop streaming';
+
+  useEffect(() => {
+    const writerChanged = (_: IChatModel, writers: IChatModel.IWriter[]) => {
+      const w = writers.filter(w => w.messageID === message.id);
+      if (w.length > 0) {
+        setVisible(true);
+      } else {
+        setVisible(false);
+      }
+    };
+
+    // Listen only the messages that are from a bot.
+    if (message.sender.username !== model.user?.username) {
+      model.writersChanged?.connect(writerChanged);
+
+      // Check if the message is currently being edited.
+      writerChanged(model, model.writers);
+    }
+
+    return () => {
+      model.writersChanged?.disconnect(writerChanged);
+    };
+  }, [model]);
+
+  const onClick = () => {
+    // Post request to the stop streaming handler.
+    requestAPI('chats/stop_streaming', {
+      method: 'POST',
+      body: JSON.stringify({
+        message_id: message.id
+      }),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  };
+
+  return visible ? (
+    <TooltippedButton
+      onClick={onClick}
+      tooltip={tooltip}
+      buttonProps={{
+        size: 'small',
+        variant: 'contained',
+        title: tooltip
+      }}
+      sx={{ display: visible ? 'inline-flex' : 'none' }}
+    >
+      <StopIcon />
+    </TooltippedButton>
+  ) : (
+    <></>
+  );
+}

--- a/packages/jupyter-ai/src/components/message-footer/stop-button.tsx
+++ b/packages/jupyter-ai/src/components/message-footer/stop-button.tsx
@@ -26,7 +26,10 @@ export function StopButton(props: MessageFooterSectionProps): JSX.Element {
     };
 
     // Listen only the messages that are from a bot.
-    if (message.sender.username !== model.user?.username && message.sender.bot) {
+    if (
+      message.sender.username !== model.user?.username &&
+      message.sender.bot
+    ) {
       model.writersChanged?.connect(writerChanged);
 
       // Check if the message is currently being edited.

--- a/packages/jupyter-ai/src/components/message-footer/stop-button.tsx
+++ b/packages/jupyter-ai/src/components/message-footer/stop-button.tsx
@@ -26,7 +26,7 @@ export function StopButton(props: MessageFooterSectionProps): JSX.Element {
     };
 
     // Listen only the messages that are from a bot.
-    if (message.sender.username !== model.user?.username) {
+    if (message.sender.username !== model.user?.username && message.sender.bot) {
       model.writersChanged?.connect(writerChanged);
 
       // Check if the message is currently being edited.

--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -1,4 +1,5 @@
 import { INotebookShell } from '@jupyter-notebook/application';
+import { IMessageFooterRegistry } from '@jupyter/chat';
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -16,6 +17,7 @@ import { SingletonLayout, Widget } from '@lumino/widgets';
 
 import { chatCommandPlugins } from './chat-commands';
 import { completionPlugin } from './completions';
+import { StopButton } from './components/message-footer/stop-button';
 import { statusItemPlugin } from './status';
 import { IJaiCompletionProvider } from './tokens';
 import { buildErrorWidget } from './widgets/chat-error';
@@ -104,10 +106,23 @@ const plugin: JupyterFrontEndPlugin<void> = {
   }
 };
 
+const stopStreaming: JupyterFrontEndPlugin<void> = {
+  id: '@jupyter-ai/core:stop-streaming',
+  autoStart: true,
+  requires: [IMessageFooterRegistry],
+  activate: (app: JupyterFrontEnd, registry: IMessageFooterRegistry) => {
+    registry.addSection({
+      component: StopButton,
+      position: 'center'
+    });
+  }
+};
+
 export default [
   plugin,
   statusItemPlugin,
   completionPlugin,
+  stopStreaming,
   ...chatCommandPlugins
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,7 +2237,7 @@ __metadata:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
     "@jupyter-notebook/application": ^7.2.0
-    "@jupyter/chat": ^0.11.0
+    "@jupyter/chat": ^0.12.0
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.2.0
     "@jupyterlab/builder": ^4.2.0
@@ -2322,9 +2322,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/chat@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@jupyter/chat@npm:0.11.0"
+"@jupyter/chat@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "@jupyter/chat@npm:0.12.0"
   dependencies:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
@@ -2337,6 +2337,7 @@ __metadata:
     "@jupyterlab/notebook": ^4.2.0
     "@jupyterlab/rendermime": ^4.2.0
     "@jupyterlab/ui-components": ^4.2.0
+    "@lumino/algorithm": ^2.0.0
     "@lumino/commands": ^2.0.0
     "@lumino/coreutils": ^2.0.0
     "@lumino/disposable": ^2.0.0
@@ -2346,7 +2347,7 @@ __metadata:
     clsx: ^2.1.0
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: e7b5c47c94b6afa3ce6926c4f9ed1a913cfb95d7187015d058550b69cf26bdbd42240b8f550646f9ddfeed34c35ac81c7a664c1873152fa4ddd2a5f36ed5eb51
+  checksum: 4c36487123a5a176f2a865b7686b1f7d56930c3991d338be3a47286d7ebce5aac216ecd25e4f548e09e2592506a20e5756e489ed1a63ef93dec425b04295f9a9
   languageName: node
   linkType: hard
 
@@ -3703,17 +3704,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/algorithm@npm:^2.0.0, @lumino/algorithm@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@lumino/algorithm@npm:2.0.3"
+  checksum: 03932cdc39d612a00579ee40bafb0b1d8bf5f8a12449f777a1ae7201843ddefb557bc3f9260aa6b9441d87bfc43e53cced854e71c4737de59e32cd00d4ac1394
+  languageName: node
+  linkType: hard
+
 "@lumino/algorithm@npm:^2.0.1, @lumino/algorithm@npm:^2.0.2":
   version: 2.0.2
   resolution: "@lumino/algorithm@npm:2.0.2"
   checksum: 34b25684b845f1bdbf78ca45ebd99a97b67b2992440c9643aafe5fc5a99fae1ddafa9e5890b246b233dc3a12d9f66aa84afe4a2aac44cf31071348ed217740db
-  languageName: node
-  linkType: hard
-
-"@lumino/algorithm@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@lumino/algorithm@npm:2.0.3"
-  checksum: 03932cdc39d612a00579ee40bafb0b1d8bf5f8a12449f777a1ae7201843ddefb557bc3f9260aa6b9441d87bfc43e53cced854e71c4737de59e32cd00d4ac1394
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a button in message footers to stop streaming.

[record-2025-05-27_17.05.33.webm](https://github.com/user-attachments/assets/b66e64b3-d71d-49d5-ad94-fd873693a7ba)

It adds an handler `InterruptStreamingHandler`, that is called to request to stop streaming from the frontend. This handler updates the `jai_message_interrupted` in tornado settings.
The writer of the message catches this interruption to stop streaming.

### Additional context

Fixes #1297 

Depends on https://github.com/jupyterlab/jupyter-chat/pull/208, to display the button only when it is currently edited. (**EDIT:** merged)

### Question
- When the chat is empty, the button moves down while the message is updated, and can be tricky to catch if the edition is quick. This raise the question of letting it in the message footer.
- Is [chat_handlers/base.py](https://github.com/jupyterlab/jupyter-ai/blob/main/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py) still used, with the personnas ? If not, the changes in this file may be not relevant anymore.
- ~It seems that the `PersonnaAwareness` does not update the awareness, or maybe I missed something.
  I had to disable the `as_custom_client` context to update the state as expected. 
  [personna_awareness_patch.txt](https://github.com/user-attachments/files/20460241/personna_awareness_patch.txt)~ 
  **EDIT:** Fixed with https://github.com/jupyterlab/jupyter-ai/pull/1358
