### PR TITLE
Show the AI settings in the right area with Jupyter Notebook

### DIFF
--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -89,10 +89,11 @@ const plugin: JupyterFrontEndPlugin<void> = {
           }
           aiSettings.id = 'jupyter-ai-settings';
           aiSettings.title.label = 'AI settings';
+          aiSettings.title.caption = 'AI settings';
           aiSettings.title.closable = true;
         }
         if (!aiSettings.isAttached) {
-          app?.shell.add(aiSettings, notebookShell ? 'left' : 'main');
+          app?.shell.add(aiSettings, notebookShell ? 'right' : 'main');
         }
         app.shell.activateById(aiSettings.id);
       },


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab/jupyter-ai/pull/1309

Show the "AI Settings" panel in the `right` area. Since the main "Jupyter Chat" panel is already added to the `left` area, this will allow having them open at the same time:

<img width="3600" height="2080" alt="image" src="https://github.com/user-attachments/assets/39487b4a-a0aa-44d8-b4ac-fae37c18533b" />

Also add a `caption` to the settings widget so it appears in the menu:

<img width="1370" height="1828" alt="image" src="https://github.com/user-attachments/assets/971493a7-a7f5-419d-9e67-8c75b77a6437" />
