### PR TITLE
Allow personas to get current chat file path & parent directory

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/models/persona.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/models/persona.py
@@ -1,3 +1,11 @@
+# NOTE: This is the outdated `Persona` model used by Jupyter AI v2.
+# This is deprecated and will be removed by Jupyter AI v3.
+# The latest definition of a persona is located in
+# `jupyter_ai/personas/base_persona.py`.
+#
+# TODO: Delete this file once v3 model API changes are complete. The current model
+# API still depends on this, so that work must be done first.
+
 from pydantic import BaseModel
 
 

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -10,7 +10,7 @@ from jupyter_ai_magics import BaseProvider, JupyternautPersona
 from jupyter_ai_magics.utils import get_em_providers, get_lm_providers
 from jupyter_events import EventLogger
 from jupyter_server.extension.application import ExtensionApp
-from jupyter_server_fileid.manager import BaseFileIdManager
+from jupyter_server_fileid.manager import BaseFileIdManager # type: ignore[import-untyped]
 from jupyterlab_chat.models import Message
 from jupyterlab_chat.ychat import YChat
 from pycrdt import ArrayEvent
@@ -400,6 +400,9 @@ class AiExtension(ExtensionApp):
                 message_interrupted, dict
             )
 
+            assert self.serverapp
+            assert self.serverapp.web_app
+            assert self.serverapp.web_app.settings
             fileid_manager = self.serverapp.web_app.settings.get(
                 "file_id_manager", None
             )

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -10,12 +10,12 @@ from jupyter_ai_magics import BaseProvider, JupyternautPersona
 from jupyter_ai_magics.utils import get_em_providers, get_lm_providers
 from jupyter_events import EventLogger
 from jupyter_server.extension.application import ExtensionApp
+from jupyter_server_fileid.manager import BaseFileIdManager
 from jupyterlab_chat.models import Message
 from jupyterlab_chat.ychat import YChat
-from jupyter_server_fileid.manager import BaseFileIdManager
 from pycrdt import ArrayEvent
 from tornado.web import StaticFileHandler
-from traitlets import Integer, List, Unicode, Type
+from traitlets import Integer, List, Type, Unicode
 
 from .completions.handlers import DefaultInlineCompletionHandler
 from .config_manager import ConfigManager
@@ -76,7 +76,7 @@ class AiExtension(ExtensionApp):
         klass=PersonaManager,
         default_value=PersonaManager,
         config=True,
-        help="The `PersonaManager` class."
+        help="The `PersonaManager` class.",
     )
 
     allowed_providers = List(
@@ -380,7 +380,9 @@ class AiExtension(ExtensionApp):
         """
         # TODO: explore if cleanup is necessary
 
-    def _init_persona_manager(self, room_id: str, ychat: YChat) -> Optional[PersonaManager]:
+    def _init_persona_manager(
+        self, room_id: str, ychat: YChat
+    ) -> Optional[PersonaManager]:
         """
         Initializes a `PersonaManager` instance scoped to a `YChat`.
 
@@ -398,11 +400,13 @@ class AiExtension(ExtensionApp):
                 message_interrupted, dict
             )
 
-            fileid_manager = self.serverapp.web_app.settings.get("file_id_manager", None)
+            fileid_manager = self.serverapp.web_app.settings.get(
+                "file_id_manager", None
+            )
             assert isinstance(fileid_manager, BaseFileIdManager)
 
             contents_manager = self.serverapp.contents_manager
-            root_dir = getattr(contents_manager, 'root_dir')
+            root_dir = getattr(contents_manager, "root_dir", None)
             assert isinstance(root_dir, str)
 
             PersonaManagerClass = self.persona_manager_class

--- a/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
@@ -10,6 +10,7 @@ from jupyterlab_chat.models import Message, NewMessage, User
 from jupyterlab_chat.ychat import YChat
 from pydantic import BaseModel
 from traitlets.config import LoggingConfigurable
+from traitlets import MetaHasTraits
 
 from .persona_awareness import PersonaAwareness
 
@@ -45,7 +46,7 @@ class PersonaDefaults(BaseModel):
     # ^^^ set this to automatically default to a model after a fresh start, no config file
 
 
-class ABCLoggingConfigurableMeta(ABCMeta, type(LoggingConfigurable)):  # type: ignore
+class ABCLoggingConfigurableMeta(ABCMeta, MetaHasTraits):
     """
     Metaclass required for `BasePersona` to inherit from both `ABC` and
     `LoggingConfigurable`. This pattern is also followed by `BaseFileIdManager`
@@ -64,7 +65,7 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
     Automatically set by `BasePersona`.
     """
 
-    parent: "PersonaManager"
+    parent: "PersonaManager" # type: ignore
     """
     Reference to the `PersonaManager` for this `YChat`, which manages this
     instance. Automatically set by the `LoggingConfigurable` parent class.
@@ -76,7 +77,7 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
     the Jupyter AI settings. Automatically set by `BasePersona`.
     """
 
