### PR TITLE
Load personas dynamically from `.jupyter` dir

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -323,6 +323,7 @@ def load_from_dir(root_dir: str, log: Logger) -> list[type[BasePersona]]:
     """
     persona_classes: list[type[BasePersona]] = []
 
+    log.info(f"Loading persona files from {root_dir}")
     # Check if root directory exists
     if not os.path.exists(root_dir):
         return persona_classes
@@ -366,6 +367,7 @@ def load_from_dir(root_dir: str, log: Logger) -> list[type[BasePersona]]:
                     and obj is not BasePersona
                     and obj.__module__ == module_name
                 ):
+                    log.info(f"Found persona class '{obj.__name__}' in '{py_file}'")
                     persona_classes.append(obj)
 
         except Exception as e:
@@ -376,3 +378,4 @@ def load_from_dir(root_dir: str, log: Logger) -> list[type[BasePersona]]:
             continue
 
     return persona_classes
+

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -373,9 +373,7 @@ def load_from_dir(root_dir: str, log: Logger) -> list[type[BasePersona]]:
 
         except Exception as e:
             # On exception, log error and continue to next file
-            # This mirrors the error handling pattern from entry point loading
-            log.error(f"Unable to load persona classes from '{py_file}'")
-            log.error(f"Error was: {type(e).__name__}: {e} - Unable to load persona classes from '{py_file}'")
+            log.exception(f"Unable to load persona classes from '{py_file}', exception details printed below.")
             continue
 
     return persona_classes

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -335,14 +335,15 @@ class LocalPersonaLoader(LoggingConfigurable):
             self.log.info(f"Root directory does not exist: {self.root_dir}")
             return persona_classes
         
-        # Find all .py files in the root directory
-        py_files = glob(os.path.join(self.root_dir, "*.py"))
+        # Find all .py files in the root directory that contain "persona" in the name
+        all_py_files = glob(os.path.join(self.root_dir, "*.py"))
+        py_files = [f for f in all_py_files if "persona" in Path(f).stem.lower()]
         
         if not py_files:
-            self.log.info(f"No Python files found in directory: {self.root_dir}")
+            self.log.info(f"No Python files with 'persona' in the name found in directory: {self.root_dir}")
             return persona_classes
         
-        self.log.info(f"Found {len(py_files)} Python files in {self.root_dir}")
+        self.log.info(f"Found {len(py_files)} Python files with 'persona' in the name in {self.root_dir}")
         self.log.info("PENDING: Loading persona classes from local Python files...")
         start_time_ns = time_ns()
         

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -347,7 +347,7 @@ def load_from_dir(root_dir: str, log: Logger) -> list[type[BasePersona]]:
             module_name = Path(py_file).stem
 
             # Skip if module name starts with underscore (private modules)
-            if module_name.startswith("_"):
+            if module_name.startswith("_") or module_name.startswith("."):
                 continue
 
             # Create module spec and load the module

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -52,7 +52,11 @@ class PersonaManager(LoggingConfigurable):
     type for type checkers.
     """
 
-    _persona_classes: ClassVar[list[type[BasePersona]] | None] = None
+    # TODO: the Persona classes from entry points should be stored as a class
+    # attribute, since they will not change at runtime.
+    # That should be injected into this instance attribute when personas defined
+    # under `.jupyter` are loaded.
+    _persona_classes: list[type[BasePersona]] | None = None
     _personas: dict[str, BasePersona]
     file_id: str
 
@@ -152,7 +156,11 @@ class PersonaManager(LoggingConfigurable):
             )
 
         # Load persona classes from local filesystem
-        persona_classes.extend(load_from_dir(self.get_dotjupyter_dir(), self.log))
+        dotjupyter_dir = self.get_dotjupyter_dir()
+        if dotjupyter_dir is None:
+            self.log.info("No .jupyter directory found for loading local personas.")
+        else:
+            persona_classes.extend(load_from_dir(dotjupyter_dir, self.log))
 
         self._persona_classes = persona_classes
 

