### PR TITLE
Update user message routing rules

### DIFF
--- a/packages/jupyter-ai-test/jupyter_ai_test/debug_persona.py
+++ b/packages/jupyter-ai-test/jupyter_ai_test/debug_persona.py
@@ -1,5 +1,5 @@
 from jupyter_ai.personas.base_persona import BasePersona, PersonaDefaults
-from jupyterlab_chat.models import Message, NewMessage
+from jupyterlab_chat.models import Message
 
 
 class DebugPersona(BasePersona):
@@ -20,4 +20,5 @@ class DebugPersona(BasePersona):
         )
 
     async def process_message(self, message: Message):
-        self.send_message("Hola!")
+        # Note: Echoing messages with @persona mentions causes infinite loops
+        self.send_message("Hello!, how are you?")

--- a/packages/jupyter-ai-test/jupyter_ai_test/debug_persona.py
+++ b/packages/jupyter-ai-test/jupyter_ai_test/debug_persona.py
@@ -20,5 +20,4 @@ class DebugPersona(BasePersona):
         )
 
     async def process_message(self, message: Message):
-        self.ychat.add_message(NewMessage(body="Hello!", sender=self.id))
-        return
+        self.send_message("Hola!")

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -285,17 +285,13 @@ class PersonaManager(LoggingConfigurable):
         Method that routes an incoming message to the correct persona by calling
         its `process_message()` method.
 
-        - If the chat has more than one user, then this requires
-          `@`- mention to route the message to the persona
+        - If the chat has multiple users, then each persona only replies
+          when `@`-mentioned.
 
-        - If the chat contains only one persona & one user, then this
-          method routes all new messages to that persona.
-
-        - If the message contains `@`-mentioned personas, it routes to those personas
-          and updates the last_mentioned_persona.
-
-        - If no personas are mentioned and there is a last_mentioned_persona, it routes
-          to that persona.
+        - If there is only one user, the last mentioned persona replies
+          unless another persona is `@`-mentioned. If only one persona exists
+          as well, then the persona always replies, regardless of whether
+          it is `@`-mentioned.
 
         - Otherwise, it does not route the message to any persona.
         """

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -285,6 +285,9 @@ class PersonaManager(LoggingConfigurable):
         Method that routes an incoming message to the correct persona by calling
         its `process_message()` method.
 
+        - If the chat has more than one user, then this requires
+          `@`- mention to route the message to the persona
+
         - If the chat contains only one persona & one user, then this
           method routes all new messages to that persona.
 
@@ -296,9 +299,6 @@ class PersonaManager(LoggingConfigurable):
 
         - Otherwise, it does not route the message to any persona.
         """
-        # Early exit if no personas are available
-        if not self.personas:
-            return
 
         # Gather routing context
         human_users = self.get_active_human_users()
@@ -321,8 +321,9 @@ class PersonaManager(LoggingConfigurable):
 
         # Single user + single persona: auto-route all messages
         if persona_count == 1 and human_user_count == 1:
-            persona = self.personas.values()
-            self.event_loop.create_task(persona.process_message(new_message))
+            for persona in self.personas.values():
+                self.event_loop.create_task(persona.process_message(new_message))
+                break
             return
 
         # Handle mentioned personas

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -285,7 +285,7 @@ class PersonaManager(LoggingConfigurable):
         Method that routes an incoming message to the correct persona by calling
         its `process_message()` method.
 
-        - (TODO) If the chat contains only one persona & one user, then this
+        - If the chat contains only one persona & one user, then this
           method routes all new messages to that persona.
 
         - If the message contains `@`-mentioned personas, it routes to those personas

--- a/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/persona_manager.py
@@ -293,7 +293,6 @@ class PersonaManager(LoggingConfigurable):
           as well, then the persona always replies, regardless of whether
           it is `@`-mentioned.
 
-        - Otherwise, it does not route the message to any persona.
         """
 
         # Gather routing context


### PR DESCRIPTION
Updates routing of messages, keeping track of last mentioned persona.

1. Chats with one user and one persona don't need to use `@persona`.

      https://github.com/user-attachments/assets/fefa7dde-b914-48ed-af4b-acb5b1540684


2. For multi-user or multi-persona chats, messages don't require repeated `@persona` mentions, the last mentioned 
`@persona` is tracked and used to route the message to that persona.
      
      https://github.com/user-attachments/assets/c889606d-7460-4609-a448-1e6a8bebc8bc


**Note**: The last mention currently is not  tracked across server restarts, this can be implemented by processing the ychat messages, or adding a state variable to the ychat.