### PR TITLE
Implements arguments for providers and models in `%ai list`

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
@@ -248,7 +248,10 @@ def help_subparser():
 )
 @click.argument("provider_id", required=False)
 def list_subparser(**kwargs):
-    """List language models, optionally scoped to PROVIDER_ID."""
+    """List language models, optionally scoped to PROVIDER_ID.\n\n
+    If no PROVIDER_ID is given, all providers are listed.
+    If PROVIDER_ID is given, only models from that provider are listed.
+    If PROVIDER_ID is 'all', models from all providers are listed."""
     return ListArgs(**kwargs)
 
 


### PR DESCRIPTION
Fixes #1451 

Adds the following options to `%ai list`

1. `%ai list` lists all _providers_ by default, and asks the user to run `%ai list <provider-name>`.
2. `%ai list <provider-name>` lists all models available from one provider. Notes that the list is not comprehensive, and includes a reference to the upstream LiteLLM docs for the specific provider.
3. `%ai list all` lists models for all providers and links to the docs page listing all providers for `litellm`.
4. `Handles error gracefully if invalid `%ai` arguments are given. 
5. Updates help for the usage of `%ai`. 

See the usage examples here:

<img width="692" height="714" alt="image" src="https://github.com/user-attachments/assets/8fd37d57-f25c-4610-8f08-a1ee4347d8d1" />

<img width="694" height="455" alt="image" src="https://github.com/user-attachments/assets/50ea5664-1d98-4794-84e5-b9097a8b6eee" />

<img width="694" height="647" alt="image" src="https://github.com/user-attachments/assets/c5b42eee-4c2d-49e0-a6ba-a2f294c3d6fd" />


