### PR TITLE
Add `api_base` to common model parameters

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
+++ b/packages/jupyter-ai/jupyter_ai/model_providers/parameter_schemas.py
@@ -104,6 +104,10 @@ PARAMETER_SCHEMAS: dict[str, dict[str, Any]] = {
         "type": "integer",
         "min": 1,
         "description": "Limit the next token selection to the K most probable tokens."
+    },
+    "api_base": {
+        "type": "string",
+        "description": "Base URL where LLM requests are sent, used for enterprise proxy gateways."
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Jupyter AI! Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://jupyter-ai.readthedocs.io/en/latest/contributors/
-->

## Description

Adds the `api_base: str` model parameter to the common/static set of model parameters shown in the dropdown menu.

## Code changes

Added an "api_base" string schema to the parameter_schemas.py file.

## User-facing changes

Allows users to set the base URL where LLM requests are sent through a proxy gateway.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Jupyter AI public APIs. -->