--- a/packages/jupyter-ai/jupyter_ai/tests/test_personas.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_personas.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 from jupyter_ai.personas.base_persona import BasePersona, PersonaDefaults
-from jupyter_ai.personas.persona_manager import load_persona_classes_from_directory
+from jupyter_ai.personas.persona_manager import load_from_dir
 
 
 @pytest.fixture
@@ -18,11 +18,11 @@ def tmp_persona_dir():
 
 
 class TestLoadPersonaClassesFromDirectory:
-    """Test cases for load_persona_classes_from_directory function."""
+    """Test cases for load_from_dir function."""
 
     def test_empty_directory_returns_empty_list(self, tmp_persona_dir):
         """Test that an empty directory returns an empty list of persona classes."""
-        result = load_persona_classes_from_directory(str(tmp_persona_dir))
+        result = load_from_dir(str(tmp_persona_dir))
         assert result == []
 
     def test_non_persona_file_returns_empty_list(self, tmp_persona_dir):
@@ -31,7 +31,7 @@ class TestLoadPersonaClassesFromDirectory:
         non_persona_file = tmp_persona_dir / "no_personas.py"
         non_persona_file.write_text("pass")
 
-        result = load_persona_classes_from_directory(str(tmp_persona_dir))
+        result = load_from_dir(str(tmp_persona_dir))
         assert result == []
 
     def test_simple_persona_file_returns_persona_class(self, tmp_persona_dir):
@@ -51,7 +51,7 @@ class TestPersona(BasePersona):
 """
         persona_file.write_text(persona_content)
 
-        result = load_persona_classes_from_directory(str(tmp_persona_dir))
+        result = load_from_dir(str(tmp_persona_dir))
 
         assert len(result) == 1
         assert result[0].__name__ == "TestPersona"
@@ -63,6 +63,6 @@ class TestPersona(BasePersona):
         bad_persona_file = tmp_persona_dir / "bad_persona.py"
         bad_persona_file.write_text("1/0")
 
-        result = load_persona_classes_from_directory(str(tmp_persona_dir))
+        result = load_from_dir(str(tmp_persona_dir))
 
         assert result == []

--- a/packages/jupyter-ai/jupyter_ai/tests/test_personas.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_personas.py
@@ -1,0 +1,77 @@
+"""
+Test the local persona manager.
+"""
+
+import pytest
+import tempfile
+from pathlib import Path
+
+from jupyter_ai.personas.base_persona import BasePersona, PersonaDefaults
+from jupyter_ai.personas.persona_manager import LocalPersonaLoader
+
+
+@pytest.fixture
+def tmp_persona_dir():
+    """Create a temporary directory for testing LocalPersonaLoader with guaranteed cleanup."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield Path(temp_dir)
+
+
+class TestLocalPersonaLoader:
+    """Test cases for LocalPersonaLoader class."""
+    
+    def test_empty_directory_returns_empty_list(self, tmp_persona_dir):
+        """Test that an empty directory returns an empty list of persona classes."""
+        loader = LocalPersonaLoader(root_dir=str(tmp_persona_dir))
+        result = loader.load_persona_classes()
+        assert result == []
+    
+    def test_non_persona_file_returns_empty_list(self, tmp_persona_dir):
+        """Test that a Python file without persona classes returns an empty list."""
+        # Create a file that doesn't contain "persona" in the name
+        non_persona_file = tmp_persona_dir / "no_personas.py"
+        non_persona_file.write_text("pass")
+        
+        loader = LocalPersonaLoader(root_dir=str(tmp_persona_dir))
+        result = loader.load_persona_classes()
+        assert result == []
+    
+    def test_simple_persona_file_returns_persona_class(self, tmp_persona_dir):
+        """Test that a file with a BasePersona subclass returns that class."""
+        # Create a simple persona file
+        persona_file = tmp_persona_dir / "simple_personas.py"
+        persona_content = '''
+from jupyter_ai.personas.base_persona import BasePersona
+
+class TestPersona(BasePersona):
+    id = "test_persona"
+    name = "Test Persona"
+    description = "A simple test persona"
+    
+    def process_message(self, message):
+        pass
+'''
+        persona_file.write_text(persona_content)
+        
+        loader = LocalPersonaLoader(root_dir=str(tmp_persona_dir))
+        result = loader.load_persona_classes()
+        
+        assert len(result) == 1
+        assert result[0].__name__ == "TestPersona"
+        assert issubclass(result[0], BasePersona)
+    
+    def test_bad_persona_file_logs_exception_returns_empty_list(self, tmp_persona_dir, caplog):
+        """Test that a file with syntax errors logs an exception and returns empty list."""
+        # Create a file with invalid Python code
+        bad_persona_file = tmp_persona_dir / "bad_persona.py" 
+        bad_persona_file.write_text("1/0")
+        
+        loader = LocalPersonaLoader(root_dir=str(tmp_persona_dir))
+        result = loader.load_persona_classes()
+                
+        assert result == []
+        # Check that an error was logged
+        assert any("Unable to load persona classes from" in record.message 
+                  for record in caplog.records if record.levelname in ["ERROR", "EXCEPTION"])
+
+

