### PR TITLE
Fix the path missing in inline completion  request when there is no kernel

### DIFF
--- a/packages/jupyter-ai/src/completions/provider.ts
+++ b/packages/jupyter-ai/src/completions/provider.ts
@@ -103,7 +103,7 @@ export class JaiInlineProvider
       this._streamPromises.clear();
     }
     const result = await this.options.completionHandler.sendMessage({
-      path: context.session?.path,
+      path,
       mime,
       prefix: this._prefixFromRequest(request),
       suffix: this._suffixFromRequest(request),


### PR DESCRIPTION
Fixes #1359

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/d509c425-1b9d-4a86-bfe3-0040d1841442) | ![image](https://github.com/user-attachments/assets/07eda533-aef2-4a45-802a-27513d0e34af) |

To test you can just switch to "No kernel" or start with:

```
jupyter lab --LabServerApp.notebook_starts_kernel=False
```