### PR TITLE
Bump jupyterlab-chat version to v0.16.0

### DIFF
--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "deepmerge>=2.0,<3",
     # NOTE: Make sure to update the corresponding dependency in
     # `packages/jupyter-ai/package.json` to match the version range below
-    "jupyterlab-chat>=0.15.0,<0.16.0",
+    "jupyterlab-chat>=0.16.0,<0.17.0",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]


### PR DESCRIPTION
[Jupyter Chat v0.16.0](https://github.com/jupyterlab/jupyter-chat/releases/tag/v0.16.0) among other things updates attachments API to support cells and selection ranges https://github.com/jupyterlab/jupyter-chat/pull/247 and allows to create chat message attachments via drag-and-drop from files, notebook cells https://github.com/jupyterlab/jupyter-chat/pull/248.