### PR TITLE
Implemented model parameter input component

### DIFF
--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -21,7 +21,7 @@ import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { Select } from './select';
 import { AiService } from '../handler';
 import { ModelFields } from './settings/model-fields';
-import { ModelParametersInput} from './settings/model-parameters-input';
+import { ModelParametersInput } from './settings/model-parameters-input';
 import { ServerInfoState, useServerInfo } from './settings/use-server-info';
 import { ExistingApiKeys } from './settings/existing-api-keys';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -349,7 +349,8 @@ export function ChatSettings(props: ChatSettingsProps): JSX.Element {
         '& .MuiAlert-root': {
           marginTop: 2
         },
-        overflowY: 'auto'
+        overflowY: 'auto',
+        height: '100%'
       }}
     >
       {/* Chat language model section */}

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -21,6 +21,7 @@ import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { Select } from './select';
 import { AiService } from '../handler';
 import { ModelFields } from './settings/model-fields';
+import { ModelParametersInput} from './settings/model-parameters-input';
 import { ServerInfoState, useServerInfo } from './settings/use-server-info';
 import { ExistingApiKeys } from './settings/existing-api-keys';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
@@ -571,6 +572,10 @@ export function ChatSettings(props: ChatSettingsProps): JSX.Element {
       ) : (
         <p>No Inline Completion models.</p>
       )}
+
+      {/* Model Parameters Input section */}
+      <h2 className="jp-ai-ChatSettings-header">Model Parameters Input</h2>
+      <ModelParametersInput />
 
       {/* API Keys section */}
       <h2 className="jp-ai-ChatSettings-header">API Keys</h2>

