### PR TITLE
[magics] Enhances the `alias` option to include the base API url and key

### DIFF
--- a/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/parsers.py
@@ -88,6 +88,8 @@ class RegisterArgs(BaseModel):
     type: Literal["alias"] = "alias"
     name: str
     target: str
+    api_base: Optional[str] = None
+    api_key_name: Optional[str] = None
 
 
 class DeleteArgs(BaseModel):
@@ -99,6 +101,8 @@ class UpdateArgs(BaseModel):
     type: Literal["update"] = "update"
     name: str
     target: str
+    api_base: Optional[str] = None
+    api_key_name: Optional[str] = None
 
 
 class ResetArgs(BaseModel):
@@ -292,8 +296,23 @@ def list_subparser(**kwargs):
 )
 @click.argument("name")
 @click.argument("target")
+@click.option(
+    "--api-base",
+    required=False,
+    help="Base URL for the API endpoint.",
+)
+@click.option(
+    "--api-key-name",
+    required=False,
+    help="Name of the environment variable containing the API key.",
+)
 def register_subparser(**kwargs):
-    """Register a new alias called NAME for the model or chain named TARGET."""
+    """Register a new alias called NAME for the model or chain named TARGET.
+    
+    Optional parameters:
+    --api-base: Base URL for the API endpoint
+    --api-key-name: Name of the environment variable containing the API key
+    """
     return RegisterArgs(**kwargs)
 
 
@@ -301,15 +320,34 @@ def register_subparser(**kwargs):
     name="dealias", short_help="Delete an alias. See `%ai dealias --help` for options."
 )
 @click.argument("name")
-def register_subparser(**kwargs):
+def dealias_subparser(**kwargs):
     """Delete an alias called NAME."""
     return DeleteArgs(**kwargs)
 
 
+@line_magic_parser.command(
+    name="update",
+    short_help="Update an alias. See `%ai update --help` for options.",
+)
 @click.argument("name")
 @click.argument("target")
-def register_subparser(**kwargs):
-    """Update an alias called NAME to refer to the model or chain named TARGET."""
+@click.option(
+    "--api-base",
+    required=False,
+    help="Base URL for the API endpoint.",
+)
+@click.option(
+    "--api-key-name",
+    required=False,
+    help="Name of the environment variable containing the API key.",
+)
+def update_subparser(**kwargs):
+    """Update an alias called NAME to refer to the model or chain named TARGET.
+    
+    Optional parameters:
+    --api-base: Base URL for the API endpoint
+    --api-key-name: Name of the environment variable containing the API key
+    """
     return UpdateArgs(**kwargs)
 
 
@@ -317,6 +355,6 @@ def register_subparser(**kwargs):
     name="reset",
     short_help="Clear the conversation transcript.",
 )
-def register_subparser(**kwargs):
+def reset_subparser(**kwargs):
     """Clear the conversation transcript."""
     return ResetArgs()


### PR DESCRIPTION
In PR #1471 we added the option to pass the API url and key name in the code cell when using `%%ai` magics. After the model or alias, we pass either or both `--api-base` and `--api-key-name` as needed. 

Here, we add the ability to include the `api-base` and/or `api-key-name` in the alias, which streamlines the use of the alias in magics. The following examples illustrate the usage:

Use an alias with no API options: 
<img width="601" height="426" alt="image" src="https://github.com/user-attachments/assets/1f3c5fe8-46da-4331-b298-04a361e4cf67" />

Use the alias with base API url options: 
<img width="609" height="442" alt="image" src="https://github.com/user-attachments/assets/458fcca2-9638-4752-bd6c-c237e489f65a" />
 
Use the alias with base API url and key-name options: 
<img width="784" height="526" alt="image" src="https://github.com/user-attachments/assets/905e6a9d-375d-4dcc-ba23-f1d2cf80b5bb" />
