### PR TITLE
[litellm] Initial migration to LiteLLM

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_utils.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/tests/test_utils.py
@@ -18,6 +18,7 @@ KNOWN_LM_B = "huggingface_hub"
         {"allowed_providers": [KNOWN_LM_A], "blocked_providers": None},
     ],
 )
+@pytest.skip("Update this to use LiteLLM")
 def test_get_lm_providers_not_restricted(restrictions):
     a_not_restricted = get_lm_providers(None, restrictions)
     assert KNOWN_LM_A in a_not_restricted
@@ -33,6 +34,7 @@ def test_get_lm_providers_not_restricted(restrictions):
         {"allowed_providers": [KNOWN_LM_B], "blocked_providers": None},
     ],
 )
+@pytest.skip("Update this to use LiteLLM")
 def test_get_lm_providers_restricted(restrictions):
     a_not_restricted = get_lm_providers(None, restrictions)
     assert KNOWN_LM_A not in a_not_restricted

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -48,42 +48,6 @@ all = [
     "boto3",
 ]
 
-[project.entry-points."jupyter_ai.model_providers"]
-ai21 = "jupyter_ai_magics:AI21Provider"
-anthropic-chat = "jupyter_ai_magics.partner_providers.anthropic:ChatAnthropicProvider"
-cohere = "jupyter_ai_magics.partner_providers.cohere:CohereProvider"
-gpt4all = "jupyter_ai_magics:GPT4AllProvider"
-huggingface_hub = "jupyter_ai_magics:HfHubProvider"
-ollama = "jupyter_ai_magics.partner_providers.ollama:OllamaProvider"
-openai = "jupyter_ai_magics.partner_providers.openai:OpenAIProvider"
-openai-chat = "jupyter_ai_magics.partner_providers.openai:ChatOpenAIProvider"
-openai-chat-custom = "jupyter_ai_magics.partner_providers.openai:ChatOpenAICustomProvider"
-azure-chat-openai = "jupyter_ai_magics.partner_providers.openai:AzureChatOpenAIProvider"
-sagemaker-endpoint = "jupyter_ai_magics.partner_providers.aws:SmEndpointProvider"
-amazon-bedrock = "jupyter_ai_magics.partner_providers.aws:BedrockProvider"
-amazon-bedrock-chat = "jupyter_ai_magics.partner_providers.aws:BedrockChatProvider"
-amazon-bedrock-custom = "jupyter_ai_magics.partner_providers.aws:BedrockCustomProvider"
-qianfan = "jupyter_ai_magics:QianfanProvider"
-nvidia-chat = "jupyter_ai_magics.partner_providers.nvidia:ChatNVIDIAProvider"
-together-ai = "jupyter_ai_magics:TogetherAIProvider"
-gemini = "jupyter_ai_magics.partner_providers.gemini:GeminiProvider"
-mistralai = "jupyter_ai_magics.partner_providers.mistralai:MistralAIProvider"
-openrouter = "jupyter_ai_magics.partner_providers.openrouter:OpenRouterProvider"
-vertexai = "jupyter_ai_magics.partner_providers.vertexai:VertexAIProvider"
-
-[project.entry-points."jupyter_ai.embeddings_model_providers"]
-azure = "jupyter_ai_magics.partner_providers.openai:AzureOpenAIEmbeddingsProvider"
-bedrock = "jupyter_ai_magics.partner_providers.aws:BedrockEmbeddingsProvider"
-cohere = "jupyter_ai_magics.partner_providers.cohere:CohereEmbeddingsProvider"
-mistralai = "jupyter_ai_magics.partner_providers.mistralai:MistralAIEmbeddingsProvider"
-gpt4all = "jupyter_ai_magics:GPT4AllEmbeddingsProvider"
-huggingface_hub = "jupyter_ai_magics:HfHubEmbeddingsProvider"
-ollama = "jupyter_ai_magics.partner_providers.ollama:OllamaEmbeddingsProvider"
-openai = "jupyter_ai_magics.partner_providers.openai:OpenAIEmbeddingsProvider"
-openai-custom = "jupyter_ai_magics.partner_providers.openai:OpenAIEmbeddingsCustomProvider"
-qianfan = "jupyter_ai_magics:QianfanEmbeddingsEndpointProvider"
-vertexai = "jupyter_ai_magics.partner_providers.vertexai:VertexAIEmbeddingsProvider"
-
 [tool.hatch.version]
 source = "nodejs"
 

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "pydantic>=2.10.0,<3",
     "click>=8.1.0,<9",
     "jsonpath-ng>=1.5.3,<2",
-    "langchain-google-vertexai",
 ]
 
 [project.optional-dependencies]
