### PR TITLE
Simplify model parameter REST API

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, Literal, Optional
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from typing import Any
@@ -110,26 +111,36 @@ PARAMETER_SCHEMAS: dict[str, dict[str, Any]] = {
     }
 }
 
-def get_parameter_schema(param_name: str) -> dict[str, Any]:
+
+class ParameterSchema(BaseModel):
+    """Pydantic model for parameter schema definition."""
+    type: Literal['boolean', 'integer', 'float', 'string', 'array', 'object']
+    description: str
+    min: Optional[float] = None
+    max: Optional[float] = None
+
+
+class GetModelParametersResponse(BaseModel):
+    """Pydantic model for GET model parameters response."""
+    parameters: dict[str, ParameterSchema]
+    parameter_names: list[str]
+
+
+def get_parameter_schema(param_name: str) -> ParameterSchema:
     """
     Get the schema for a specific parameter.
-
-    TODO: Define a Pydantic model for the parameter schema, e.g.
-    `ParameterSchema`. Update the return type annotation to `ParameterSchema`.
     """
     schema = PARAMETER_SCHEMAS.get(param_name)
     if schema is None:
-        return {
-            "type": "string",
-            "description": f"Parameter {param_name} (schema not defined)"
-        }
-    return schema
+        return ParameterSchema(
+            type="string",
+            description=f"Parameter {param_name} (schema not defined)"
+        )
+    return ParameterSchema(**schema)
 