--- a/packages/jupyter-ai/jupyter_ai/tests/test_personas.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_personas.py
@@ -2,10 +2,10 @@
 Test the local persona manager.
 """
 
-import pytest
 import tempfile
 from pathlib import Path
 
+import pytest
 from jupyter_ai.personas.base_persona import BasePersona, PersonaDefaults
 from jupyter_ai.personas.persona_manager import LocalPersonaLoader
 
@@ -19,59 +19,62 @@ def tmp_persona_dir():
 
 class TestLocalPersonaLoader:
     """Test cases for LocalPersonaLoader class."""
-    
+
     def test_empty_directory_returns_empty_list(self, tmp_persona_dir):
         """Test that an empty directory returns an empty list of persona classes."""
         loader = LocalPersonaLoader(root_dir=str(tmp_persona_dir))
         result = loader.load_persona_classes()
         assert result == []
-    
+
     def test_non_persona_file_returns_empty_list(self, tmp_persona_dir):
         """Test that a Python file without persona classes returns an empty list."""
         # Create a file that doesn't contain "persona" in the name
         non_persona_file = tmp_persona_dir / "no_personas.py"
         non_persona_file.write_text("pass")
-        
+
         loader = LocalPersonaLoader(root_dir=str(tmp_persona_dir))
         result = loader.load_persona_classes()
         assert result == []
-    
+
     def test_simple_persona_file_returns_persona_class(self, tmp_persona_dir):
         """Test that a file with a BasePersona subclass returns that class."""
         # Create a simple persona file
         persona_file = tmp_persona_dir / "simple_personas.py"
-        persona_content = '''
+        persona_content = """
 from jupyter_ai.personas.base_persona import BasePersona
 
 class TestPersona(BasePersona):
     id = "test_persona"
     name = "Test Persona"
     description = "A simple test persona"
-    
+
     def process_message(self, message):
         pass