@@ -45,26 +44,8 @@ dev = [
 test = ["coverage", "pytest", "pytest-asyncio", "pytest-cov"]
 
 all = [
-    "ai21",
-    "gpt4all",
-    "huggingface_hub",
-    "ipywidgets",
-    "langchain_anthropic",
-    "langchain_aws",
-    "langchain_cohere",
-    # Pin cohere to <5.16 to prevent langchain_cohere from breaking as it uses ChatResponse removed in cohere 5.16.0
-    # TODO: remove cohere pin when langchain_cohere is updated to work with cohere >=5.16
-    "cohere<5.16",
-    "langchain_google_genai",
-    "langchain_mistralai",
-    "langchain_nvidia_ai_endpoints",
-    "langchain_openai",
-    "langchain_ollama",
-    "pillow",
+    # Required for using Amazon Bedrock
     "boto3",
-    "qianfan",
-    "together",
-    "langchain-google-vertexai",
 ]
 
 [project.entry-points."jupyter_ai.model_providers"]

--- a/packages/jupyter-ai/jupyter_ai/config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/config_manager.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 from copy import deepcopy
-from typing import Optional, Union
+from typing import Optional, Union, Any
 
 from deepmerge import always_merger
 from jupyter_ai_magics.utils import (
@@ -175,69 +175,10 @@ class ConfigManager(Configurable):
         with open(self.config_path, encoding="utf-8") as f:
             existing_config = json.loads(f.read())
             config = JaiConfig(**existing_config)
-            validated_config = self._validate_model_ids(config)
 
         # re-write to the file to validate the config and apply any
         # updates to the config file immediately
-        self._write_config(validated_config)
-
-    def _validate_model_ids(self, config):
-        lm_provider_keys = ["model_provider_id", "completions_model_provider_id"]
-        em_provider_keys = ["embeddings_provider_id"]
-        clm_provider_keys = ["completions_model_provider_id"]
-
-        # if the currently selected language or embedding model are
-        # forbidden, set them to `None` and log a warning.
-        for lm_key in lm_provider_keys:
-            lm_id = getattr(config, lm_key)
-            if lm_id is not None and not self._validate_model(lm_id, raise_exc=False):
-                self.log.warning(
-                    f"Language model {lm_id} is forbidden by current allow/blocklists. Setting to None."
-                )
-                setattr(config, lm_key, None)
-        for em_key in em_provider_keys:
-            em_id = getattr(config, em_key)
-            if em_id is not None and not self._validate_model(em_id, raise_exc=False):
-                self.log.warning(
-                    f"Embedding model {em_id} is forbidden by current allow/blocklists. Setting to None."
-                )
-                setattr(config, em_key, None)
-        for clm_key in clm_provider_keys:
-            clm_id = getattr(config, clm_key)
-            if clm_id is not None and not self._validate_model(clm_id, raise_exc=False):
-                self.log.warning(
-                    f"Completion model {clm_id} is forbidden by current allow/blocklists. Setting to None."
-                )
-                setattr(config, clm_key, None)
-
-        # if the currently selected language or embedding model ids are
-        # not associated with models, set them to `None` and log a warning.
-        for lm_key in lm_provider_keys:
-            lm_id = getattr(config, lm_key)
-            if lm_id is not None and not get_lm_provider(lm_id, self._lm_providers)[1]:
-                self.log.warning(
-                    f"No language model is associated with '{lm_id}'. Setting to None."
-                )
-                setattr(config, lm_key, None)
-        for em_key in em_provider_keys:
-            em_id = getattr(config, em_key)
-            if em_id is not None and not get_em_provider(em_id, self._em_providers)[1]:
-                self.log.warning(
-                    f"No embedding model is associated with '{em_id}'. Setting to None."
-                )
-                setattr(config, em_key, None)
-        for clm_key in clm_provider_keys:
-            clm_id = getattr(config, clm_key)
-            if (
-                clm_id is not None
-                and not get_lm_provider(clm_id, self._lm_providers)[1]
-            ):
-                self.log.warning(
-                    f"No completion model is associated with '{clm_id}'. Setting to None."
-                )
-                setattr(config, clm_key, None)
-
-        return config
+        self._write_config(config)
 
     def _read_config(self) -> JaiConfig:
         """
@@ -268,78 +209,80 @@ class ConfigManager(Configurable):
         user has specified authentication for all configured models that require
         it.
         """
+        # TODO: re-implement this w/ liteLLM
+        pass
         # validate language model config
-        if config.model_provider_id:
-            _, lm_provider = get_lm_provider(
-                config.model_provider_id, self._lm_providers
-            )
+        # if config.model_provider_id:
+        #     _, lm_provider = get_lm_provider(
+        #         config.model_provider_id, self._lm_providers
+        #     )
 
-            # verify model is declared by some provider
-            if not lm_provider:
-                raise ValueError(
-                    f"No language model is associated with '{config.model_provider_id}'."
-                )
+        #     # verify model is declared by some provider
+        #     if not lm_provider:
+        #         raise ValueError(
+        #             f"No language model is associated with '{config.model_provider_id}'."
+        #         )
 
-            # verify model is not blocked
-            self._validate_model(config.model_provider_id)
+        #     # verify model is not blocked
+        #     self._validate_model(config.model_provider_id)
 
-            # verify model is authenticated
-            _validate_provider_authn(config, lm_provider)
+        #     # verify model is authenticated
+        #     _validate_provider_authn(config, lm_provider)
 
-            # verify fields exist for this model if needed
-            if lm_provider.fields and config.model_provider_id not in config.fields:
-                config.fields[config.model_provider_id] = {}
+        #     # verify fields exist for this model if needed
+        #     if lm_provider.fields and config.model_provider_id not in config.fields:
+        #         config.fields[config.model_provider_id] = {}
 
         # validate completions model config
-        if config.completions_model_provider_id:
-            _, completions_provider = get_lm_provider(
-                config.completions_model_provider_id, self._lm_providers
-            )
+        # if config.completions_model_provider_id:
+        #     _, completions_provider = get_lm_provider(
+        #         config.completions_model_provider_id, self._lm_providers
+        #     )
 
-            # verify model is declared by some provider
-            if not completions_provider:
-                raise ValueError(
-                    f"No language model is associated with '{config.completions_model_provider_id}'."
-                )
+        #     # verify model is declared by some provider
+        #     if not completions_provider:
+        #         raise ValueError(
+        #             f"No language model is associated with '{config.completions_model_provider_id}'."
+        #         )
 
-            # verify model is not blocked
-            self._validate_model(config.completions_model_provider_id)
+        #     # verify model is not blocked
+        #     self._validate_model(config.completions_model_provider_id)
 
-            # verify model is authenticated
-            _validate_provider_authn(config, completions_provider)
+        #     # verify model is authenticated
+        #     _validate_provider_authn(config, completions_provider)
 
-            # verify completions fields exist for this model if needed
-            if (
-                completions_provider.fields
-                and config.completions_model_provider_id
-                not in config.completions_fields
-            ):
-                config.completions_fields[config.completions_model_provider_id] = {}
+        #     # verify completions fields exist for this model if needed
+        #     if (
+        #         completions_provider.fields
+        #         and config.completions_model_provider_id
+        #         not in config.completions_fields
+        #     ):
+        #         config.completions_fields[config.completions_model_provider_id] = {}
 
-        # validate embedding model config
-        if config.embeddings_provider_id:
-            _, em_provider = get_em_provider(
-                config.embeddings_provider_id, self._em_providers
-            )
+        # # validate embedding model config
+        # if config.embeddings_provider_id:
+        #     _, em_provider = get_em_provider(
+        #         config.embeddings_provider_id, self._em_providers
+        #     )
 
-            # verify model is declared by some provider
-            if not em_provider:
-                raise ValueError(
-                    f"No embedding model is associated with '{config.embeddings_provider_id}'."
-                )
+        #     # verify model is declared by some provider
+        #     if not em_provider:
+        #         raise ValueError(
+        #             f"No embedding model is associated with '{config.embeddings_provider_id}'."
+        #         )
 
-            # verify model is not blocked
-            self._validate_model(config.embeddings_provider_id)
+        #     # verify model is not blocked
+        #     self._validate_model(config.embeddings_provider_id)
 
-            # verify model is authenticated
-            _validate_provider_authn(config, em_provider)
+        #     # verify model is authenticated
+        #     _validate_provider_authn(config, em_provider)
 
-            # verify embedding fields exist for this model if needed
-            if (
-                em_provider.fields
-                and config.embeddings_provider_id not in config.embeddings_fields
-            ):
-                config.embeddings_fields[config.embeddings_provider_id] = {}
+        #     # verify embedding fields exist for this model if needed
+        #     if (
+        #         em_provider.fields
+        #         and config.embeddings_provider_id not in config.embeddings_fields
+        #     ):
+        #         config.embeddings_fields[config.embeddings_provider_id] = {}
 
     def _validate_model(self, model_id: str, raise_exc=True):
         """
@@ -449,23 +392,30 @@ class ConfigManager(Configurable):
         )
 
     @property
-    def lm_gid(self):
+    def chat_model(self) -> str | None:
+        """
+        Returns the model ID of the chat model from AI settings, if any.
+        """
         config = self._read_config()
         return config.model_provider_id
+    
+    @property
+    def chat_model_params(self) -> dict[str, Any]:
+        return self._provider_params("model_provider_id", self._lm_providers)
 
     @property
-    def em_gid(self):
+    def embedding_model(self) -> str | None:
+        """
+        Returns the model ID of the embedding model from AI settings, if any.
+        """
         config = self._read_config()
         return config.embeddings_provider_id
 
     @property
-    def lm_provider(self):
-        return self._get_provider("model_provider_id", self._lm_providers)
+    def embedding_model_params(self) -> dict[str, Any]:
+        return self._provider_params("embeddings_provider_id", self._em_providers)
 
-    @property
-    def em_provider(self):
-        return self._get_provider("embeddings_provider_id", self._em_providers)
-
+    # TODO: use LiteLLM in completions
     @property
     def completions_lm_provider(self):
         return self._get_provider("completions_model_provider_id", self._lm_providers)
@@ -479,14 +429,7 @@ class ConfigManager(Configurable):
         _, Provider = get_lm_provider(gid, listing)
         return Provider
 
-    @property
-    def lm_provider_params(self):
-        return self._provider_params("model_provider_id", self._lm_providers)
-
-    @property
-    def em_provider_params(self):
-        return self._provider_params("embeddings_provider_id", self._em_providers)
-
+    # TODO: use LiteLLM in completions
     @property
     def completions_lm_provider_params(self):
         return self._provider_params(

--- a/packages/jupyter-ai/jupyter_ai/config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/config_manager.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 from copy import deepcopy
-from typing import Optional, Union, Any
+from typing import Any, Optional, Union
 
 from deepmerge import always_merger
 from jupyter_ai_magics.utils import (
@@ -210,7 +210,6 @@ class ConfigManager(Configurable):
         it.
         """
         # TODO: re-implement this w/ liteLLM
-        pass
         # validate language model config
         # if config.model_provider_id:
         #     _, lm_provider = get_lm_provider(
@@ -398,7 +397,7 @@ class ConfigManager(Configurable):
         """
         config = self._read_config()
         return config.model_provider_id
-    
+
     @property
     def chat_model_params(self) -> dict[str, Any]:
         return self._provider_params("model_provider_id", self._lm_providers)

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -67,7 +67,7 @@ class AiExtension(ExtensionApp):
         (r"api/ai/providers/?", ModelProviderHandler),
         (r"api/ai/providers/embeddings/?", EmbeddingsModelProviderHandler),
         (r"api/ai/completion/inline/?", DefaultInlineCompletionHandler),
-        (r"api/ai/models/?", ChatModelEndpoint),
+        (r"api/ai/models/chat/?", ChatModelEndpoint),
         (
             r"api/ai/static/jupyternaut.svg()/?",
             StaticFileHandler,

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -56,6 +56,7 @@ else:
     )
 
 
+from .model_providers.model_handlers import ChatModelEndpoint
 class AiExtension(ExtensionApp):
     name = "jupyter_ai"
     handlers = [  # type:ignore[assignment]
@@ -65,6 +66,7 @@ class AiExtension(ExtensionApp):
         (r"api/ai/providers/?", ModelProviderHandler),
         (r"api/ai/providers/embeddings/?", EmbeddingsModelProviderHandler),
         (r"api/ai/completion/inline/?", DefaultInlineCompletionHandler),
+        (r"api/ai/models/?", ChatModelEndpoint),
         (
             r"api/ai/static/jupyternaut.svg()/?",
             StaticFileHandler,

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -56,6 +56,8 @@ else:
 
 
 from .model_providers.model_handlers import ChatModelEndpoint
+
+
 class AiExtension(ExtensionApp):
     name = "jupyter_ai"
     handlers = [  # type:ignore[assignment]

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Optional
 
 import traitlets
 from jupyter_ai_magics import BaseProvider
-from jupyter_ai_magics.utils import get_em_providers, get_lm_providers
 from jupyter_events import EventLogger
 from jupyter_server.extension.application import ExtensionApp
 from jupyter_server.serverapp import ServerApp
@@ -324,12 +323,9 @@ class AiExtension(ExtensionApp):
         }
 
         # Fetch LM & EM providers
-        self.settings["lm_providers"] = get_lm_providers(
-            log=self.log, restrictions=restrictions
-        )
-        self.settings["em_providers"] = get_em_providers(
-            log=self.log, restrictions=restrictions
-        )
+        # TODO: remove this & jupyter_ai_magics.utils
+        self.settings["lm_providers"] = {}
+        self.settings["em_providers"] = {}
 
         self.settings["jai_config_manager"] = ConfigManager(
             # traitlets configuration, not JAI configuration.

--- a/packages/jupyter-ai/jupyter_ai/model_providers/model_handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/model_handlers.py
@@ -1,10 +1,8 @@
-from typing import TYPE_CHECKING, Optional, cast
+from jupyter_server.base.handlers import APIHandler as BaseAPIHandler
 from pydantic import BaseModel
+from tornado import web
 
 from .model_list import CHAT_MODELS
-
-from jupyter_server.base.handlers import APIHandler as BaseAPIHandler
-from tornado import web
 
 
 class ChatModelEndpoint(BaseAPIHandler):
@@ -21,8 +19,10 @@ class ChatModelEndpoint(BaseAPIHandler):
         response = ListChatModelsResponse(chat_models=CHAT_MODELS)
         self.finish(response.model_dump_json())
 
+
 class ListChatModelsResponse(BaseModel):
     chat_models: list[str]
+
 
 class ListEmbeddingModelsResponse(BaseModel):
     embedding_models: list[str]

--- a/packages/jupyter-ai/jupyter_ai/model_providers/model_handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/model_handlers.py
@@ -1,0 +1,28 @@
+from typing import TYPE_CHECKING, Optional, cast
+from pydantic import BaseModel
+
+from .model_list import CHAT_MODELS
+
+from jupyter_server.base.handlers import APIHandler as BaseAPIHandler
+from tornado import web
+
+
+class ChatModelEndpoint(BaseAPIHandler):
+    """
+    A handler class that defines the `/api/ai/models/chat` endpoint.
+
+    - `GET /api/ai/models/chat`: returns list of all chat models.
+
+    - `GET /api/ai/models/chat?id=<model_id>`: returns info on that model (TODO)
+    """
+
+    @web.authenticated
+    def get(self):
+        response = ListChatModelsResponse(chat_models=CHAT_MODELS)
+        self.finish(response.model_dump_json())
+
+class ListChatModelsResponse(BaseModel):
+    chat_models: list[str]
+
+class ListEmbeddingModelsResponse(BaseModel):
+    embedding_models: list[str]

--- a/packages/jupyter-ai/jupyter_ai/model_providers/model_list.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/model_list.py
@@ -1,4 +1,4 @@
-from litellm import models_by_provider, all_embedding_models
+from litellm import all_embedding_models, models_by_provider
 
 chat_model_ids = []
 embedding_model_ids = []
@@ -12,9 +12,13 @@ for provider_name in models_by_provider:
             model_id = model_name
         else:
             model_id = f"{provider_name}/{model_name}"
-        
-        is_embedding = model_name in embedding_model_set or model_id in embedding_model_set or "embed" in model_id
-        
+
+        is_embedding = (
+            model_name in embedding_model_set
+            or model_id in embedding_model_set
+            or "embed" in model_id
+        )
+
         if is_embedding:
             embedding_model_ids.append(model_id)
         else:

--- a/packages/jupyter-ai/jupyter_ai/model_providers/model_list.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/model_list.py
@@ -1,0 +1,32 @@
+from litellm import models_by_provider, all_embedding_models
+
+chat_model_ids = []
+embedding_model_ids = []
+embedding_model_set = set(all_embedding_models)
+
+for provider_name in models_by_provider:
+    for model_name in models_by_provider[provider_name]:
+        model_name: str = model_name
+
+        if model_name.startswith(f"{provider_name}/"):
+            model_id = model_name
+        else:
+            model_id = f"{provider_name}/{model_name}"
+        
+        is_embedding = model_name in embedding_model_set or model_id in embedding_model_set or "embed" in model_id
+        
+        if is_embedding:
+            embedding_model_ids.append(model_id)
+        else:
+            chat_model_ids.append(model_id)
+
+
+CHAT_MODELS = sorted(chat_model_ids)
+"""
+List of chat model IDs, following the `litellm` syntax.
+"""
+
+EMBEDDING_MODELS = sorted(embedding_model_ids)
+"""
+List of embedding model IDs, following the `litellm` syntax.
+"""

--- a/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
@@ -20,8 +20,9 @@ from .persona_awareness import PersonaAwareness
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
-    from .persona_manager import PersonaManager
     from litellm import ModelResponseStream
+
+    from .persona_manager import PersonaManager
 
 
 class PersonaDefaults(BaseModel):
@@ -234,7 +235,9 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
         user = self.as_user()
         return asdict(user)
 
-    async def stream_message(self, reply_stream: "AsyncIterator[ModelResponseStream | str]") -> None:
+    async def stream_message(
+        self, reply_stream: "AsyncIterator[ModelResponseStream | str]"
+    ) -> None:
         """
         Takes an async iterator, dubbed the 'reply stream', and streams it to a
         new message by this persona in the YChat. The async iterator may yield

--- a/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/base_persona.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from .persona_manager import PersonaManager
+    from litellm import ModelResponseStream
 
 
 class PersonaDefaults(BaseModel):
@@ -233,10 +234,11 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
         user = self.as_user()
         return asdict(user)
 
-    async def stream_message(self, reply_stream: "AsyncIterator") -> None:
+    async def stream_message(self, reply_stream: "AsyncIterator[ModelResponseStream | str]") -> None:
         """
         Takes an async iterator, dubbed the 'reply stream', and streams it to a
-        new message by this persona in the YChat.
+        new message by this persona in the YChat. The async iterator may yield
+        either strings or `litellm.ModelResponseStream` objects. Details:
 
         - Creates a new message upon receiving the first chunk from the reply
         stream, then continuously updates it until the stream is closed.
@@ -248,6 +250,15 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
         try:
             self.awareness.set_local_state_field("isWriting", True)
             async for chunk in reply_stream:
+                # Coerce LiteLLM stream chunk to a string delta
+                if not isinstance(chunk, str):
+                    chunk = chunk.choices[0].delta.content
+
+                # LiteLLM streams always terminate with an empty chunk, so we
+                # ignore and continue when this occurs.
+                if not chunk:
+                    continue
+
                 if (
                     stream_id
                     and stream_id in self.message_interrupted.keys()

--- a/packages/jupyter-ai/jupyter_ai/personas/jupyternaut/jupyternaut.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/jupyternaut/jupyternaut.py
@@ -1,13 +1,12 @@
-from typing import Any
+from typing import Any, Optional
 
 from jupyterlab_chat.models import Message
-from langchain_core.output_parsers import StrOutputParser
-from langchain_core.runnables.history import RunnableWithMessageHistory
 
-from ...history import YChatHistory
 from ..base_persona import BasePersona, PersonaDefaults
-from .prompt_template import JUPYTERNAUT_PROMPT_TEMPLATE, JupyternautVariables
+from .prompt_template import JUPYTERNAUT_SYSTEM_PROMPT_TEMPLATE, JupyternautSystemPromptArgs
+from litellm import acompletion
 
+from ..persona_manager import SYSTEM_USERNAME
 
 class JupyternautPersona(BasePersona):
     """
@@ -27,40 +26,74 @@ class JupyternautPersona(BasePersona):
         )
 
     async def process_message(self, message: Message) -> None:
-        if not self.config_manager.lm_provider:
+        if not self.config_manager.chat_model:
             self.send_message(
-                "No language model provider configured. Please set one in the Jupyter AI settings."
+                "No chat model is configured.\n\n"
+                "You must set one first in the Jupyter AI settings, found in 'Settings > AI Settings' from the menu bar."
             )
             return
 
-        provider_name = self.config_manager.lm_provider.name
-        model_id = self.config_manager.lm_provider_params["model_id"]
+        model_id = self.config_manager.chat_model
+        context_as_messages = self.get_context_as_messages(model_id, message)
+        response_aiter = await acompletion(
+            model=model_id,
+            messages=[*context_as_messages, {
+                "role": "user",
+                "content": message.body,
+            }],
+            stream=True,
+        )
 
-        # Process file attachments and include their content in the context
-        context = self.process_attachments(message)
+        await self.stream_message(response_aiter)
 
-        runnable = self.build_runnable()
-        variables = JupyternautVariables(
-            input=message.body,
+
+    def get_context_as_messages(self, model_id: str, message: Message) -> list[dict[str, Any]]:
+        """
+        Returns the current context, including attachments and recent messages,
+        as a list of messages accepted by `litellm.acompletion()`.
+        """
+        system_msg_args = JupyternautSystemPromptArgs(
             model_id=model_id,
-            provider_name=provider_name,
             persona_name=self.name,
-            context=context,
-        )
-        variables_dict = variables.model_dump()
-        reply_stream = runnable.astream(variables_dict)
-        await self.stream_message(reply_stream)
+            context=self.process_attachments(message)
+        ).model_dump()
 
-    def build_runnable(self) -> Any:
-        # TODO: support model parameters. maybe we just add it to lm_provider_params in both 2.x and 3.x
-        llm = self.config_manager.lm_provider(**self.config_manager.lm_provider_params)
-        runnable = JUPYTERNAUT_PROMPT_TEMPLATE | llm | StrOutputParser()
+        system_msg = {
+            "role": "system",
+            "content": JUPYTERNAUT_SYSTEM_PROMPT_TEMPLATE.render(**system_msg_args)
+        }
 
-        runnable = RunnableWithMessageHistory(
-            runnable=runnable,  #  type:ignore[arg-type]
-            get_session_history=lambda: YChatHistory(ychat=self.ychat, k=2),
-            input_messages_key="input",
-            history_messages_key="history",
-        )
+        context_as_messages = [system_msg, *self._get_history_as_messages()]
+        return context_as_messages
 
-        return runnable
+
+    def _get_history_as_messages(self, k: Optional[int] = 2) -> list[dict[str, Any]]:
+        """
+        Returns the current history as a list of messages accepted by
+        `litellm.acompletion()`.
+        """
+        # TODO: consider bounding history based on message size (e.g. total
+        # char/token count) instead of message count.
+        all_messages = self.ychat.get_messages()
+
+        # gather last k * 2 messages and return
+        # we exclude the last message since that is the human message just
+        # submitted by a user.
+        start_idx = 0 if k is None else -2 * k - 1
+        recent_messages: list[Message] = all_messages[start_idx:-1]
+
+        history: list[dict[str, Any]] = []
+        for msg in recent_messages:
+            role = ("assistant"
+                if msg.sender.startswith("jupyter-ai-personas::")
+                else "system"
+                if msg.sender == SYSTEM_USERNAME
+                else "user"
+            )
+            history.append({
+                "role": role,
+                "content": msg.body
+            })
+        
+        return history
+

--- a/packages/jupyter-ai/jupyter_ai/personas/jupyternaut/prompt_template.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/jupyternaut/prompt_template.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from jinja2 import Template
 from langchain.prompts import (
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
@@ -7,7 +8,6 @@ from langchain.prompts import (
     SystemMessagePromptTemplate,
 )
 from pydantic import BaseModel
-from jinja2 import Template
 
 _JUPYTERNAUT_SYSTEM_PROMPT_FORMAT = """
 <instructions>
@@ -77,7 +77,10 @@ class JupyternautVariables(BaseModel):
     context: Optional[str] = None
 
 
-JUPYTERNAUT_SYSTEM_PROMPT_TEMPLATE: Template = Template(_JUPYTERNAUT_SYSTEM_PROMPT_FORMAT)
+JUPYTERNAUT_SYSTEM_PROMPT_TEMPLATE: Template = Template(
+    _JUPYTERNAUT_SYSTEM_PROMPT_FORMAT
+)
+
 
 class JupyternautSystemPromptArgs(BaseModel):
     persona_name: str

--- a/packages/jupyter-ai/jupyter_ai/personas/jupyternaut/prompt_template.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/jupyternaut/prompt_template.py
@@ -7,6 +7,7 @@ from langchain.prompts import (
     SystemMessagePromptTemplate,
 )
 from pydantic import BaseModel
+from jinja2 import Template
 
 _JUPYTERNAUT_SYSTEM_PROMPT_FORMAT = """
 <instructions>
@@ -17,7 +18,7 @@ Jupyter AI is an installable software package listed on PyPI and Conda Forge as 
 
 When installed, Jupyter AI adds a chat experience in JupyterLab that allows multiple users to collaborate with one or more agents like yourself.
 
-You are not a language model, but rather an AI agent powered by a foundation model `{{model_id}}`, provided by '{{provider_name}}'.
+You are not a language model, but rather an AI agent powered by a foundation model `{{model_id}}`.
 
 You are receiving a request from a user in JupyterLab. Your goal is to fulfill this request to the best of your ability.
 
@@ -48,6 +49,7 @@ The user's request is located at the last message. Please fulfill the user's req
 </context>
 """.strip()
 
+# TODO: Delete this. This is just being kept to prevent merge conflicts.
 JUPYTERNAUT_PROMPT_TEMPLATE = ChatPromptTemplate.from_messages(
     [
         SystemMessagePromptTemplate.from_template(
@@ -59,6 +61,7 @@ JUPYTERNAUT_PROMPT_TEMPLATE = ChatPromptTemplate.from_messages(
 )
 
 
+# TODO: Delete this. This is just being kept to prevent merge conflicts.
 class JupyternautVariables(BaseModel):
     """
     Variables expected by `JUPYTERNAUT_PROMPT_TEMPLATE`, defined as a Pydantic
@@ -70,6 +73,13 @@ class JupyternautVariables(BaseModel):
 
     input: str
     persona_name: str
-    provider_name: str
+    model_id: str
+    context: Optional[str] = None
+
+
+JUPYTERNAUT_SYSTEM_PROMPT_TEMPLATE: Template = Template(_JUPYTERNAUT_SYSTEM_PROMPT_FORMAT)
+
+class JupyternautSystemPromptArgs(BaseModel):
+    persona_name: str
     model_id: str
     context: Optional[str] = None

--- a/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_config_manager.py
@@ -43,8 +43,8 @@ def config_file_with_model_fields(jp_data_dir):
 def common_cm_kwargs(config_path):
     """Kwargs that are commonly used when initializing the CM."""
     log = logging.getLogger()
-    lm_providers = get_lm_providers()
-    em_providers = get_em_providers()
+    lm_providers = {}
+    em_providers = {}
     return {
         "log": log,
         "lm_providers": lm_providers,
@@ -467,8 +467,8 @@ def test_config_manager_does_not_write_to_defaults(config_file_with_model_fields
 
     config_path = config_file_with_model_fields
     log = logging.getLogger()
-    lm_providers = get_lm_providers()
-    em_providers = get_em_providers()
+    lm_providers = {}
+    em_providers = {}
 
     defaults = {
         "model_provider_id": None,

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -60,7 +60,7 @@ test = [
 
 dev = ["jupyter_ai_magics[dev]"]
 
-all = ["jupyter_ai_magics[all]", "pypdf", "arxiv"]
+all = ["jupyter_ai_magics[all]"]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     # NOTE: Make sure to update the corresponding dependency in
     # `packages/jupyter-ai/package.json` to match the version range below
     "jupyterlab-chat>=0.16.0,<0.17.0",
+    "litellm>=1.73,<2",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     # `packages/jupyter-ai/package.json` to match the version range below
     "jupyterlab-chat>=0.16.0,<0.17.0",
     "litellm>=1.73,<2",
+    "jinja2>=3.0,<4",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -1,110 +1,33 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Box } from '@mui/system';
-import {
-  Alert,
-  Button,
-  IconButton,
-  FormControl,
-  FormControlLabel,
-  FormLabel,
-  MenuItem,
-  Radio,
-  RadioGroup,
-  TextField,
-  Tooltip,
-  CircularProgress
-} from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 
-import { Select } from './select';
-import { AiService } from '../handler';
-import { ModelFields } from './settings/model-fields';
-import { ServerInfoState, useServerInfo } from './settings/use-server-info';
-import { ExistingApiKeys } from './settings/existing-api-keys';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import { minifyUpdate } from './settings/minify';
-import { useStackingAlert } from './mui-extras/stacking-alert';
-import { RendermimeMarkdown } from './settings/rendermime-markdown';
 import { IJaiCompletionProvider } from '../tokens';
-import { getProviderId, getModelLocalId } from '../utils';
 import { ModelIdInput } from './settings/model-id-input';
 
 type ChatSettingsProps = {
   rmRegistry: IRenderMimeRegistry;
   completionProvider: IJaiCompletionProvider | null;
   openInlineCompleterSettings: () => void;
-  // The temporary input options,  should be removed when jupyterlab chat is
-  // the only chat.
-  inputOptions?: boolean;
 };
 
 /**
  * Component that returns the settings view in the chat panel.
  */
 export function ChatSettings(props: ChatSettingsProps): JSX.Element {
-  // state fetched on initial render
-  const server = useServerInfo();
-
-  // initialize alert helper
-  const alert = useStackingAlert();
-  const apiKeysAlert = useStackingAlert();
-
-  // user inputs
-  const [lmProvider, setLmProvider] =
-    useState<AiService.ListProvidersEntry | null>(null);
-  const [emProvider, setEmProvider] =
-    useState<AiService.ListProvidersEntry | null>(null);
-  const [clmProvider, setClmProvider] =
-    useState<AiService.ListProvidersEntry | null>(null);
-  const [showLmLocalId, setShowLmLocalId] = useState<boolean>(false);
-  const [showEmLocalId, setShowEmLocalId] = useState<boolean>(false);
-  const [showClmLocalId, setShowClmLocalId] = useState<boolean>(false);
-  const [chatHelpMarkdown, setChatHelpMarkdown] = useState<string | null>(null);
-  const [embeddingHelpMarkdown, setEmbeddingHelpMarkdown] = useState<
-    string | null
-  >(null);
-  const [completionHelpMarkdown, setCompletionHelpMarkdown] = useState<
-    string | null
-  >(null);
-  const [lmLocalId, setLmLocalId] = useState<string>('');
-  const [emLocalId, setEmLocalId] = useState<string>('');
-  const [clmLocalId, setClmLocalId] = useState<string>('');
-
-  const lmGlobalId = useMemo<string | null>(() => {
-    if (!lmProvider) {
-      return null;
-    }
-
-    return lmProvider.id + ':' + lmLocalId;
-  }, [lmProvider, lmLocalId]);
-
-  const emGlobalId = useMemo<string | null>(() => {
-    if (!emProvider) {
-      return null;
-    }
-
-    return emProvider.id + ':' + emLocalId;
-  }, [emProvider, emLocalId]);
-
-  const clmGlobalId = useMemo<string | null>(() => {
-    if (!clmProvider) {
-      return null;
-    }
-
-    return clmProvider.id + ':' + clmLocalId;
-  }, [clmProvider, clmLocalId]);
-
-  const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
-  const [sendWse, setSendWse] = useState<boolean>(false);
-  const [lmFields, setLmFields] = useState<Record<string, any>>({});
-  const [emFields, setEmFields] = useState<Record<string, any>>({});
-  const [clmFields, setClmFields] = useState<Record<string, any>>({});
+  const [completionModel, setCompletionModel] = useState<string | null>(null);
   const [isCompleterEnabled, setIsCompleterEnabled] = useState(
     props.completionProvider && props.completionProvider.isEnabled()
   );
 
+  /**
+   * Effect: Listen to JupyterLab completer settings updates on initial render
+   * and update the `isCompleterEnabled` state variable accordingly.
+   */
   useEffect(() => {
     const refreshCompleterState = () => {
       setIsCompleterEnabled(
@@ -119,228 +42,6 @@ export function ChatSettings(props: ChatSettingsProps): JSX.Element {
     };
   }, [props.completionProvider]);
 
-  // whether the form is currently saving
-  const [saving, setSaving] = useState(false);
-
-  /**
-   * Effect: initialize inputs after fetching server info.
-   */
-  useEffect(() => {
-    if (server.state !== ServerInfoState.Ready) {
-      return;
-    }
-
-    setLmLocalId(server.chat.lmLocalId);
-    setEmLocalId(server.chat.emLocalId);
-    setClmLocalId(server.completions.lmLocalId);
-    setSendWse(server.config.send_with_shift_enter);
-    setChatHelpMarkdown(server.chat.lmProvider?.help ?? null);
-    setEmbeddingHelpMarkdown(server.chat.emProvider?.help ?? null);
-    setCompletionHelpMarkdown(server.completions.lmProvider?.help ?? null);
-    if (server.chat.lmProvider?.registry) {
-      setShowLmLocalId(true);
-    }
-    if (server.chat.emProvider?.registry) {
-      setShowEmLocalId(true);
-    }
-    if (server.completions.lmProvider?.registry) {
-      setShowClmLocalId(true);
-    }
-    setLmProvider(server.chat.lmProvider);
-    setClmProvider(server.completions.lmProvider);
-    setEmProvider(server.chat.emProvider);
-  }, [server]);
-
-  /**
-   * Effect: re-initialize apiKeys object whenever the selected LM/EM changes.
-   * Properties with a value of '' indicate necessary user input.
-   */
-  useEffect(() => {
-    if (server.state !== ServerInfoState.Ready) {
-      return;
-    }
-
-    const newApiKeys: Record<string, string> = {};
-    const lmAuth = lmProvider?.auth_strategy;
-    const emAuth = emProvider?.auth_strategy;
-    if (
-      lmAuth?.type === 'env' &&
-      !server.config.api_keys.includes(lmAuth.name)
-    ) {
-      newApiKeys[lmAuth.name] = '';
-    }
-    if (lmAuth?.type === 'multienv') {
-      lmAuth.names.forEach(apiKey => {
-        if (!server.config.api_keys.includes(apiKey)) {
-          newApiKeys[apiKey] = '';
-        }
-      });
-    }
-
-    if (
-      emAuth?.type === 'env' &&
-      !server.config.api_keys.includes(emAuth.name)
-    ) {
-      newApiKeys[emAuth.name] = '';
-    }
-    if (emAuth?.type === 'multienv') {
-      emAuth.names.forEach(apiKey => {
-        if (!server.config.api_keys.includes(apiKey)) {
-          newApiKeys[apiKey] = '';
-        }
-      });
-    }
-
-    setApiKeys(newApiKeys);
-  }, [lmProvider, emProvider, server]);
-
-  /**
-   * Effect: re-initialize fields object whenever the selected LM changes.
-   */
-  useEffect(() => {
-    if (server.state !== ServerInfoState.Ready || !lmGlobalId) {
-      return;
-    }
-
-    const currFields: Record<string, any> =
-      server.config.fields?.[lmGlobalId] ?? {};
-    setLmFields(currFields);
-
-    if (!emGlobalId) {
-      return;
-    }
-
-    const initEmbeddingModelFields: Record<string, any> =
-      server.config.embeddings_fields?.[emGlobalId] ?? {};
-    setEmFields(initEmbeddingModelFields);
-
-    if (!clmGlobalId) {
-      return;
-    }
-
-    const initCompleterModelFields: Record<string, any> =
-      server.config.completions_fields?.[clmGlobalId] ?? {};
-    setClmFields(initCompleterModelFields);
-  }, [server, lmGlobalId, emGlobalId, clmGlobalId]);
-
-  const handleSave = async () => {
-    // compress fields with JSON values
-    if (server.state !== ServerInfoState.Ready) {
-      return;
-    }
-
-    for (const fieldKey in lmFields) {
-      const fieldVal = lmFields[fieldKey];
-      if (typeof fieldVal !== 'string' || !fieldVal.trim().startsWith('{')) {
-        continue;
-      }
-
-      try {
-        const parsedFieldVal = JSON.parse(fieldVal);
-        const compressedFieldVal = JSON.stringify(parsedFieldVal);
-        lmFields[fieldKey] = compressedFieldVal;
-      } catch (e) {
-        continue;
-      }
-    }
-
-    for (const fieldKey in emFields) {
-      const fieldVal = emFields[fieldKey];
-      if (typeof fieldVal !== 'string' || !fieldVal.trim().startsWith('{')) {
-        continue;
-      }
-
-      try {
-        const parsedFieldVal = JSON.parse(fieldVal);
-        const compressedFieldVal = JSON.stringify(parsedFieldVal);
-        emFields[fieldKey] = compressedFieldVal;
-      } catch (e) {
-        continue;
-      }
-    }
-
-    for (const fieldKey in clmFields) {
-      const fieldVal = clmFields[fieldKey];
-      if (typeof fieldVal !== 'string' || !fieldVal.trim().startsWith('{')) {
-        continue;
-      }
-
-      try {
-        const parsedFieldVal = JSON.parse(fieldVal);
-        const compressedFieldVal = JSON.stringify(parsedFieldVal);
-        clmFields[fieldKey] = compressedFieldVal;
-      } catch (e) {
-        continue;
-      }
-    }
-
-    let updateRequest: AiService.UpdateConfigRequest = {
-      model_provider_id: lmGlobalId,
-      embeddings_provider_id: emGlobalId,
-      api_keys: apiKeys,
-      fields: lmGlobalId ? { [lmGlobalId]: lmFields } : {},
-      completions_fields: clmGlobalId ? { [clmGlobalId]: clmFields } : {},
-      embeddings_fields: emGlobalId ? { [emGlobalId]: emFields } : {},
-      completions_model_provider_id: clmGlobalId,
-      send_with_shift_enter: sendWse
-    };
-    updateRequest = minifyUpdate(server.config, updateRequest);
-    updateRequest.last_read = server.config.last_read;
-
-    setSaving(true);
-    try {
-      await apiKeysAlert.clear();
-      await AiService.updateConfig(updateRequest);
-    } catch (e) {
-      console.error(e);
-      const msg =
-        e instanceof Error || typeof e === 'string'
-          ? e.toString()
-          : 'An unknown error occurred. Check the console for more details.';
-      alert.show('error', msg);
-      return;
-    } finally {
-      setSaving(false);
-    }
-    await server.refetchAll();
-    alert.show('success', 'Settings saved successfully.');
-  };
-
-  if (server.state === ServerInfoState.Loading) {
-    return (
-      <Box
-        sx={{
-          width: '100%',
-          height: '100%',
-          boxSizing: 'border-box',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-around'
-        }}
-      >
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (server.state === ServerInfoState.Error) {
-    return (
-      <Box
-        sx={{
-          width: '100%',
-          height: '100%',
-          padding: 4,
-          boxSizing: 'border-box'
-        }}
-      >
-        <Alert severity="error">
-          {server.error ||
-            'An unknown error occurred. Check the console for more details.'}
-        </Alert>
-      </Box>
-    );
-  }
-
   return (
     <Box
       sx={{
@@ -352,326 +53,58 @@ export function ChatSettings(props: ChatSettingsProps): JSX.Element {
         overflowY: 'auto'
       }}
     >
-      {/* Chat language model section */}
-      <h2
-        className="jp-ai-ChatSettings-header"
-        title="The language model used in the chat panel"
-      >
-        Language model
-      </h2>
-
+      {/* Chat model section */}
+      <h2 className="jp-ai-ChatSettings-header">Chat model</h2>
+      <p>Configure the language model used by Jupyternaut in chats.</p>
       <ModelIdInput
+        modality="chat"
         label="Chat model ID"
-        placeholder="e.g. 'anthropic/claude-3'"
-        fullWidth
+        placeholder="e.g. 'anthropic/claude-3-5-haiku-latest'"
       />
 
-      <h2 className="jp-ai-ChatSettings-header">Language model v2</h2>
-
-      {server.lmProviders.providers
-        .map(lmp => lmp.chat_models.length)
-        .reduce((partialSum, num) => partialSum + num, 0) > 0 ? (
-        <Box>
-          <Select
-            value={lmProvider?.registry ? lmProvider.id + ':*' : lmGlobalId}
-            label="Completion model"
-            onChange={e => {
-              const lmGid = e.target.value === 'null' ? null : e.target.value;
-              if (lmGid === null) {
-                setLmProvider(null);
-                return;
-              }
-
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              const nextLmProvider = getProvider(lmGid, server.lmProviders)!;
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              const nextLmLocalId = getModelLocalId(lmGid)!;
-
-              setLmProvider(nextLmProvider);
-              setChatHelpMarkdown(nextLmProvider?.help ?? null);
-              if (nextLmProvider.registry) {
-                setLmLocalId('');
-                setShowLmLocalId(true);
-              } else {
-                setLmLocalId(nextLmLocalId);
-                setShowLmLocalId(false);
-              }
-            }}
-            MenuProps={{ sx: { maxHeight: '50%', minHeight: 400 } }}
-          >
-            <MenuItem value="null">None</MenuItem>
-            {server.lmProviders.providers.map(lmp =>
-              lmp.models
-                .filter(lm => lmp.chat_models.includes(lm))
-                .map(lm => (
-                  <MenuItem value={`${lmp.id}:${lm}`}>
-                    {lmp.name} :: {lm}
-                  </MenuItem>
-                ))
-            )}
-          </Select>
-          {showLmLocalId && (
-            <TextField
-              label={lmProvider?.model_id_label || 'Local model ID'}
-              value={lmLocalId}
-              onChange={e => setLmLocalId(e.target.value)}
-              fullWidth
-            />
-          )}
-          {chatHelpMarkdown && (
-            <RendermimeMarkdown
-              rmRegistry={props.rmRegistry}
-              markdownStr={chatHelpMarkdown}
-            />
-          )}
-          {lmGlobalId && (
-            <ModelFields
-              fields={lmProvider?.fields}
-              values={lmFields}
-              onChange={setLmFields}
-            />
-          )}
-        </Box>
-      ) : (
-        <p>No language models available.</p>
-      )}
-
       {/* Embedding model section */}
-      <h2 className="jp-ai-ChatSettings-header">Embedding model</h2>
-      {server.emProviders.providers.length > 0 ? (
-        <Box>
-          <Select
-            value={emProvider?.registry ? emProvider.id + ':*' : emGlobalId}
-            label="Embedding model"
-            onChange={e => {
-              const emGid = e.target.value === 'null' ? null : e.target.value;
-              if (emGid === null) {
-                setEmProvider(null);
-                return;
-              }
+      {/* TODO */}
 
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              const nextEmProvider = getProvider(emGid, server.emProviders)!;
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              const nextEmLocalId = getModelLocalId(emGid)!;
-
-              setEmProvider(nextEmProvider);
-              setEmbeddingHelpMarkdown(nextEmProvider?.help ?? null);
-              if (nextEmProvider.registry) {
-                setEmLocalId('');
-                setShowEmLocalId(true);
-              } else {
-                setEmLocalId(nextEmLocalId);
-                setShowEmLocalId(false);
-              }
-            }}
-            MenuProps={{ sx: { maxHeight: '50%', minHeight: 400 } }}
-          >
-            <MenuItem value="null">None</MenuItem>
-            {server.emProviders.providers.map(emp =>
-              emp.models.map(em => (
-                <MenuItem value={`${emp.id}:${em}`}>
-                  {emp.name} :: {em}
-                </MenuItem>
-              ))
-            )}
-          </Select>
-          {showEmLocalId && (
-            <TextField
-              label={emProvider?.model_id_label || 'Local model ID'}
-              value={emLocalId}
-              onChange={e => setEmLocalId(e.target.value)}
-              fullWidth
-            />
-          )}
-          {embeddingHelpMarkdown && (
-            <RendermimeMarkdown
-              rmRegistry={props.rmRegistry}
-              markdownStr={embeddingHelpMarkdown}
-            />
-          )}
-          {emGlobalId && (
-            <ModelFields
-              fields={emProvider?.fields}
-              values={emFields}
-              onChange={setEmFields}
-            />
-          )}
-        </Box>
-      ) : (
-        <p>No embedding models available.</p>
-      )}
-
-      {/* Completer language model section */}
+      {/* Completion model section */}
       <h2 className="jp-ai-ChatSettings-header">
-        Inline completions model
+        Completion model
         <CompleterSettingsButton
           provider={props.completionProvider}
           openSettings={props.openInlineCompleterSettings}
           isCompleterEnabled={isCompleterEnabled}
-          selection={clmProvider}
+          hasCompletionModel={!!completionModel}
         />
       </h2>
-      {server.lmProviders.providers
-        .map(lmp => lmp.completion_models.length)
-        .reduce((partialSum, num) => partialSum + num, 0) > 0 ? (
-        <Box>
-          <Select
-            value={clmProvider?.registry ? clmProvider.id + ':*' : clmGlobalId}
-            label="Inline completion model"
-            disabled={!isCompleterEnabled}
-            onChange={e => {
-              const clmGid = e.target.value === 'null' ? null : e.target.value;
-              if (clmGid === null) {
-                setClmProvider(null);
-                return;
-              }
-
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              const nextClmProvider = getProvider(clmGid, server.lmProviders)!;
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              const nextClmLocalId = getModelLocalId(clmGid)!;
-
-              setClmProvider(nextClmProvider);
-              setCompletionHelpMarkdown(nextClmProvider?.help ?? null);
-              if (nextClmProvider.registry) {
-                setClmLocalId('');
-                setShowClmLocalId(true);
-              } else {
-                setClmLocalId(nextClmLocalId);
-                setShowClmLocalId(false);
-              }
-            }}
-            MenuProps={{ sx: { maxHeight: '50%', minHeight: 400 } }}
-          >
-            <MenuItem value="null">None</MenuItem>
-            {server.lmProviders.providers.map(lmp =>
-              lmp.models
-                .filter(lm => lmp.completion_models.includes(lm))
-                .map(lm => (
-                  <MenuItem value={`${lmp.id}:${lm}`}>
-                    {lmp.name} :: {lm}
-                  </MenuItem>
-                ))
-            )}
-          </Select>
-          {showClmLocalId && (
-            <TextField
-              label={clmProvider?.model_id_label || 'Local model ID'}
-              value={clmLocalId}
-              onChange={e => setClmLocalId(e.target.value)}
-              fullWidth
-            />
-          )}
-          {completionHelpMarkdown && (
-            <RendermimeMarkdown
-              rmRegistry={props.rmRegistry}
-              markdownStr={completionHelpMarkdown}
-            />
-          )}
-          {clmGlobalId && (
-            <ModelFields
-              fields={clmProvider?.fields}
-              values={clmFields}
-              onChange={setClmFields}
-            />
-          )}
-        </Box>
-      ) : (
-        <p>No Inline Completion models.</p>
-      )}
-
-      {/* API Keys section */}
-      <h2 className="jp-ai-ChatSettings-header">API Keys</h2>
-
-      {Object.entries(apiKeys).length === 0 &&
-      server.config.api_keys.length === 0 ? (
-        <p>No API keys are required by the selected models.</p>
-      ) : null}
-
-      {/* API key inputs for newly-used providers */}
-      {Object.entries(apiKeys).map(([apiKeyName, apiKeyValue], idx) => (
-        <TextField
-          key={idx}
-          label={apiKeyName}
-          value={apiKeyValue}
-          fullWidth
-          type="password"
-          onChange={e =>
-            setApiKeys(apiKeys => ({
-              ...apiKeys,
-              [apiKeyName]: e.target.value
-            }))
-          }
-        />
-      ))}
-      {/* Pre-existing API keys */}
-      <ExistingApiKeys
-        alert={apiKeysAlert}
-        apiKeys={server.config.api_keys}
-        onSuccess={server.refetchApiKeys}
+      <p>
+        Configure the language model used to generate inline completions when
+        editing documents in JupyterLab.
+      </p>
+      <ModelIdInput
+        modality="completion"
+        label="Completion model ID"
+        placeholder="e.g. 'anthropic/claude-3-5-haiku-latest'"
+        onModelIdFetch={latestChatModelId => {
+          setCompletionModel(latestChatModelId);
+        }}
       />
-
-      {/* Input - to remove when jupyterlab chat is the only chat */}
-      {(props.inputOptions ?? true) && (
-        <>
-          <h2 className="jp-ai-ChatSettings-header">Input</h2>
-          <FormControl>
-            <FormLabel id="send-radio-buttons-group-label">
-              When writing a message, press <kbd>Enter</kbd> to:
-            </FormLabel>
-            <RadioGroup
-              aria-labelledby="send-radio-buttons-group-label"
-              value={sendWse ? 'newline' : 'send'}
-              name="send-radio-buttons-group"
-              onChange={e => {
-                setSendWse(e.target.value === 'newline');
-              }}
-            >
-              <FormControlLabel
-                value="send"
-                control={<Radio />}
-                label="Send the message"
-              />
-              <FormControlLabel
-                value="newline"
-                control={<Radio />}
-                label={
-                  <>
-                    Start a new line (use <kbd>Shift</kbd>+<kbd>Enter</kbd> to
-                    send)
-                  </>
-                }
-              />
-            </RadioGroup>
-          </FormControl>
-        </>
-      )}
-
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-        <Button variant="contained" onClick={handleSave} disabled={saving}>
-          {saving ? 'Saving...' : 'Save changes'}
-        </Button>
-      </Box>
-      {alert.jsx}
     </Box>
   );
 }
 
 function CompleterSettingsButton(props: {
-  selection: AiService.ListProvidersEntry | null;
+  hasCompletionModel: boolean;
   provider: IJaiCompletionProvider | null;
   isCompleterEnabled: boolean | null;
   openSettings: () => void;
 }): JSX.Element {
-  if (props.selection && !props.isCompleterEnabled) {
+  if (props.hasCompletionModel && !props.isCompleterEnabled) {
     return (
       <Tooltip
         title={
-          'A completer model is selected, but ' +
+          'A completion model is selected, but ' +
           (props.provider === null
-            ? 'the completion provider plugin is not available.'
-            : 'the inline completion provider is not enabled in the settings: click to open settings.')
+            ? 'the inline completion plugin is not available. Update to JupyterLab 4.1+ to use inline completions.'
+            : 'inline completions are disabled. Click the icon to open the inline completion settings.')
         }
       >
         <IconButton onClick={props.openSettings}>
@@ -681,19 +114,10 @@ function CompleterSettingsButton(props: {
     );
   }
   return (
-    <Tooltip title="Completer settings">
+    <Tooltip title="Open inline completion settings">
       <IconButton onClick={props.openSettings}>
         <SettingsIcon />
       </IconButton>
     </Tooltip>
   );
-}
-
-function getProvider(
-  globalModelId: string,
-  providers: AiService.ListProvidersResponse
-): AiService.ListProvidersEntry | null {
-  const providerId = getProviderId(globalModelId);
-  const provider = providers.providers.find(p => p.id === providerId);
-  return provider ?? null;
 }

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -29,6 +29,7 @@ import { useStackingAlert } from './mui-extras/stacking-alert';
 import { RendermimeMarkdown } from './settings/rendermime-markdown';
 import { IJaiCompletionProvider } from '../tokens';
 import { getProviderId, getModelLocalId } from '../utils';
+import { ModelIdInput } from './settings/model-id-input';
 
 type ChatSettingsProps = {
   rmRegistry: IRenderMimeRegistry;
@@ -358,6 +359,14 @@ export function ChatSettings(props: ChatSettingsProps): JSX.Element {
       >
         Language model
       </h2>
+
+      <ModelIdInput
+        label="Chat model ID"
+        placeholder="e.g. 'anthropic/claude-3'"
+        fullWidth
+      />
+
+      <h2 className="jp-ai-ChatSettings-header">Language model v2</h2>
 
       {server.lmProviders.providers
         .map(lmp => lmp.chat_models.length)

--- a/packages/jupyter-ai/src/components/settings/model-id-input.tsx
+++ b/packages/jupyter-ai/src/components/settings/model-id-input.tsx
@@ -92,6 +92,7 @@ export function ModelIdInput(props: ModelIdInputProps): JSX.Element {
           }
         }}
         freeSolo
+        autoSelect
         loading={loading}
         fullWidth={props.fullWidth}
         renderInput={params => (

--- a/packages/jupyter-ai/src/components/settings/model-id-input.tsx
+++ b/packages/jupyter-ai/src/components/settings/model-id-input.tsx
@@ -1,0 +1,117 @@
+import React, { useState, useEffect } from 'react';
+import { Autocomplete, TextField, Button, Box } from '@mui/material';
+import { AiService } from '../../handler';
+import { useStackingAlert } from '../mui-extras/stacking-alert';
+
+export type ModelIdInputProps = {
+  /**
+   * The label of the model ID input field.
+   */
+  label?: string;
+
+  /**
+   * The placeholder text shown within the model ID input field.
+   */
+  placeholder?: string;
+
+  /**
+   * Whether to render in full width. Defaults to `true`.
+   */
+  fullWidth?: boolean;
+};
+
+/**
+ * A model ID input.
+ */
+export function ModelIdInput(props: ModelIdInputProps): JSX.Element {
+  const [chatModels, setChatModels] = useState<string[]>([]);
+  const [prevModel, setPrevModel] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+  const [updating, setUpdating] = useState(false);
+
+  const [input, setInput] = useState('');
+  const alert = useStackingAlert();
+
+  /**
+   * Effect: Fetch list of chat models and current chat model on initial render.
+   */
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const [models, currentModel] = await Promise.all([
+          AiService.listChatModels(),
+          AiService.getChatModel()
+        ]);
+        setChatModels(models);
+        setPrevModel(currentModel ?? '');
+        setInput(currentModel ?? '');
+      } catch (error) {
+        console.error('Failed to load chat models:', error);
+        setChatModels([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadData();
+  }, []);
+
+  const handleUpdateChatModel = async () => {
+    if (!input.trim()) {
+      return;
+    }
+
+    setUpdating(true);
+    try {
+      await AiService.setChatModel(input.trim());
+      setPrevModel(input.trim());
+      alert.show(
+        'success',
+        `Successfully updated chat model to: ${input.trim()}`
+      );
+    } catch (error) {
+      console.error('Failed to update chat model:', error);
+      const msg =
+        error instanceof Error ? error.message : 'An unknown error occurred';
+      alert.show('error', `Failed to update chat model: ${msg}`);
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Autocomplete
+        options={chatModels}
+        value={input}
+        onChange={(_, newValue) => {
+          // This condition prevents whitespace from being inserted in the model
+          // ID by accident.
+          if (newValue !== null && !newValue.includes(' ')) {
+            setInput(newValue);
+          }
+        }}
+        freeSolo
+        loading={loading}
+        fullWidth={props.fullWidth}
+        renderInput={params => (
+          <TextField
+            {...params}
+            label={props.label || 'Model ID'}
+            placeholder={props.placeholder}
+            fullWidth={props.fullWidth ?? true}
+          />
+        )}
+      />
+      <Button
+        variant="contained"
+        onClick={handleUpdateChatModel}
+        disabled={prevModel === input || updating}
+        sx={{ alignSelf: 'center' }}
+      >
+        {updating ? 'Updating...' : 'Update chat model'}
+      </Button>
+      {alert.jsx}
+    </Box>
+  );
+}

--- a/packages/jupyter-ai/src/components/settings/model-id-input.tsx
+++ b/packages/jupyter-ai/src/components/settings/model-id-input.tsx
@@ -2,30 +2,51 @@ import React, { useState, useEffect } from 'react';
 import { Autocomplete, TextField, Button, Box } from '@mui/material';
 import { AiService } from '../../handler';
 import { useStackingAlert } from '../mui-extras/stacking-alert';
+import Save from '@mui/icons-material/Save';
 
 export type ModelIdInputProps = {
   /**
    * The label of the model ID input field.
    */
-  label?: string;
+  label: string;
 
   /**
-   * The placeholder text shown within the model ID input field.
+   * The "type" of the model being configured. This prop should control the API
+   * endpoints used to get the current model, set the current model, and
+   * retrieve model ID suggestions.
+   */
+  modality: 'chat' | 'completion';
+
+  /**
+   * (optional) The placeholder text shown within the model ID input field.
    */
   placeholder?: string;
 
   /**
-   * Whether to render in full width. Defaults to `true`.
+   * (optional) Whether to render in full width. Defaults to `true`.
    */
   fullWidth?: boolean;
+
+  /**
+   * (optional) Callback that is run when the component retrieves the current
+   * model ID _or_ successfully updates the model ID. Details:
+   *
+   * - This callback is run once when the current model ID is retrieved from the
+   * backend, with `initial=true`. Any model ID updates made through this
+   * component run this callback with `initial=false`.
+   *
+   * - This callback will not run if an exception was raised while updating the
+   * model ID.
+   */
+  onModelIdFetch?: (modelId: string | null, initial: boolean) => unknown;
 };
 
 /**
  * A model ID input.
  */
 export function ModelIdInput(props: ModelIdInputProps): JSX.Element {
-  const [chatModels, setChatModels] = useState<string[]>([]);
-  const [prevModel, setPrevModel] = useState<string>('');
+  const [models, setModels] = useState<string[]>([]);
+  const [prevModel, setPrevModel] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [updating, setUpdating] = useState(false);
 
@@ -33,21 +54,35 @@ export function ModelIdInput(props: ModelIdInputProps): JSX.Element {
   const alert = useStackingAlert();
 
   /**
-   * Effect: Fetch list of chat models and current chat model on initial render.
+   * Effect: Fetch list of models and current model on initial render, based on
+   * the modality.
    */
   useEffect(() => {
     async function loadData() {
       try {
-        const [models, currentModel] = await Promise.all([
-          AiService.listChatModels(),
-          AiService.getChatModel()
-        ]);
-        setChatModels(models);
-        setPrevModel(currentModel ?? '');
-        setInput(currentModel ?? '');
+        let modelsResponse: string[];
+        let currModelResponse: string | null;
+
+        if (props.modality === 'chat') {
+          [modelsResponse, currModelResponse] = await Promise.all([
+            AiService.listChatModels(),
+            AiService.getChatModel()
+          ]);
+        } else if (props.modality === 'completion') {
+          [modelsResponse, currModelResponse] = await Promise.all([
+            AiService.listChatModels(),
+            AiService.getCompletionModel()
+          ]);
+        } else {
+          throw new Error(`Unrecognized model modality '${props.modality}'.`);
+        }
+
+        setModels(modelsResponse);
+        setPrevModel(currModelResponse);
+        setInput(currModelResponse ?? '');
       } catch (error) {
         console.error('Failed to load chat models:', error);
-        setChatModels([]);
+        setModels([]);
       } finally {
         setLoading(false);
       }
@@ -57,23 +92,35 @@ export function ModelIdInput(props: ModelIdInputProps): JSX.Element {
   }, []);
 
   const handleUpdateChatModel = async () => {
-    if (!input.trim()) {
-      return;
-    }
-
     setUpdating(true);
     try {
-      await AiService.setChatModel(input.trim());
-      setPrevModel(input.trim());
+      // perform correct REST API call based on model modality
+      const newModelId = input.trim() || null;
+      if (props.modality === 'chat') {
+        await AiService.updateChatModel(newModelId);
+      } else if (props.modality === 'completion') {
+        await AiService.updateCompletionModel(newModelId);
+      } else {
+        throw new Error(`Unrecognized model modality '${props.modality}'.`);
+      }
+
+      // update local state and run parent callback
+      setPrevModel(newModelId);
+      props.onModelIdFetch?.(newModelId, true);
+
+      // show success alert
+      // TODO: maybe just use the JL Notifications API
       alert.show(
         'success',
-        `Successfully updated chat model to: ${input.trim()}`
+        newModelId
+          ? `Successfully updated ${props.modality} model to '${input.trim()}'.`
+          : `Successfully cleared ${props.modality} model.`
       );
     } catch (error) {
-      console.error('Failed to update chat model:', error);
+      console.error(`Failed to update ${props.modality} model:`, error);
       const msg =
         error instanceof Error ? error.message : 'An unknown error occurred';
-      alert.show('error', `Failed to update chat model: ${msg}`);
+      alert.show('error', `Failed to update ${props.modality} model: ${msg}`);
     } finally {
       setUpdating(false);
     }
@@ -82,19 +129,19 @@ export function ModelIdInput(props: ModelIdInputProps): JSX.Element {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       <Autocomplete
-        options={chatModels}
+        options={models}
         value={input}
-        onChange={(_, newValue) => {
+        freeSolo
+        autoSelect
+        loading={loading}
+        fullWidth={props.fullWidth}
+        onInputChange={(e, newValue, r) => {
           // This condition prevents whitespace from being inserted in the model
           // ID by accident.
           if (newValue !== null && !newValue.includes(' ')) {
             setInput(newValue);
           }
         }}
-        freeSolo
-        autoSelect
-        loading={loading}
-        fullWidth={props.fullWidth}
         renderInput={params => (
           <TextField
             {...params}
@@ -107,10 +154,13 @@ export function ModelIdInput(props: ModelIdInputProps): JSX.Element {
       <Button
         variant="contained"
         onClick={handleUpdateChatModel}
-        disabled={prevModel === input || updating}
+        disabled={loading || prevModel === (input || null) || updating}
         sx={{ alignSelf: 'center' }}
+        startIcon={<Save />}
       >
-        {updating ? 'Updating...' : 'Update chat model'}
+        {updating
+          ? `Updating ${props.modality} model...`
+          : `Update ${props.modality} model`}
       </Button>
       {alert.jsx}
     </Box>

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -138,6 +138,10 @@ export namespace AiService {
     providers: ListProvidersEntry[];
   };
 
+  export type ListChatModelsResponse = {
+    chat_models: string[];
+  };
+
   export async function listLmProviders(): Promise<ListProvidersResponse> {
     return requestAPI<ListProvidersResponse>('providers');
   }
@@ -158,6 +162,24 @@ export namespace AiService {
   export async function deleteApiKey(keyName: string): Promise<void> {
     return requestAPI<void>(`api_keys/${keyName}`, {
       method: 'DELETE'
+    });
+  }
+
+  export async function listChatModels(): Promise<string[]> {
+    const response = await requestAPI<ListChatModelsResponse>('models/', {
+      method: 'GET'
+    });
+    return response.chat_models;
+  }
+
+  export async function getChatModel(): Promise<string | null> {
+    const response = await requestAPI<DescribeConfigResponse>('config/');
+    return response.model_provider_id;
+  }
+
+  export async function setChatModel(modelId: string): Promise<void> {
+    return await updateConfig({
+      model_provider_id: modelId
     });
   }
 }

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -166,7 +166,7 @@ export namespace AiService {
   }
 
   export async function listChatModels(): Promise<string[]> {
-    const response = await requestAPI<ListChatModelsResponse>('models/', {
+    const response = await requestAPI<ListChatModelsResponse>('models/chat/', {
       method: 'GET'
     });
     return response.chat_models;

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -177,9 +177,22 @@ export namespace AiService {
     return response.model_provider_id;
   }
 
-  export async function setChatModel(modelId: string): Promise<void> {
+  export async function updateChatModel(modelId: string | null): Promise<void> {
     return await updateConfig({
       model_provider_id: modelId
+    });
+  }
+
+  export async function getCompletionModel(): Promise<string | null> {
+    const response = await requestAPI<DescribeConfigResponse>('config/');
+    return response.completions_model_provider_id;
+  }
+
+  export async function updateCompletionModel(
+    modelId: string | null
+  ): Promise<void> {
+    return await updateConfig({
+      completions_model_provider_id: modelId
     });
   }
 }

--- a/packages/jupyter-ai/src/widgets/settings-widget.tsx
+++ b/packages/jupyter-ai/src/widgets/settings-widget.tsx
@@ -19,7 +19,6 @@ export function buildAiSettings(
         rmRegistry={rmRegistry}
         completionProvider={completionProvider}
         openInlineCompleterSettings={openInlineCompleterSettings}
-        inputOptions={false}
       />
     </JlThemeProvider>
   );


### PR DESCRIPTION
## Context

- This PR starts the `litellm` feature branch by adding the minimum code required for LiteLLM to be used instead of LangChain.

- This PR is **not** targeting `main`, but rather the new `litellm` feature branch. We will merge the `litellm` branch into `main` once it is stable.

- The CI on this PR is expected to fail. We can address CI failures before merging `litellm` into `main`.

## Description

- Migrates from LangChain to LiteLLM. Removes all model provider dependencies and model provider entry points. Server startup time now takes ~3-4 ms instead of ~3000-4000 ms.

- Model IDs now follow the `litellm` model ID syntax: `<provider-name>/<model-name>`.

- Adds a new `/api/ai/models/chat` endpoint that simply returns the list of all chat model IDs. This list is obtained from `litellm`.

- Rewrites the AI settings. The new AI settings allow for any LiteLLM model ID to be set, so users can use a model even if it is not present in the list of model ID suggestions.

    - This allows a user to use a newly-released model before it is added to the list of model IDs provided by `litellm`.

    - For example, you can use `ollama/deepseek-coder-v2`, even though it does not show in the list of model ID suggestions.

## Demo


https://github.com/user-attachments/assets/ab1a1ba1-e384-432d-b3fe-45fa5bde85c7


https://github.com/user-attachments/assets/b12fa066-89be-4dd7-91f4-83eb4e0d437e



## Technical details

- Most of the code in `chat-settings.tsx` has been deleted. There is a new `<ModelIdInput />` component that is used to show the "Chat model" and "Completion model" settings.

- The `ConfigManager` logic for validating model IDs has been disabled for now to allow LiteLLM model IDs instead of our previous custom model ID syntax.

- API keys are **only** read from the environment at this time. The "API keys" section in the AI settings do not work yet.

    - For example, to use Anthropic models, you should start JupyterLab via `ANTHROPIC_API_KEY="..." jupyter lab`.
    - The `ollama/` and `bedrock/` providers do not require an API key environment variable, so those may be easier to use in testing.

- Embedding model support is not implemented yet. We're still debating if this is worth supporting, given that the token limit on the most recent models has grown dramatically.

## Follow-up issues

1. Remove all references to LangChain
2. Fix model ID input field. The MUI autocomplete component is glitchy and the model ID suggestions don't always update. We may need to use `fuzzysort` from NPM in the model ID input component.
3. Add support for adding API keys - store in `.env` files
4. Add support for adding model parameters (https://docs.litellm.ai/docs/completion/drop_params)
5. Fix inline completions when using LiteLLM
6. Update magic commands to use LiteLLM
7. Add validation for new AI settings UI.
