### PR TITLE
Upgrade to `jupyterlab-chat` v0.17.0

### DIFF
--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -62,7 +62,7 @@
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@jupyter-notebook/application": "^7.2.0",
-    "@jupyter/chat": "^0.16.0",
+    "@jupyter/chat": "^0.17.0",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.2.0",
     "@jupyterlab/codeeditor": "^4.2.0",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "deepmerge>=2.0,<3",
     # NOTE: Make sure to update the corresponding dependency in
     # `packages/jupyter-ai/package.json` to match the version range below
-    "jupyterlab-chat>=0.16.0,<0.17.0",
+    "jupyterlab-chat>=0.17.0,<0.18.0",
     "litellm>=1.73,<2",
     "jinja2>=3.0,<4",
     "python_dotenv>=1,<2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,7 +2237,7 @@ __metadata:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
     "@jupyter-notebook/application": ^7.2.0
-    "@jupyter/chat": ^0.16.0
+    "@jupyter/chat": ^0.17.0
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.2.0
     "@jupyterlab/builder": ^4.2.0
@@ -2322,9 +2322,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/chat@npm:^0.16.0":
-  version: 0.16.0
-  resolution: "@jupyter/chat@npm:0.16.0"
+"@jupyter/chat@npm:^0.17.0":
+  version: 0.17.0
+  resolution: "@jupyter/chat@npm:0.17.0"
   dependencies:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
@@ -2349,7 +2349,7 @@ __metadata:
     clsx: ^2.1.0
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: c92b195b5b13d57e4cd29d81e8b3f3a75b2eee15540d753fffd3a1b3536706f1d7980dd8af51ff06dbf57bc563631841ee25ad93e4be152da37bb7bcd665806a
+  checksum: 75d906e59c28ae34132011583769bab2ce7e2d727888c7e644f2db0ddda60d9bf46a9c16bac67e55d06ad82319078ec0f6eed5468534bde5fd3c15a279e8be45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Upgrades to `jupyterlab-chat==0.17.0`.

- Fixes #1436.

I am currently uploading `jupyterlab-chat` to Conda Forge. After this PR is merged & released, we will be able to push pre-releases of Jupyter AI onto Conda Forge.

## Code changes

Upgrades to `jupyterlab-chat==0.17.0`.

## User-facing changes

- The current user is filtered from the `@`-mention menu.

- This release should have included a fix for the "Error opening chat" dialogs. https://github.com/jupyterlab/jupyter-chat/pull/260. However, this is not working for me locally:

https://github.com/user-attachments/assets/962edcd0-6aa9-4b8e-ba88-ffd54c1bacb1

I reinstalled `jupyterlab-chat==0.17.0` by running `jlpm dev:reinstall && jlpm && jlpm build`.

## Backwards-incompatible changes

None known.
