### PR TITLE
Hide backslashes in `@file` paths with spaces

### DIFF
--- a/packages/jupyter-ai/src/chat-commands/context-commands.tsx
+++ b/packages/jupyter-ai/src/chat-commands/context-commands.tsx
@@ -111,7 +111,7 @@ export class ContextCommandsProvider implements IChatCommandProvider {
     // for readability, both to humans & to the AI.
     inputModel.value = inputModel.value.replaceAll(
       this._regex,
-      (command, path) => `\`${path}\``
+      (_, path) => `\`${path.replaceAll('\\ ', ' ')}\``
     );
 
     return;


### PR DESCRIPTION
## Problem
When using `@file:` with paths containing spaces (e.g., `@file:my     nb.ipynb`), the backslash escapes remain visible in the rendered message making paths harder to read.

## Solution
Don't render backslash escape characters in file paths in sent messages.

Before this PR:
<img width="461" alt="Screenshot 2025-06-26 at 9 50 21 AM" src="https://github.com/user-attachments/assets/8698d0b9-4beb-42cf-8ff0-31601f5ebb57" />


After this PR:
<img width="466" alt="Screenshot 2025-06-26 at 9 50 35 AM" src="https://github.com/user-attachments/assets/6c56757b-2a6a-4d91-9148-e24b62df995d" />

