### PR TITLE
Periodically update the persona awareness to keep it alive

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -275,11 +275,11 @@ class BaseChatHandler:
         TODO: Either properly store & use reply state in YChat, or remove the
         `human_message` argument here.
         """
-        bot = self.ychat.get_user(BOT["username"])
+        bot = self.ychat.get_user(BOT.username)
         if not bot:
-            self.ychat.set_user(User(**BOT))
+            self.ychat.set_user(BOT)
 
-        id = self.ychat.add_message(NewMessage(body=body, sender=BOT["username"]))
+        id = self.ychat.add_message(NewMessage(body=body, sender=BOT.username))
         return id
 
     @property

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/utils/streaming.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/utils/streaming.py
@@ -38,9 +38,9 @@ class ReplyStream:
         self._stream_id: Optional[str] = None
 
     def _set_user(self):
-        bot = self.ychat.get_user(BOT["username"])
+        bot = self.ychat.get_user(BOT.username)
         if not bot:
-            self.ychat.set_user(User(**BOT))
+            self.ychat.set_user(BOT)
 
     def open(self):
         self._set_user()
@@ -60,7 +60,7 @@ class ReplyStream:
         if not self._stream_id:
             self._set_user()
             self._stream_id = self.ychat.add_message(
-                NewMessage(body="", sender=BOT["username"])
+                NewMessage(body="", sender=BOT.username)
             )
 
         self._set_user()
@@ -69,7 +69,7 @@ class ReplyStream:
                 id=self._stream_id,
                 body=chunk,
                 time=time.time(),
-                sender=BOT["username"],
+                sender=BOT.username,
                 raw_time=False,
             ),
             append=True,

--- a/packages/jupyter-ai/jupyter_ai/constants.py
+++ b/packages/jupyter-ai/jupyter_ai/constants.py
@@ -1,8 +1,11 @@
+from jupyterlab_chat.models import User
+
 # The BOT currently has a fixed username, because this username is used has key in chats,
 # it needs to constant. Do we need to change it ?
-BOT = {
-    "username": "5f6a7570-7974-6572-6e61-75742d626f74",
-    "name": "Jupyternaut",
-    "display_name": "Jupyternaut",
-    "initials": "J",
-}
+BOT = User(
+    username="5f6a7570-7974-6572-6e61-75742d626f74",
+    name="Jupyternaut",
+    display_name="Jupyternaut",
+    initials="J",
+    bot=True,
+)

--- a/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
@@ -199,6 +199,7 @@ class BasePersona(ABC):
             name=self.name,
             display_name=self.name,
             avatar_url=self.avatar_path,
+            bot=True,
         )
 
     def as_user_dict(self) -> dict[str, Any]:

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
@@ -119,7 +119,9 @@ class PersonaAwareness:
         Restore the local state if it is not set, and register the user if available.
         """
         if self._heartbeat:
-            self.log.warning("Awareness heartbeat is already running.")
+            self.log.warning(
+                f"Awareness heartbeat is already running for {self._custom_client_id} ({self.user.username})."
+            )
             return
 
         if self.get_local_state() is None:

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
@@ -5,7 +5,6 @@ from dataclasses import asdict
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Optional
 
-from anyio import create_task_group, sleep
 from jupyterlab_chat.models import User
 from jupyterlab_chat.ychat import YChat
 from pycrdt import Awareness

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
@@ -119,8 +119,9 @@ class PersonaAwareness:
         Restore the local state if it is not set, and register the user if available.
         """
         if self._heartbeat:
+            username = self.user.username if self.user else "unknown user"
             self.log.warning(
-                f"Awareness heartbeat is already running for {self._custom_client_id} ({self.user.username})."
+                f"Awareness heartbeat is already running for {self._custom_client_id} ({username})."
             )
             return
 

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
@@ -1,9 +1,12 @@
+from asyncio import Task, TaskGroup, create_task
 import random
 from contextlib import contextmanager
 from dataclasses import asdict
 from logging import Logger
+from time import time
 from typing import TYPE_CHECKING, Any, Optional
 
+from anyio import create_task_group, sleep
 from jupyterlab_chat.models import User
 from jupyterlab_chat.ychat import YChat
 from pycrdt import Awareness
@@ -38,6 +41,7 @@ class PersonaAwareness:
 
     _original_client_id: int
     _custom_client_id: int
+    _heartbeat: Task | None
 
     def __init__(self, *, ychat: YChat, log: Logger, user: Optional[User]):
         # Bind instance attributes
@@ -60,6 +64,8 @@ class PersonaAwareness:
         if self.user:
             self._register_user()
 
+        self._heartbeat = create_task(self._start())
+
     @contextmanager
     def as_custom_client(self) -> "Iterator[None]":
         """