-def get_parameters_with_schemas(param_names: list[str]) -> dict[str, Any]:
+def get_parameters_with_schemas(param_names: list[str]) -> dict[str, ParameterSchema]:
     """
     Get schemas for a list of parameter names.
-
-    TODO: Update the return type annotation to `dict[str, ParameterSchema]`.
     """
     return {
         name: get_parameter_schema(name) 

--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, cast, Literal, Optional
+from typing import TYPE_CHECKING, cast, Literal, Optional, Any
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
-    from typing import Any
+    pass
 
 
 PARAMETER_SCHEMAS: dict[str, dict[str, Any]] = {
@@ -116,14 +116,18 @@ class ParameterSchema(BaseModel):
     """Pydantic model for parameter schema definition."""
     type: Literal['boolean', 'integer', 'float', 'string', 'array', 'object']
     description: str
-    min: Optional[float] = None
-    max: Optional[float] = None
-
 
 class GetModelParametersResponse(BaseModel):
     """Pydantic model for GET model parameters response."""
     parameters: dict[str, ParameterSchema]
     parameter_names: list[str]
+
+class UpdateModelParametersResponse(BaseModel):
+    """Pydantic model for PUT model parameters response."""
+    status: str
+    message: str
+    model_id: str
+    parameters: dict[str, Any]
 
 
 def get_parameter_schema(param_name: str) -> ParameterSchema:

--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
@@ -7,13 +7,13 @@ if TYPE_CHECKING:
 
 PARAMETER_SCHEMAS: dict[str, dict[str, Any]] = {
     "temperature": {
-        "type": "number",
+        "type": "float",
         "min": 0,
         "max": 2,
         "description": "Controls randomness in the output. Lower values make it more focused and deterministic."
     },
     "top_p": {
-        "type": "number", 
+        "type": "float", 
         "min": 0,
         "max": 1,
         "description": "Nucleus sampling parameter. Consider tokens with top_p probability mass."
@@ -69,13 +69,13 @@ PARAMETER_SCHEMAS: dict[str, dict[str, Any]] = {
     # },
     
     "presence_penalty": {
-        "type": "number",
+        "type": "float",
         "min": -2,
         "max": 2,
         "description": "Penalize new tokens based on whether they appear in the text so far."
     },
     "frequency_penalty": {
-        "type": "number",
+        "type": "float",
         "min": -2,
         "max": 2,
         "description": "Penalize new tokens based on their frequency in the text so far."

--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, cast, Literal, Optional, Any
+from typing import TYPE_CHECKING, cast, Literal, Any
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
     pass
-
 
 PARAMETER_SCHEMAS: dict[str, dict[str, Any]] = {
     "temperature": {

--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
@@ -119,9 +119,6 @@ class GetModelParametersResponse(BaseModel):
 
 class UpdateModelParametersResponse(BaseModel):
     """Pydantic model for PUT model parameters response."""
-    status: str
-    message: str
-    model_id: str
     parameters: dict[str, Any]
 
 def get_parameter_schema(param_name: str) -> ParameterSchema:

--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, cast, Literal, Any
+from typing import Literal, Any
 from pydantic import BaseModel
-
-if TYPE_CHECKING:
-    pass
 
 PARAMETER_SCHEMAS: dict[str, dict[str, Any]] = {
     "temperature": {
@@ -110,7 +107,6 @@ PARAMETER_SCHEMAS: dict[str, dict[str, Any]] = {
     }
 }
 
-
 class ParameterSchema(BaseModel):
     """Pydantic model for parameter schema definition."""
     type: Literal['boolean', 'integer', 'float', 'string', 'array', 'object']
@@ -127,7 +123,6 @@ class UpdateModelParametersResponse(BaseModel):
     message: str
     model_id: str
     parameters: dict[str, Any]
-
 
 def get_parameter_schema(param_name: str) -> ParameterSchema:
     """

--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameters_rest_api.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameters_rest_api.py
@@ -3,7 +3,7 @@ from tornado.web import authenticated, HTTPError
 import json
 
 from litellm.litellm_core_utils.get_supported_openai_params import get_supported_openai_params
-from .parameter_schemas import get_parameters_with_schemas, coerce_parameter_value
+from .parameter_schemas import get_parameters_with_schemas, coerce_parameter_value, GetModelParametersResponse
 from ..config_manager import ConfigManager
 from ..config import UpdateConfigRequest
     
@@ -56,16 +56,14 @@ class ModelParametersRestAPI(BaseAPIHandler):
             # Get parameter schemas with types, defaults, and descriptions
             parameters_with_schemas = get_parameters_with_schemas(parameter_names)
             
-            # TODO: Define the response type as a Pydantic model to prevent
-            # breaking API changes, e.g. `GetModelParametersResponse`.
-            #
-            response = {
-                "parameters": parameters_with_schemas,
-                "parameter_names": parameter_names
-            }
+            # Create Pydantic response model
+            response = GetModelParametersResponse(
+                parameters=parameters_with_schemas,
+                parameter_names=parameter_names
+            )
             
             self.set_header("Content-Type", "application/json")
-            self.finish(json.dumps(response))
+            self.finish(response.model_dump_json())
             
         except Exception as e:
             self.log.exception("Failed to get model parameters")

--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameters_rest_api.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameters_rest_api.py
@@ -59,16 +59,9 @@ class ModelParametersRestAPI(BaseAPIHandler):
             # TODO: Define the response type as a Pydantic model to prevent
             # breaking API changes, e.g. `GetModelParametersResponse`.
             #
-            # TODO: replace 'number' with 'float' in parameter schemas for
-            # clarity. 'number' is ambiguous as to whether it is an integer or
-            # float. Make sure to update the frontend type.
-            #
-            # TODO: Drop 'count' from the response (and the corresponding types
-            # across the frontend & backend).
             response = {
                 "parameters": parameters_with_schemas,
-                "parameter_names": parameter_names,
-                "count": len(parameter_names)
+                "parameter_names": parameter_names
             }
             
             self.set_header("Content-Type", "application/json")
@@ -127,12 +120,9 @@ class ModelParametersRestAPI(BaseAPIHandler):
             )
             config_manager.update_config(update_request)
             
-            # TODO: Determine what a response could be used for, and remove the
-            # response if it is unnecessary. Right now the response body is
-            # ignored by the frontend.
-            #
             # TODO: Define the response type as a Pydantic model to prevent
-            # breaking API changes, e.g. `UpdateModelParametersResponse`.
+            # breaking API changes. Response body is currently unused by frontend
+            # but kept for API compatibility.
             response = {
                 "status": "success",
                 "message": f"Parameters saved for model {model_id}",

--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameters_rest_api.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameters_rest_api.py
@@ -3,7 +3,7 @@ from tornado.web import authenticated, HTTPError
 import json
 
 from litellm.litellm_core_utils.get_supported_openai_params import get_supported_openai_params
-from .parameter_schemas import get_parameters_with_schemas, coerce_parameter_value, GetModelParametersResponse
+from .parameter_schemas import get_parameters_with_schemas, coerce_parameter_value, GetModelParametersResponse, UpdateModelParametersResponse
 from ..config_manager import ConfigManager
 from ..config import UpdateConfigRequest
     
@@ -118,18 +118,16 @@ class ModelParametersRestAPI(BaseAPIHandler):
             )
             config_manager.update_config(update_request)
             
-            # TODO: Define the response type as a Pydantic model to prevent
-            # breaking API changes. Response body is currently unused by frontend
-            # but kept for API compatibility.
-            response = {
-                "status": "success",
-                "message": f"Parameters saved for model {model_id}",
-                "model_id": model_id,
-                "parameters": coerced_parameters,
-            }
+            # Create Pydantic response model for API compatibility
+            response = UpdateModelParametersResponse(
+                status="success",
+                message=f"Parameters saved for model {model_id}",
+                model_id=model_id,
+                parameters=coerced_parameters
+            )
             
             self.set_header("Content-Type", "application/json")
-            self.finish(json.dumps(response))
+            self.finish(response.model_dump_json())
             
         except json.JSONDecodeError:
             raise HTTPError(400, "Invalid JSON in request body")

--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameters_rest_api.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameters_rest_api.py
@@ -120,9 +120,6 @@ class ModelParametersRestAPI(BaseAPIHandler):
             
             # Create Pydantic response model for API compatibility
             response = UpdateModelParametersResponse(
-                status="success",
-                message=f"Parameters saved for model {model_id}",
-                model_id=model_id,
                 parameters=coerced_parameters
             )
             

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -210,13 +210,6 @@ export namespace AiService {
     max?: number;
   };
 
-  export type UpdateModelParametersResponse = {
-    status: string;
-    message: string;
-    model_id: string;
-    parameters: Record<string, any>;
-  };
-
   export async function getModelParameters(
     modelId?: string,
     provider?: string
@@ -238,8 +231,8 @@ export namespace AiService {
   export async function saveModelParameters(
     modelId: string,
     parameters: Record<string, any>
-  ): Promise<UpdateModelParametersResponse> {
-    return await requestAPI<UpdateModelParametersResponse>('model-parameters', {
+  ): Promise<void> {
+    await requestAPI<void>('model-parameters', {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json'

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -200,11 +200,10 @@ export namespace AiService {
   export type GetModelParametersResponse = {
     parameters: Record<string, ParameterSchema>;
     parameter_names: string[];
-    count: number;
   };
 
   export type ParameterSchema = {
-    type: 'boolean' | 'integer' | 'number' | 'string' | 'array' | 'object';
+    type: 'boolean' | 'integer' | 'float' | 'string' | 'array' | 'object';
     description: string;
     min?: number;
     max?: number;

--- a/packages/jupyter-ai/src/handler.ts
+++ b/packages/jupyter-ai/src/handler.ts
@@ -209,6 +209,10 @@ export namespace AiService {
     max?: number;
   };
 
+  export type UpdateModelParametersResponse = {
+    parameters: Record<string, any>;
+  };
+
   export async function getModelParameters(
     modelId?: string,
     provider?: string
@@ -230,8 +234,8 @@ export namespace AiService {
   export async function saveModelParameters(
     modelId: string,
     parameters: Record<string, any>
-  ): Promise<void> {
-    await requestAPI<void>('model-parameters', {
+  ): Promise<UpdateModelParametersResponse> {
+    return await requestAPI<UpdateModelParametersResponse>('model-parameters', {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json'


### PR DESCRIPTION
## Description:
- Fixes #1464 
- Remove unused UpdateModelParametersResponse type from frontend
- Remove redundant count field from GetModelParametersResponse  
- Rename 'number' type to 'float' in ParameterSchema for clarity
- Add Pydantic models for type safety in backend

## Code changes:
- UpdateModelParametersResponse was unused - frontend already has model_id, HTTP status codes handle errors
- GetModelParametersResponse.count is unnecessary - frontend can get array length
- ParameterSchema 'number' type was ambiguous vs 'integer' - now uses clear 'float' type
- Missing Pydantic validation for GetModelParametersResponse and ParameterSchema

## User facing changes:
- No user-facing changes, internal API cleanup and improved type safety