--- a/packages/jupyter-ai/src/components/settings/model-parameters-input.tsx
+++ b/packages/jupyter-ai/src/components/settings/model-parameters-input.tsx
@@ -20,7 +20,7 @@ interface StaticParameterDef {
 const STATIC_PARAMETERS: StaticParameterDef[] = [
   { name: 'temperature', type: 'float', label: 'Temperature' },
   { name: 'api_url', type: 'string', label: 'API URL' },
-  { name: 'max_tokens', type: 'integer', label: 'Max Tokens' },
+  { name: 'max_tokens', type: 'integer', label: 'Max Tokens' }
 ];
 
 export function ModelParametersInput(): JSX.Element {
@@ -41,7 +41,9 @@ export function ModelParametersInput(): JSX.Element {
 
   const handleAddStaticParameter = (staticParam: StaticParameterDef) => {
     // Check if static parameter already exists
-    const exists = parameters.some(param => param.name === staticParam.name && param.isStatic);
+    const exists = parameters.some(
+      param => param.name === staticParam.name && param.isStatic
+    );
     if (exists) {
       setValidationError(`Parameter "${staticParam.label}" is already added`);
       return;
@@ -57,9 +59,13 @@ export function ModelParametersInput(): JSX.Element {
     setValidationError('');
   };
   // For when user changes their parameter
-  const handleParameterChange = (id: string, field: keyof ModelParameter, value: string) => {
-    setParameters(prev => 
-      prev.map(param => 
+  const handleParameterChange = (
+    id: string,
+    field: keyof ModelParameter,
+    value: string
+  ) => {
+    setParameters(prev =>
+      prev.map(param =>
         param.id === id ? { ...param, [field]: value } : param
       )
     );
@@ -73,16 +79,18 @@ export function ModelParametersInput(): JSX.Element {
   };
 
   const handleSaveParameters = () => {
-    
     // Validation: Check if any parameter has a value but missing name or type (only for custom parameters)
-    const invalidParams = parameters.filter(param => 
-      param.value.trim() !== '' && 
-      !param.isStatic && 
-      (param.name.trim() === '' || param.type.trim() === '')
+    const invalidParams = parameters.filter(
+      param =>
+        param.value.trim() !== '' &&
+        !param.isStatic &&
+        (param.name.trim() === '' || param.type.trim() === '')
     );
 
     if (invalidParams.length > 0) {
-      setValidationError('Parameter value specified but name or type is missing');
+      setValidationError(
+        'Parameter value specified but name or type is missing'
+      );
       return;
     }
 
@@ -100,17 +108,16 @@ export function ModelParametersInput(): JSX.Element {
   };
 
   const showSaveButton = parameters.length > 0;
-  const availableStaticParams = STATIC_PARAMETERS.filter(staticParam => 
-    !parameters.some(param => param.name === staticParam.name && param.isStatic)
+  const availableStaticParams = STATIC_PARAMETERS.filter(
+    staticParam =>
+      !parameters.some(
+        param => param.name === staticParam.name && param.isStatic
+      )
   );
 
   return (
     <Box>
-      <Button 
-        variant="outlined" 
-        onClick={handleAddParameter}
-        sx={{ mb: 2 }}
-      >
+      <Button variant="outlined" onClick={handleAddParameter} sx={{ mb: 2 }}>
         Add a custom model parameter
       </Button>
       {/* Static parameter buttons */}
@@ -135,11 +142,11 @@ export function ModelParametersInput(): JSX.Element {
       )}
 
       {parameters.map(param => (
-        <Box 
-          key={param.id} 
-          sx={{ 
-            display: 'flex', 
-            gap: 2, 
+        <Box
+          key={param.id}
+          sx={{
+            display: 'flex',
+            gap: 2,
             mb: 2,
             alignItems: 'center'
           }}
@@ -148,7 +155,9 @@ export function ModelParametersInput(): JSX.Element {
             label="Parameter name"
             placeholder="e.g. temperature, api_url"
             value={param.name}
-            onChange={(e) => handleParameterChange(param.id, 'name', e.target.value)}
+            onChange={e =>
+              handleParameterChange(param.id, 'name', e.target.value)
+            }
             size="small"
             sx={{ flex: 1 }}
             disabled={param.isStatic}
@@ -160,7 +169,9 @@ export function ModelParametersInput(): JSX.Element {
             label="Parameter type"
             placeholder="e.g. float, string"
             value={param.type}
-            onChange={(e) => handleParameterChange(param.id, 'type', e.target.value)}
+            onChange={e =>
+              handleParameterChange(param.id, 'type', e.target.value)
+            }
             size="small"
             sx={{ flex: 1 }}
             disabled={param.isStatic}
@@ -172,7 +183,9 @@ export function ModelParametersInput(): JSX.Element {
             label="Parameter value"
             placeholder="e.g. 0.7, https://localhost:8989"
             value={param.value}
-            onChange={(e) => handleParameterChange(param.id, 'value', e.target.value)}
+            onChange={e =>
+              handleParameterChange(param.id, 'value', e.target.value)
+            }
             size="small"
             sx={{ flex: 1 }}
           />
@@ -194,8 +207,8 @@ export function ModelParametersInput(): JSX.Element {
       )}
 
       {showSaveButton && (
-        <Button 
-          variant="contained" 
+        <Button
+          variant="contained"
           onClick={handleSaveParameters}
           sx={{ mt: 1 }}
         >

--- a/packages/jupyter-ai/src/components/settings/model-parameters-input.tsx
+++ b/packages/jupyter-ai/src/components/settings/model-parameters-input.tsx
@@ -1,0 +1,207 @@
+import React, { useState } from 'react';
+import { Button, TextField, Box, Alert, IconButton } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+interface ModelParameter {
+  id: string;
+  name: string;
+  type: string;
+  value: string;
+  isStatic?: boolean;
+}
+
+interface StaticParameterDef {
+  name: string;
+  type: string;
+  label: string;
+}
+
+// Add some common fields as static parameters here
+const STATIC_PARAMETERS: StaticParameterDef[] = [
+  { name: 'temperature', type: 'float', label: 'Temperature' },
+  { name: 'api_url', type: 'string', label: 'API URL' },
+  { name: 'max_tokens', type: 'integer', label: 'Max Tokens' },
+];
+
+export function ModelParametersInput(): JSX.Element {
+  const [parameters, setParameters] = useState<ModelParameter[]>([]);
+  const [validationError, setValidationError] = useState<string>('');
+
+  const handleAddParameter = () => {
+    const newParameter: ModelParameter = {
+      id: Date.now().toString(),
+      name: '',
+      type: '',
+      value: '',
+      isStatic: false
+    };
+    setParameters([...parameters, newParameter]);
+    setValidationError('');
+  };
+
+  const handleAddStaticParameter = (staticParam: StaticParameterDef) => {
+    // Check if static parameter already exists
+    const exists = parameters.some(param => param.name === staticParam.name && param.isStatic);
+    if (exists) {
+      setValidationError(`Parameter "${staticParam.label}" is already added`);
+      return;
+    }
+    const newParameter: ModelParameter = {
+      id: Date.now().toString(),
+      name: staticParam.name,
+      type: staticParam.type,
+      value: '',
+      isStatic: true
+    };
+    setParameters([...parameters, newParameter]);
+    setValidationError('');
+  };
+  // For when user changes their parameter
+  const handleParameterChange = (id: string, field: keyof ModelParameter, value: string) => {
+    setParameters(prev => 
+      prev.map(param => 
+        param.id === id ? { ...param, [field]: value } : param
+      )
+    );
+    setValidationError('');
+  };
+
+  // For when user deletes parameter
+  const handleDeleteParameter = (id: string) => {
+    setParameters(prev => prev.filter(param => param.id !== id));
+    setValidationError('');
+  };
+
+  const handleSaveParameters = () => {
+    
+    // Validation: Check if any parameter has a value but missing name or type (only for custom parameters)
+    const invalidParams = parameters.filter(param => 
+      param.value.trim() !== '' && 
+      !param.isStatic && 
+      (param.name.trim() === '' || param.type.trim() === '')
+    );
+
+    if (invalidParams.length > 0) {
+      setValidationError('Parameter value specified but name or type is missing');
+      return;
+    }
+
+    // Filter out parameters with empty values
+    const validParams = parameters.filter(param => param.value.trim() !== '');
+
+    // Creates JSON object of valid parameters ONLY if all 3 fields are given valid inputs
+    const paramsObject = validParams.reduce((acc, param) => {
+      acc[param.name] = param.value;
+      return acc;
+    }, {} as Record<string, string>);
+
+    // Logs the JSON object of its input state to the browser console
+    console.log('Model Parameters:', paramsObject);
+  };
+
+  const showSaveButton = parameters.length > 0;
+  const availableStaticParams = STATIC_PARAMETERS.filter(staticParam => 
+    !parameters.some(param => param.name === staticParam.name && param.isStatic)
+  );
+
+  return (
+    <Box>
+      <Button 
+        variant="outlined" 
+        onClick={handleAddParameter}
+        sx={{ mb: 2 }}
+      >
+        Add a custom model parameter
+      </Button>
+      {/* Static parameter buttons */}
+      {availableStaticParams.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <Box sx={{ mb: 1, fontWeight: 'medium', fontSize: '0.875rem' }}>
+            Common parameters:
+          </Box>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
+            {availableStaticParams.map(staticParam => (
+              <Button
+                key={staticParam.name}
+                variant="outlined"
+                size="small"
+                onClick={() => handleAddStaticParameter(staticParam)}
+              >
+                {staticParam.label}
+              </Button>
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {parameters.map(param => (
+        <Box 
+          key={param.id} 
+          sx={{ 
+            display: 'flex', 
+            gap: 2, 
+            mb: 2,
+            alignItems: 'center'
+          }}
+        >
+          <TextField
+            label="Parameter name"
+            placeholder="e.g. temperature, api_url"
+            value={param.name}
+            onChange={(e) => handleParameterChange(param.id, 'name', e.target.value)}
+            size="small"
+            sx={{ flex: 1 }}
+            disabled={param.isStatic}
+            InputProps={{
+              readOnly: param.isStatic
+            }}
+          />
+          <TextField
+            label="Parameter type"
+            placeholder="e.g. float, string"
+            value={param.type}
+            onChange={(e) => handleParameterChange(param.id, 'type', e.target.value)}
+            size="small"
+            sx={{ flex: 1 }}
+            disabled={param.isStatic}
+            InputProps={{
+              readOnly: param.isStatic
+            }}
+          />
+          <TextField
+            label="Parameter value"
+            placeholder="e.g. 0.7, https://localhost:8989"
+            value={param.value}
+            onChange={(e) => handleParameterChange(param.id, 'value', e.target.value)}
+            size="small"
+            sx={{ flex: 1 }}
+          />
+          <IconButton
+            onClick={() => handleDeleteParameter(param.id)}
+            color="error"
+            size="small"
+            sx={{ ml: 1 }}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </Box>
+      ))}
+
+      {validationError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {validationError}
+        </Alert>
+      )}
+
+      {showSaveButton && (
+        <Button 
+          variant="contained" 
+          onClick={handleSaveParameters}
+          sx={{ mt: 1 }}
+        >
+          Save Model Parameters
+        </Button>
+      )}
+    </Box>
+  );
+}

--- a/packages/jupyter-ai/src/components/settings/model-parameters-input.tsx
+++ b/packages/jupyter-ai/src/components/settings/model-parameters-input.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button, TextField, Box, Alert, IconButton } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 
-interface ModelParameter {
+interface IModelParameter {
   id: string;
   name: string;
   type: string;
@@ -10,25 +10,25 @@ interface ModelParameter {
   isStatic?: boolean;
 }
 
-interface StaticParameterDef {
+interface IStaticParameterDef {
   name: string;
   type: string;
   label: string;
 }
 
 // Add some common fields as static parameters here
-const STATIC_PARAMETERS: StaticParameterDef[] = [
+const STATIC_PARAMETERS: IStaticParameterDef[] = [
   { name: 'temperature', type: 'float', label: 'Temperature' },
   { name: 'api_url', type: 'string', label: 'API URL' },
   { name: 'max_tokens', type: 'integer', label: 'Max Tokens' }
 ];
 
 export function ModelParametersInput(): JSX.Element {
-  const [parameters, setParameters] = useState<ModelParameter[]>([]);
+  const [parameters, setParameters] = useState<IModelParameter[]>([]);
   const [validationError, setValidationError] = useState<string>('');
 
   const handleAddParameter = () => {
-    const newParameter: ModelParameter = {
+    const newParameter: IModelParameter = {
       id: Date.now().toString(),
       name: '',
       type: '',
@@ -39,7 +39,7 @@ export function ModelParametersInput(): JSX.Element {
     setValidationError('');
   };
 
-  const handleAddStaticParameter = (staticParam: StaticParameterDef) => {
+  const handleAddStaticParameter = (staticParam: IStaticParameterDef) => {
     // Check if static parameter already exists
     const exists = parameters.some(
       param => param.name === staticParam.name && param.isStatic
@@ -48,7 +48,7 @@ export function ModelParametersInput(): JSX.Element {
       setValidationError(`Parameter "${staticParam.label}" is already added`);
       return;
     }
-    const newParameter: ModelParameter = {
+    const newParameter: IModelParameter = {
       id: Date.now().toString(),
       name: staticParam.name,
       type: staticParam.type,
@@ -61,7 +61,7 @@ export function ModelParametersInput(): JSX.Element {
   // For when user changes their parameter
   const handleParameterChange = (
     id: string,
-    field: keyof ModelParameter,
+    field: keyof IModelParameter,
     value: string
   ) => {
     setParameters(prev =>


### PR DESCRIPTION
**Problem**

- Fixes #1438.

We need a new React component in the Jupyter AI settings page that allows a user to add arbitrary model parameters. Each model parameter will be a keyword argument passed to LiteLLM.

**Solution**

Built a <ModelParametersInput /> component, which will:

1. Show just a "Add a custom model parameter" button initially.
2.  After clicking that button, there should a new input for the parameter name (e.g. temperature or api_url), parameter type (e.g. float or string), and parameter value (e.g. 0.7 or https://localhost:8989). These should appear as 3 text fields on the same line.
3. After clicking that button, there should also be a new button that says "Save Model Parameters". For now, this button can just log the JSON object of its input state to the browser console.
4. A validation error should be emitted if the user specifies a parameter value but does not specify its type or its name. If a user specifies an empty parameter value, it should be ignored entirely, regardless of the type or name inputs.
5. The "Add a model parameter" button should still show after the user clicks it once, i.e. users should be able to add any number of model parameters.
6. Implemented a "static parameters" whose name & type are fixed. For example, this would be useful for basic parameters like temperature: float and api_url: string.

