### PR TITLE
Clean up AI settings page

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameters_rest_api.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameters_rest_api.py
@@ -138,7 +138,6 @@ class ModelParametersRestAPI(BaseAPIHandler):
                 "message": f"Parameters saved for model {model_id}",
                 "model_id": model_id,
                 "parameters": coerced_parameters,
-                "new_config": config_manager.fields.get(model_id, None)
             }
             
             self.set_header("Content-Type", "application/json")

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -17,6 +17,21 @@ type ChatSettingsProps = {
   openInlineCompleterSettings: () => void;
 };
 
+const MODEL_ID_HELP = (
+  <p>
+    You may provide any model ID accepted by LiteLLM. Details can be found from
+    the{' '}
+    <a
+      href="https://docs.litellm.ai/docs/providers"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      LiteLLM documentation
+    </a>
+    .
+  </p>
+);
+
 /**
  * Component that returns the settings view in the chat panel.
  */
@@ -57,6 +72,7 @@ export function ChatSettings(props: ChatSettingsProps): JSX.Element {
       {/* SECTION: Chat model */}
       <h2 className="jp-ai-ChatSettings-header">Chat model</h2>
       <p>Configure the language model used by Jupyternaut in chats.</p>
+      {MODEL_ID_HELP}
       <ModelIdInput
         modality="chat"
         label="Chat model ID"
@@ -64,31 +80,32 @@ export function ChatSettings(props: ChatSettingsProps): JSX.Element {
         onModelIdFetch={modelId => setChatModel(modelId)}
       />
 
-      {/* SECTION: Embedding model */}
-      {/* TODO */}
-
       {/* SECTION: Completion model */}
-      <h2 className="jp-ai-ChatSettings-header">
-        Completion model
-        <CompleterSettingsButton
-          provider={props.completionProvider}
-          openSettings={props.openInlineCompleterSettings}
-          isCompleterEnabled={isCompleterEnabled}
-          hasCompletionModel={!!completionModel}
+      {/* TODO: Re-enable this when the completion backend works with LiteLLM. */}
+      <Box sx={{ display: 'none' }}>
+        <h2 className="jp-ai-ChatSettings-header">
+          Completion model
+          <CompleterSettingsButton
+            provider={props.completionProvider}
+            openSettings={props.openInlineCompleterSettings}
+            isCompleterEnabled={isCompleterEnabled}
+            hasCompletionModel={!!completionModel}
+          />
+        </h2>
+        <p>
+          Configure the language model used to generate inline completions when
+          editing documents in JupyterLab.
+        </p>
+        {MODEL_ID_HELP}
+        <ModelIdInput
+          modality="completion"
+          label="Completion model ID"
+          placeholder="e.g. 'anthropic/claude-3-5-haiku-latest'"
+          onModelIdFetch={modelId => {
+            setCompletionModel(modelId);
+          }}
         />
-      </h2>
-      <p>
-        Configure the language model used to generate inline completions when
-        editing documents in JupyterLab.
-      </p>
-      <ModelIdInput
-        modality="completion"
-        label="Completion model ID"
-        placeholder="e.g. 'anthropic/claude-3-5-haiku-latest'"
-        onModelIdFetch={latestChatModelId => {
-          setCompletionModel(latestChatModelId);
-        }}
-      />
+      </Box>
 
       {/* Model parameters section */}
       <h2 className="jp-ai-ChatSettings-header">Model parameters</h2>


### PR DESCRIPTION
## Description

- Adds a help message to the "Chat model" section explaining that model IDs now follow the LiteLLM syntax. Includes a link to the documentation.

- Hides the "completion model" form section since they will not work until the completion backend works with LiteLLM. That is being tracked in #1431.

- Fix runtime error noted out by Sanjiv below.

## Demo

<img width="1564" height="726" alt="Screenshot 2025-08-21 at 11 46 38 AM" src="https://github.com/user-attachments/assets/4bd782ea-4a9e-44ee-863a-510247ce0aee" />
