### PR TITLE
Add ignore globs for hidden files in CM config

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -442,20 +442,20 @@ class AiExtension(ExtensionApp):
         c = Config()
         c.ContentsManager.allow_hidden = True
         c.ContentsManager.hide_globs = [
-            "__pycache__",          # Python bytecode cache directories
-            "*.pyc",                # Compiled Python files
-            "*.pyo",                # Optimized Python files
-            ".DS_Store",            # macOS system files
-            "*~",                   # Editor backup files
-            ".ipynb_checkpoints",   # Jupyter notebook checkpoint files
-            ".git",                 # Git version control directory
-            ".venv",                # Python virtual environment directory
-            "venv",                 # Python virtual environment directory
-            ".env",                 # Environment variable files
-            "node_modules",         # Node.js dependencies directory
-            ".pytest_cache",        # PyTest cache directory
-            ".mypy_cache",          # MyPy type checker cache directory
-            "*.egg-info"            # Python package metadata directories
+            "__pycache__",  # Python bytecode cache directories
+            "*.pyc",  # Compiled Python files
+            "*.pyo",  # Optimized Python files
+            ".DS_Store",  # macOS system files
+            "*~",  # Editor backup files
+            ".ipynb_checkpoints",  # Jupyter notebook checkpoint files
+            ".git",  # Git version control directory
+            ".venv",  # Python virtual environment directory
+            "venv",  # Python virtual environment directory
+            ".env",  # Environment variable files
+            "node_modules",  # Node.js dependencies directory
+            ".pytest_cache",  # PyTest cache directory
+            ".mypy_cache",  # MyPy type checker cache directory
+            "*.egg-info",  # Python package metadata directories
         ]
         server_app.update_config(c)
         super()._link_jupyter_server_extension(server_app)

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -441,5 +441,21 @@ class AiExtension(ExtensionApp):
         """Setup custom config needed by this extension."""
         c = Config()
         c.ContentsManager.allow_hidden = True
+        c.ContentsManager.hide_globs = [
+            "__pycache__",          # Python bytecode cache directories
+            "*.pyc",                # Compiled Python files
+            "*.pyo",                # Optimized Python files
+            ".DS_Store",            # macOS system files
+            "*~",                   # Editor backup files
+            ".ipynb_checkpoints",   # Jupyter notebook checkpoint files
+            ".git",                 # Git version control directory
+            ".venv",                # Python virtual environment directory
+            "venv",                 # Python virtual environment directory
+            ".env",                 # Environment variable files
+            "node_modules",         # Node.js dependencies directory
+            ".pytest_cache",        # PyTest cache directory
+            ".mypy_cache",          # MyPy type checker cache directory
+            "*.egg-info"            # Python package metadata directories
+        ]
         server_app.update_config(c)
         super()._link_jupyter_server_extension(server_app)

--- a/packages/jupyter-ai/jupyter_ai/tests/test_personas.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_personas.py
@@ -31,17 +31,19 @@ class TestLoadPersonaClassesFromDirectory:
         """Test that an empty directory returns an empty list of persona classes."""
         result = load_from_dir(str(tmp_persona_dir), mock_logger)
         assert result == []
-    
+
     def test_non_persona_file_returns_empty_list(self, tmp_persona_dir, mock_logger):
         """Test that a Python file without persona classes returns an empty list."""
         # Create a file that doesn't contain "persona" in the name
         non_persona_file = tmp_persona_dir / "no_personas.py"
         non_persona_file.write_text("pass")
-        
+
         result = load_from_dir(str(tmp_persona_dir), mock_logger)
         assert result == []
-    
-    def test_simple_persona_file_returns_persona_class(self, tmp_persona_dir, mock_logger):
+
+    def test_simple_persona_file_returns_persona_class(
+        self, tmp_persona_dir, mock_logger
+    ):
         """Test that a file with a BasePersona subclass returns that class."""
         # Create a simple persona file
         persona_file = tmp_persona_dir / "simple_personas.py"
@@ -52,24 +54,24 @@ class TestPersona(BasePersona):
     id = "test_persona"
     name = "Test Persona"
     description = "A simple test persona"
-    
+
     def process_message(self, message):
         pass
 """
         persona_file.write_text(persona_content)
-        
+
         result = load_from_dir(str(tmp_persona_dir), mock_logger)
-        
+
         assert len(result) == 1
         assert result[0].__name__ == "TestPersona"
         assert issubclass(result[0], BasePersona)
-    
+
     def test_bad_persona_file_returns_empty_list(self, tmp_persona_dir, mock_logger):
         """Test that a file with syntax errors returns empty list."""
         # Create a file with invalid Python code
-        bad_persona_file = tmp_persona_dir / "bad_persona.py" 
+        bad_persona_file = tmp_persona_dir / "bad_persona.py"
         bad_persona_file.write_text("1/0")
-        
+
         result = load_from_dir(str(tmp_persona_dir), mock_logger)
-        
+
         assert result == []


### PR DESCRIPTION
When using Jupyter AI now, you can do things in .jupyter directories, including create new AI personas, configure MCP servers, etc. This means you need to enable hidden files in JupyterLab. This PR adds some basic glob patterns to ignore in the file browser. These overlap with the primary ones in .gitignore files for Jupyter and Python projects, but are a more limited set. We want these to be separate from .gitignore because Jupyter is often used outside of Git repos.