### PR TITLE
Upgrade to Jupyter Chat v0.14.0

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -92,7 +92,6 @@ class PersonaManager(LoggingConfigurable):
             assert isinstance(PersonaManager._persona_classes, list)
 
         self._personas = self._init_personas()
-        self.log.error(self.get_chat_dir())
 
     def _init_persona_classes(self) -> None:
         """

--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -62,7 +62,7 @@
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@jupyter-notebook/application": "^7.2.0",
-    "@jupyter/chat": "^0.12.0",
+    "@jupyter/chat": "^0.14.0",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.2.0",
     "@jupyterlab/codeeditor": "^4.2.0",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -22,9 +22,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    # jupyter_server>=2.4 is required in JL4
-    # jupyter_server>=2.11.1 is required by jupyter_server_ydoc>=3
-    "jupyter_server>=2.11.1,<3",
+    # `jupyter_collaboration>=4` requires `jupyter_server_ydoc>=2.0.0`,
+    # which requires `jupyter_server>=2.15.0`.
+    "jupyter_server>=2.15.0,<3",
     "importlib_metadata>=5.2.0",
     # pydantic <2.10.0 raises a "protected namespaces" error in JAI
     # - See: https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.protected_namespaces
@@ -40,9 +40,9 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
 test = [
-    # jupyter_server>=2.4 is required in JL4
-    # jupyter_server>=2.11.1 is required by jupyter_server_ydoc>=3
-    "jupyter_server[test]>=2.11.1,<3",
+    # `jupyter_collaboration>=4` requires `jupyter_server_ydoc>=2.0.0`,
+    # which requires `jupyter_server>=2.15.0`.
+    "jupyter_server[test]>=2.15.0,<3",
     "coverage",
     "pytest",
     "pytest-asyncio",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # traitlets>=5.6 is required in JL4
     "traitlets>=5.6",
     "deepmerge>=2.0,<3",
-    "jupyterlab-chat>=0.12.0,<0.14.0",
+    "jupyterlab-chat>=0.14.0,<0.15.0",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]

--- a/packages/jupyter-ai/src/chat-commands/context-commands.tsx
+++ b/packages/jupyter-ai/src/chat-commands/context-commands.tsx
@@ -151,8 +151,14 @@ async function getPathCompletions(
   docRegistry: DocumentRegistry,
   searchPath: string
 ): Promise<ChatCommand[]> {
+  // get parent directory & the partial basename to be completed
   const [parentPath, basename] = getParentAndBase(searchPath);
-  const parentDir = await contentsManager.get(parentPath);
+
+  // query the parent directory through the CM, un-escaping spaces beforehand
+  const parentDir = await contentsManager.get(
+    parentPath.replaceAll('\\ ', ' ')
+  );
+
   const commands: ChatCommand[] = [];
 
   if (!Array.isArray(parentDir.content)) {
@@ -181,9 +187,9 @@ async function getPathCompletions(
     // get icon
     const { icon } = docRegistry.getFileTypeForModel(child);
 
-    // calculate completion string, escaping ' ' characters
+    // calculate completion string, escaping any unescaped spaces
     let completion = '@file:' + parentPath + child.name;
-    completion = completion.replaceAll(' ', '\\ ');
+    completion = completion.replaceAll(/(?<!\\) /g, '\\ ');
 
     // add command completion to the list
     let newCommand: ChatCommand;

--- a/packages/jupyter-ai/src/chat-commands/context-commands.tsx
+++ b/packages/jupyter-ai/src/chat-commands/context-commands.tsx
@@ -3,6 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import React from 'react';
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import type { Contents } from '@jupyterlab/services';
 import type { DocumentRegistry } from '@jupyterlab/docregistry';
@@ -12,6 +13,7 @@ import {
   IInputModel,
   ChatCommand
 } from '@jupyter/chat';
+import FindInPage from '@mui/icons-material/FindInPage';
 
 const CONTEXT_COMMANDS_PROVIDER_ID =
   '@jupyter-ai/core:context-commands-provider';
@@ -21,17 +23,18 @@ const CONTEXT_COMMANDS_PROVIDER_ID =
  */
 export class ContextCommandsProvider implements IChatCommandProvider {
   public id: string = CONTEXT_COMMANDS_PROVIDER_ID;
-  private _context_commands: ChatCommand[] = [
-    // TODO: add an icon!
-    // import FindInPage from '@mui/icons-material/FindInPage';
-    // may need to change the API to allow JSX els as icons
-    {
-      name: '@file',
-      providerId: this.id,
-      replaceWith: '@file:',
-      description: 'Include a file with your prompt'
-    }
-  ];
+
+  /**
+   * Regex that matches all valid `@file` calls. The first capturing group
+   * captures the path specified by the user. Paths may contain any combination
+   * of:
+   *
+   * `[a-zA-Z0-9], '/', '-', '_', '.', '@', '\\ ' (escaped space)`
+   *
+   * IMPORTANT: `+` ensures this regex only matches an occurrence of "@file:" if
+   * the captured path is non-empty.
+   */
+  _regex: RegExp = /@file:(([\w/\-_.@]|\\ )+)/g;
 
   constructor(
     contentsManager: Contents.IManager,
@@ -41,7 +44,9 @@ export class ContextCommandsProvider implements IChatCommandProvider {
     this._docRegistry = docRegistry;
   }
 
-  async getChatCommands(inputModel: IInputModel) {
+  async listCommandCompletions(
+    inputModel: IInputModel
+  ): Promise<ChatCommand[]> {
     // do nothing if the current word does not start with '@'.
     const currentWord = inputModel.currentWord;
     if (!currentWord || !currentWord.startsWith('@')) {
@@ -49,7 +54,7 @@ export class ContextCommandsProvider implements IChatCommandProvider {
     }
 
     // if the current word starts with `@file:`, return a list of valid file
-    // paths.
+    // paths that complete the currently specified path.
     if (currentWord.startsWith('@file:')) {
       const searchPath = currentWord.split('@file:')[1];
       const commands = await getPathCompletions(
@@ -60,19 +65,55 @@ export class ContextCommandsProvider implements IChatCommandProvider {
       return commands;
     }
 
-    // otherwise, a context command has not yet been specified. return a list of
-    // valid context commands.
-    const commands = this._context_commands.filter(cmd =>
-      cmd.name.startsWith(currentWord)
-    );
-    return commands;
+    // if the current word matches the start of @file, complete it
+    if ('@file'.startsWith(currentWord)) {
+      return [
+        {
+          name: '@file:',
+          providerId: this.id,
+          description: 'Include a file with your prompt',
+          icon: <FindInPage />
+        }
+      ];
+    }
+
+    // otherwise, return nothing as this provider cannot provide any completions
+    // for the current word.
+    return [];
   }
 
-  async handleChatCommand(
-    command: ChatCommand,
-    inputModel: IInputModel
-  ): Promise<void> {
-    // no handling needed because `replaceWith` is set in each command.
+  async onSubmit(inputModel: IInputModel): Promise<void> {
+    // search entire input for valid @file commands using `this._regex`
+    const matches = Array.from(inputModel.value.matchAll(this._regex));
+
+    // aggregate all file paths specified by @file commands in the input
+    const paths: string[] = [];
+    for (const match of matches) {
+      if (match.length < 2) {
+        continue;
+      }
+      // `this._regex` contains exactly 1 group that captures the path, so
+      // match[1] will contain the path specified by a @file command.
+      paths.push(match[1]);
+    }
+
+    // add each specified file path as an attachment, unescaping ' ' characters
+    // before doing so
+    for (let path of paths) {
+      path = path.replaceAll('\\ ', ' ');
+      inputModel.addAttachment?.({
+        type: 'file',
+        value: path
+      });
+    }
+
+    // replace each @file command with the path in an inline Markdown code block
+    // for readability, both to humans & to the AI.
+    inputModel.value = inputModel.value.replaceAll(
+      this._regex,
+      (command, path) => `\`${path}\``
+    );
+
     return;
   }
 
@@ -109,7 +150,7 @@ async function getPathCompletions(
   contentsManager: Contents.IManager,
   docRegistry: DocumentRegistry,
   searchPath: string
-) {
+): Promise<ChatCommand[]> {
   const [parentPath, basename] = getParentAndBase(searchPath);
   const parentDir = await contentsManager.get(parentPath);
   const commands: ChatCommand[] = [];
@@ -140,17 +181,20 @@ async function getPathCompletions(
     // get icon
     const { icon } = docRegistry.getFileTypeForModel(child);
 
-    // compute list of results, while handling directories and non-directories
-    // appropriately.
-    const isDirectory = child.type === 'directory';
+    // calculate completion string, escaping ' ' characters
+    let completion = '@file:' + parentPath + child.name;
+    completion = completion.replaceAll(' ', '\\ ');
+
+    // add command completion to the list
     let newCommand: ChatCommand;
+    const isDirectory = child.type === 'directory';
     if (isDirectory) {
       newCommand = {
         name: child.name + '/',
         providerId: CONTEXT_COMMANDS_PROVIDER_ID,
         icon,
         description: 'Search this directory',
-        replaceWith: '@file:' + parentPath + child.name + '/'
+        replaceWith: completion + '/'
       };
     } else {
       newCommand = {
@@ -158,7 +202,8 @@ async function getPathCompletions(
         providerId: CONTEXT_COMMANDS_PROVIDER_ID,
         icon,
         description: 'Attach this file',
-        replaceWith: '@file:' + parentPath + child.name + ' '
+        replaceWith: completion,
+        spaceOnAccept: true
       };
     }
     commands.push(newCommand);

--- a/packages/jupyter-ai/tsconfig.json
+++ b/packages/jupyter-ai/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "strictNullChecks": true,
     "skipLibCheck": true,
-    "target": "ES2018",
+    "target": "es2021",
     "types": ["jest"]
   },
   "include": ["src/**/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,7 +2237,7 @@ __metadata:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
     "@jupyter-notebook/application": ^7.2.0
-    "@jupyter/chat": ^0.12.0
+    "@jupyter/chat": ^0.14.0
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.2.0
     "@jupyterlab/builder": ^4.2.0
@@ -2322,15 +2322,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/chat@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "@jupyter/chat@npm:0.12.0"
+"@jupyter/chat@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "@jupyter/chat@npm:0.14.0"
   dependencies:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
     "@jupyter/react-components": ^0.15.2
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.3.0
+    "@jupyterlab/codeeditor": ^4.2.0
+    "@jupyterlab/codemirror": ^4.2.0
     "@jupyterlab/docmanager": ^4.2.0
     "@jupyterlab/filebrowser": ^4.2.0
     "@jupyterlab/fileeditor": ^4.2.0
@@ -2347,7 +2349,7 @@ __metadata:
     clsx: ^2.1.0
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 4c36487123a5a176f2a865b7686b1f7d56930c3991d338be3a47286d7ebce5aac216ecd25e4f548e09e2592506a20e5756e489ed1a63ef93dec425b04295f9a9
+  checksum: a3a4e4156cac707a70f7e9d77ef0bedf4000fcd052a7dd3d6a13f210e160d0ebfc5b03837ba12efe134aa1cde1e76755e01a48887e9fc4e3db94a80bdc760d22
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Fixes #1364 
- Fixes #1365 

This PR upgrades to Jupyter Chat v0.14.0, which includes fixes for the `@`-mention feature. This PR also upgrades the `@file` command:

- Uses the new v0.14.0 chat commands API to ensure all calls to `@file` run when a new message is sent (even if typed literally / pasted).
- Fixes handling of files with names containing ' ' spaces by escaping them in the input.
- Replaces `@file:path` with `path` inside an inline code block upon sending the message, improving readability of the prompt to both humans & AI personas.

However, this PR requires more upstream changes in Jupyter Chat to work due to a multitude of small errors. These bugs are being tracked here: https://github.com/jupyterlab/jupyter-chat/issues/241.

I am already working on contributing fixes for these bugs upstream.