-'''
+"""
         persona_file.write_text(persona_content)
-        
+
         loader = LocalPersonaLoader(root_dir=str(tmp_persona_dir))
         result = loader.load_persona_classes()
-        
+
         assert len(result) == 1
         assert result[0].__name__ == "TestPersona"
         assert issubclass(result[0], BasePersona)
-    
-    def test_bad_persona_file_logs_exception_returns_empty_list(self, tmp_persona_dir, caplog):
+
+    def test_bad_persona_file_logs_exception_returns_empty_list(
+        self, tmp_persona_dir, caplog
+    ):
         """Test that a file with syntax errors logs an exception and returns empty list."""
         # Create a file with invalid Python code
-        bad_persona_file = tmp_persona_dir / "bad_persona.py" 
+        bad_persona_file = tmp_persona_dir / "bad_persona.py"
         bad_persona_file.write_text("1/0")
-        
+
         loader = LocalPersonaLoader(root_dir=str(tmp_persona_dir))
         result = loader.load_persona_classes()
-                
+
         assert result == []
         # Check that an error was logged
-        assert any("Unable to load persona classes from" in record.message 
-                  for record in caplog.records if record.levelname in ["ERROR", "EXCEPTION"])
-
-
+        assert any(
+            "Unable to load persona classes from" in record.message
+            for record in caplog.records
+            if record.levelname in ["ERROR", "EXCEPTION"]
+        )

--- a/packages/jupyter-ai/jupyter_ai/tests/test_personas.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_personas.py
@@ -4,6 +4,7 @@ Test the local persona manager.
 
 import tempfile
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 from jupyter_ai.personas.base_persona import BasePersona, PersonaDefaults
@@ -17,24 +18,30 @@ def tmp_persona_dir():
         yield Path(temp_dir)
 
 
+@pytest.fixture
+def mock_logger():
+    """Create a mock logger for testing."""
+    return Mock()
+
+
 class TestLoadPersonaClassesFromDirectory:
     """Test cases for load_from_dir function."""
 
-    def test_empty_directory_returns_empty_list(self, tmp_persona_dir):
+    def test_empty_directory_returns_empty_list(self, tmp_persona_dir, mock_logger):
         """Test that an empty directory returns an empty list of persona classes."""
-        result = load_from_dir(str(tmp_persona_dir))
+        result = load_from_dir(str(tmp_persona_dir), mock_logger)
         assert result == []
-
-    def test_non_persona_file_returns_empty_list(self, tmp_persona_dir):
+    
+    def test_non_persona_file_returns_empty_list(self, tmp_persona_dir, mock_logger):
         """Test that a Python file without persona classes returns an empty list."""
         # Create a file that doesn't contain "persona" in the name
         non_persona_file = tmp_persona_dir / "no_personas.py"
         non_persona_file.write_text("pass")
-
-        result = load_from_dir(str(tmp_persona_dir))
+        
+        result = load_from_dir(str(tmp_persona_dir), mock_logger)
         assert result == []
-
-    def test_simple_persona_file_returns_persona_class(self, tmp_persona_dir):
+    
+    def test_simple_persona_file_returns_persona_class(self, tmp_persona_dir, mock_logger):
         """Test that a file with a BasePersona subclass returns that class."""
         # Create a simple persona file
         persona_file = tmp_persona_dir / "simple_personas.py"
@@ -45,24 +52,24 @@ class TestPersona(BasePersona):
     id = "test_persona"
     name = "Test Persona"
     description = "A simple test persona"
-
+    
     def process_message(self, message):
         pass
 """
         persona_file.write_text(persona_content)
-
-        result = load_from_dir(str(tmp_persona_dir))
-
+        
+        result = load_from_dir(str(tmp_persona_dir), mock_logger)
+        
         assert len(result) == 1
         assert result[0].__name__ == "TestPersona"
         assert issubclass(result[0], BasePersona)
-
-    def test_bad_persona_file_returns_empty_list(self, tmp_persona_dir):
+    
+    def test_bad_persona_file_returns_empty_list(self, tmp_persona_dir, mock_logger):
         """Test that a file with syntax errors returns empty list."""
         # Create a file with invalid Python code
-        bad_persona_file = tmp_persona_dir / "bad_persona.py"
+        bad_persona_file = tmp_persona_dir / "bad_persona.py" 
         bad_persona_file.write_text("1/0")
-
-        result = load_from_dir(str(tmp_persona_dir))
-
+        
+        result = load_from_dir(str(tmp_persona_dir), mock_logger)
+        
         assert result == []


### PR DESCRIPTION
Draft PR to get a first look at the approach, will refine based on early feedback before proper review.

Implements a local persona loader that targets pure python files with `persona` in the name, and loads all personas in those files that subclass `BasePersona`. 

This is meant to be called by the main `PersonaManager` class safely.

## Follow-up issues

- #1395