### PR TITLE
Raise `jupyterlab-chat` version ceiling

### DIFF
--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # traitlets>=5.6 is required in JL4
     "traitlets>=5.6",
     "deepmerge>=2.0,<3",
-    "jupyterlab-chat>=0.12.0,<0.13.0",
+    "jupyterlab-chat>=0.12.0,<0.14.0",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]


### PR DESCRIPTION
Raises the `jupyterlab-chat` version ceiling to `<0.14.0` to allow usage with an upcoming `jupyterlab-chat==0.13.0` release/pre-release.

The next release will include https://github.com/jupyterlab/jupyter-chat/pull/227, which upgrades to Jupyter Collaboration 4. This does not require any code changes in Jupyter AI, as the Python API provided in `self.settings["jupyter_server_ydoc"]` & the event schemas we use are identical across both major versions.