### PR TITLE
Move LiteLLM model list to `jupyter_ai_magics`

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/model_list.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/model_list.py
@@ -1,0 +1,36 @@
+from litellm import all_embedding_models, models_by_provider
+
+chat_model_ids = []
+embedding_model_ids = []
+embedding_model_set = set(all_embedding_models)
+
+for provider_name in models_by_provider:
+    for model_name in models_by_provider[provider_name]:
+        model_name: str = model_name
+
+        if model_name.startswith(f"{provider_name}/"):
+            model_id = model_name
+        else:
+            model_id = f"{provider_name}/{model_name}"
+
+        is_embedding = (
+            model_name in embedding_model_set
+            or model_id in embedding_model_set
+            or "embed" in model_id
+        )
+
+        if is_embedding:
+            embedding_model_ids.append(model_id)
+        else:
+            chat_model_ids.append(model_id)
+
+
+CHAT_MODELS = sorted(chat_model_ids)
+"""
+List of chat model IDs, following the `litellm` syntax.
+"""
+
+EMBEDDING_MODELS = sorted(embedding_model_ids)
+"""
+List of embedding model IDs, following the `litellm` syntax.
+"""

--- a/packages/jupyter-ai/jupyter_ai/model_providers/model_list.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/model_list.py
@@ -1,36 +1,13 @@
-from litellm import all_embedding_models, models_by_provider
-
-chat_model_ids = []
-embedding_model_ids = []
-embedding_model_set = set(all_embedding_models)
-
-for provider_name in models_by_provider:
-    for model_name in models_by_provider[provider_name]:
-        model_name: str = model_name
-
-        if model_name.startswith(f"{provider_name}/"):
-            model_id = model_name
-        else:
-            model_id = f"{provider_name}/{model_name}"
-
-        is_embedding = (
-            model_name in embedding_model_set
-            or model_id in embedding_model_set
-            or "embed" in model_id
-        )
-
-        if is_embedding:
-            embedding_model_ids.append(model_id)
-        else:
-            chat_model_ids.append(model_id)
-
-
-CHAT_MODELS = sorted(chat_model_ids)
 """
-List of chat model IDs, following the `litellm` syntax.
-"""
+This module provides the lists of chat and embedding models available in
+LiteLLM.
 
-EMBEDDING_MODELS = sorted(embedding_model_ids)
+The source of this module is defined in `jupyter_ai_magics` because that package
+needs to be installable without `jupyter_ai`. Therefore, the source has to be
+defined in `jupyter_ai_magics.model_list` for now.
+
+In the future, we may provide a shared `jupyter_ai_models` package that provides
+the model list, allowing `jupyter_ai` and `jupyter_ai_magics` to be mutually
+independent.
 """
-List of embedding model IDs, following the `litellm` syntax.
-"""
+from jupyter_ai_magics.model_list import CHAT_MODELS, EMBEDDING_MODELS


### PR DESCRIPTION
## Description

- Closes #1460 

- Moves the model list to `jupyter_ai_magics` to ensure it does not depend on `jupyter_ai`. Without this change, there would be a cyclic dependency that could make the packages difficult to install & run.