### PR TITLE
Enable the use of API Keys in magics from the `.env` file

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/magics.py
@@ -29,6 +29,9 @@ from .parsers import (
     line_magic_parser,
 )
 
+# Load the .env file from the workspace root
+dotenv_path = os.path.join(os.getcwd(), ".env")
+
 class TextOrMarkdown:
     def __init__(self, text, markdown):
         self.text = text
@@ -178,7 +181,6 @@ class AiMagics(Magics):
         # Notify if .env file is missing in workspace root when the extension is loaded.
         # This is useful for users to know that they can set API keys in the JupyterLab
         # UI, but it is not always required to run the extension.
-        dotenv_path = os.path.join(os.getcwd(), ".env")
         if not os.path.isfile(dotenv_path):
             print(f"No `.env` file containing provider API keys found at {dotenv_path}. \
                   You can add API keys to the `.env` file via the AI Settings in the JupyterLab UI.", file=sys.stderr)


### PR DESCRIPTION
Updates the magics to load the API keys from `.env` every time it is called in a code block in Jupyter Lab. 

### Usage: (in the notebook)

Add keys to the `.env` file (manually or via the AI Settings panel in Jupyter Lab:
<img width="647" height="239" alt="openai key added" src="https://github.com/user-attachments/assets/89145ceb-6b2d-4c73-9713-acf58ee79fe6" />
<img width="322" height="128" alt="image" src="https://github.com/user-attachments/assets/2b191937-41ef-499a-8342-ff4b13a48523" />

<img width="207" height="30" alt="image" src="https://github.com/user-attachments/assets/62f47df5-f17b-45fd-b93c-37ea59c13700" />

Use a model that has API keys in the `.env` file
<img width="313" height="176" alt="image" src="https://github.com/user-attachments/assets/94331790-e495-4443-ab1b-f4b30a4b923b" />

### Test for warning when there is no `.env` file: 
<img width="645" height="263" alt="image" src="https://github.com/user-attachments/assets/26d66cee-b34d-4092-8515-8e09dd7e4510" />
<img width="578" height="73" alt="image" src="https://github.com/user-attachments/assets/7fb1cd0b-ce0a-4bf3-b2db-b18db9681cb0" />
<img width="583" height="167" alt="image" src="https://github.com/user-attachments/assets/1af3d621-98a6-4bf8-90b4-0886d35ee4f2" />

Then add keys, reload extension, and try again, _without_ restarting the kernel:
<img width="314" height="212" alt="image" src="https://github.com/user-attachments/assets/2e272fc0-691e-43ef-8294-dfb1ad9bc0a6" />