-    log: Logger
+    log: Logger # type: ignore
     """
     The `logging.Logger` instance used by this class. Automatically set by the
     `LoggingConfigurable` parent class.

--- a/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
@@ -17,7 +17,9 @@ from .persona_awareness import PersonaAwareness
 # types imported under this block have to be surrounded in single quotes on use
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+
     from .persona_manager import PersonaManager
+
 
 class PersonaDefaults(BaseModel):
     """
@@ -49,7 +51,6 @@ class ABCLoggingConfigurableMeta(ABCMeta, type(LoggingConfigurable)):  # type: i
     `LoggingConfigurable`. This pattern is also followed by `BaseFileIdManager`
     from `jupyter_server_fileid`.
     """
-    pass
 
 
 class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta):
@@ -316,11 +317,11 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
         Returns the latest path of the chat file assigned to this persona. This
         path is relative to the root directory set by `ContentsManager.root_dir`
         by default.
-        
+
         To get an absolute path, call this method with `absolute=True`.
         """
         return self.parent.get_chat_path(absolute=absolute)
-    
+
     def get_chat_dir(self) -> str:
         """
         Returns the absolute path to the parent directory of the chat file

--- a/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
@@ -311,6 +311,23 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
         """
         self.ychat.add_message(NewMessage(body=body, sender=self.id))
 
+    def get_chat_path(self, absolute: bool = False) -> str:
+        """
+        Returns the latest path of the chat file assigned to this persona. This
+        path is relative to the root directory set by `ContentsManager.root_dir`
+        by default.
+        
+        To get an absolute path, call this method with `absolute=True`.
+        """
+        return self.parent.get_chat_path(absolute=absolute)
+    
+    def get_chat_dir(self) -> str:
+        """
+        Returns the absolute path to the parent directory of the chat file
+        assigned to this persona.
+        """
+        return self.parent.get_chat_dir()
+
 
 class GenerationInterrupted(asyncio.CancelledError):
     """Exception raised when streaming is cancelled by the user"""

--- a/packages/jupyter-ai/jupyter_ai/personas/jupyternaut/jupyternaut.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/jupyternaut/jupyternaut.py
@@ -27,8 +27,8 @@ class JupyternautPersona(BasePersona):
         )
 
     async def process_message(self, message: Message) -> None:
-        provider_name = self.config.lm_provider.name
-        model_id = self.config.lm_provider_params["model_id"]
+        provider_name = self.config_manager.lm_provider.name
+        model_id = self.config_manager.lm_provider_params["model_id"]
 
         runnable = self.build_runnable()
         variables = JupyternautVariables(
@@ -43,7 +43,7 @@ class JupyternautPersona(BasePersona):
 
     def build_runnable(self) -> Any:
         # TODO: support model parameters. maybe we just add it to lm_provider_params in both 2.x and 3.x
-        llm = self.config.lm_provider(**self.config.lm_provider_params)
+        llm = self.config_manager.lm_provider(**self.config_manager.lm_provider_params)
         runnable = JUPYTERNAUT_PROMPT_TEMPLATE | llm | StrOutputParser()
 
         runnable = RunnableWithMessageHistory(

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -17,7 +17,7 @@ from .base_persona import BasePersona
 if TYPE_CHECKING:
     from asyncio import AbstractEventLoop
 
-    from jupyter_server_fileid.manager import BaseFileIdManager
+    from jupyter_server_fileid.manager import BaseFileIdManager # type: ignore[import-untyped]
 
 # EPG := entry point group
 EPG_NAME = "jupyter_ai.personas"
@@ -35,7 +35,7 @@ class PersonaManager(LoggingConfigurable):
     root_dir: str
     event_loop: AbstractEventLoop
 
-    log: Logger
+    log: Logger # type: ignore
     """
     The `logging.Logger` instance used by this class. This is automatically set
     by the `LoggingConfigurable` parent class; this declaration only hints the

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -155,10 +155,9 @@ class PersonaManager(LoggingConfigurable):
         for Persona in persona_classes:
             try:
                 persona = Persona(
+                    parent=self,
                     ychat=self.ychat,
-                    manager=self,
-                    config=self.config_manager,
-                    log=self.log,
+                    config_manager=self.config_manager,
                     message_interrupted=self.message_interrupted,
                 )
             except Exception:


### PR DESCRIPTION
## Description

- Implements `get_chat_path()` and `get_chat_dir()` on `PersonaManager` and `BasePersona`.
- Makes `PersonaManager` a `LoggingConfigurable` traitlets object.
- Makes `BasePersona` a `LoggingConfigurable` traitlets object.
- Adds the `AiExtension.persona_manager_class` trait to allow developers to customize the `PersonaManager` being used.

This PR will be used alongside #1376 to provide a `.jupyter` directory where users can store configuration for AI personas and other use-cases. These will inherit from other `.jupyter` directories in their parent directories, up to the root folder `/`.