### PR TITLE
Fix empty directory for Jupyter AI config

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/config_manager.py
@@ -317,6 +317,10 @@ class ConfigManager(Configurable):
         }
 
         self._validate_config(new_config)
+
+        # Create config directory if it doesn't exist.
+        os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
+
         with open(self.config_path, "w") as f:
             json.dump(new_config.model_dump(), f, indent=self.indentation_depth)
 
@@ -361,7 +365,7 @@ class ConfigManager(Configurable):
         user.
 
         If the current chat model is `None`, this returns an empty dictionary.
-        Otherwise, it returns the model arguments set in the dictionary at 
+        Otherwise, it returns the model arguments set in the dictionary at
         `.fields.<chat-model-id>`.
         """
         config = self._read_config()
@@ -401,4 +405,3 @@ class ConfigManager(Configurable):
     def delete_api_key(self, key_name: str):
         # TODO: store in .env files
         pass
-


### PR DESCRIPTION
While testing the Jupyter AI extension in a fresh environment, I noticed the following error:

```
[W 2025-08-27 00:01:18.321 ServerApp] jupyter_ai | extension failed loading with message: FileNotFoundError(2, 'No such file or directory')
    ...
    FileNotFoundError: [Errno 2] No such file or directory: '/Users/avelichk/Library/Jupyter/jupyter_ai/config.json'
[I 2025-08-27 00:01:18.321 ServerApp] ✅ jupyter_ai_tools extension loaded.
```

We should create config directory if it doesn't exist.
I guess, as part of this refactor: https://github.com/jupyterlab/jupyter-ai/pull/1420, we [removed it](https://github.com/jupyterlab/jupyter-ai/pull/1420/files#diff-94ed7187ad14efc118c5c81771c20af6f68ba7a79bce6249150217942542e824L167).

cc @dlqqq @andrii-i @krassowski @Zsailer 