### PR TITLE
Add model parameter type dropdown

### DIFF
--- a/packages/jupyter-ai/src/components/settings/model-parameters-input.tsx
+++ b/packages/jupyter-ai/src/components/settings/model-parameters-input.tsx
@@ -138,11 +138,12 @@ export function ModelParametersInput(
     setParameters(prev =>
       prev.map((param, i) =>
         i === index
-          ? { 
-              ...param, 
-              [field]: value, 
+          ? {
+              ...param,
+              [field]: value,
               // Only mark as non-static if it wasn't already static
-              isStatic: param.isStatic && field !== 'value' ? param.isStatic : false
+              isStatic:
+                param.isStatic && field !== 'value' ? param.isStatic : false
             }
           : param
       )


### PR DESCRIPTION
## References

This addresses issue #1461.                                          

## Code changes

- Replace TextField with Select dropdown for parameter type selection in `model-parameters-input.tsx`                                        
- Add fixed parameter types array: `string`, `integer`, `number`, `boolean`, `array`, `object`
- Add auto-focus functionality to argument value input when type is selected
- Maintain disabled state for static parameters from existing config

## User-facing changes

- Parameter type field is now a dropdown instead of free text input
- Users can only select from predefined parameter types
- Dropdown is disabled for static parameters loaded from existing configuration
- When selecting a parameter type, cursor automatically moves to argument value field for better UX
- Consistent parameter type validation across the application

## Backwards-incompatible changes

None - this only changes the UI input method.