@@ -76,6 +82,32 @@ class PersonaAwareness:
             yield
         finally:
             self.awareness.client_id = self._original_client_id
+
+    @property
+    def outdated_timeout(self) -> int:
+        """
+        Returns the outdated timeout of the document awareness, in milliseconds.
+        """
+        return self.awareness._outdated_timeout
+
+    def _get_time(self) -> int:
+        return int(time() * 1000)
+
+    async def _start(self) -> None:
+        """
+        Starts the awareness heartbeat task, which periodically renews the state.
+        """
+        while True:
+            await sleep(self.outdated_timeout / 1000 / 10)
+            now = self._get_time()
+            local_state = self.get_local_state()
+            if (
+                local_state is not None
+                and self.outdated_timeout / 2 <= now - self.awareness.meta[self._custom_client_id]["lastUpdated"]
+            ):
+                # renew local clock
+                with self.as_custom_client():
+                    self.awareness.set_local_state(local_state)
 
     def _register_user(self):
         if not self.user:

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
@@ -1,5 +1,5 @@
-from asyncio import Task, TaskGroup, create_task
 import random
+from asyncio import Task, create_task
 from contextlib import contextmanager
 from dataclasses import asdict
 from logging import Logger
@@ -103,7 +103,8 @@ class PersonaAwareness:
             local_state = self.get_local_state()
             if (
                 local_state is not None
-                and self.outdated_timeout / 2 <= now - self.awareness.meta[self._custom_client_id]["lastUpdated"]
+                and self.outdated_timeout / 2
+                <= now - self.awareness.meta[self._custom_client_id]["lastUpdated"]
             ):
                 # renew local clock
                 with self.as_custom_client():

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_awareness.py
@@ -41,7 +41,7 @@ class PersonaAwareness:
 
     _original_client_id: int
     _custom_client_id: int
-    _heartbeat: Task | None = None
+    _heartbeat: Optional[Task] = None
 
     def __init__(self, *, ychat: YChat, log: Logger, user: Optional[User]):
         # Bind instance attributes

--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -62,7 +62,7 @@
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@jupyter-notebook/application": "^7.2.0",
-    "@jupyter/chat": "^0.10.0",
+    "@jupyter/chat": "^0.11.0",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.2.0",
     "@jupyterlab/codeeditor": "^4.2.0",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     # traitlets>=5.6 is required in JL4
     "traitlets>=5.6",
     "deepmerge>=2.0,<3",
-    "jupyterlab-chat>=0.10.0,<0.11.0",
+    "jupyterlab-chat>=0.11.0,<0.12.0",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,7 +2237,7 @@ __metadata:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
     "@jupyter-notebook/application": ^7.2.0
-    "@jupyter/chat": ^0.10.0
+    "@jupyter/chat": ^0.11.0
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.2.0
     "@jupyterlab/builder": ^4.2.0
@@ -2322,9 +2322,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/chat@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "@jupyter/chat@npm:0.10.0"
+"@jupyter/chat@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@jupyter/chat@npm:0.11.0"
   dependencies:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
@@ -2346,7 +2346,7 @@ __metadata:
     clsx: ^2.1.0
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: c9b0bc1c39b966a94415f6b95c86bda1a1bedefc654cec051ca6ebd30fc218a31cc1a62628bf2c5b529284cdafd5ce3fe9e15bb9bfdaa21960d47acdc2b66ebd
+  checksum: e7b5c47c94b6afa3ce6926c4f9ed1a913cfb95d7187015d058550b69cf26bdbd42240b8f550646f9ddfeed34c35ac81c7a664c1873152fa4ddd2a5f36ed5eb51
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR add a periodic update of the personna awareness.
This is required to keep the client (personna) in the awareness object, otherwise others clients remove it as inactive (and potentially disconnected).

The personna awareness also listen for change in the document awareness, and stop updating itself if there are only bot clients (other personna).

Fixes #1357