### PR TITLE
[2.x] Disable Dask dashboard by default

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -3,13 +3,14 @@ import re
 import time
 import types
 
+import dask
 from dask.distributed import Client as DaskClient
 from importlib_metadata import entry_points
 from jupyter_ai_magics import BaseProvider, JupyternautPersona
 from jupyter_ai_magics.utils import get_em_providers, get_lm_providers
 from jupyter_server.extension.application import ExtensionApp
 from tornado.web import StaticFileHandler
-from traitlets import Dict, Integer, List, Unicode
+from traitlets import Dict, Integer, List, Unicode, Bool
 
 from .chat_handlers.base import BaseChatHandler
 from .completions.handlers import DefaultInlineCompletionHandler
@@ -204,6 +205,17 @@ class AiExtension(ExtensionApp):
         config=True,
     )
 
+    enable_dask_dashboard = Bool(
+        default_value=False,
+        help="""
+        Whether to enable the dask dashboard on port 8787.
+
+        Made an optional trait defaulting to False in v2.31.7.
+        """,
+        allow_none=False,
+        config=True,
+    )
+
     def initialize_settings(self):
         start = time.time()
 
@@ -322,8 +334,15 @@ class AiExtension(ExtensionApp):
         default_chat_handler = self.settings["jai_chat_handlers"]["default"]
         default_chat_handler.send_help_message()
 
-    async def _get_dask_client(self):
-        return DaskClient(processes=False, asynchronous=True)
+    async def _get_dask_client(self) -> DaskClient:
+        # If configured, enabled Dask dashboard
+        if self.enable_dask_dashboard:
+            return DaskClient(processes=False, asynchronous=True)
+
+        # By default, disable Dask dashboard on port 8787
+        dask.config.set({"distributed.dashboard.link": False})
+        return DaskClient(processes=False, asynchronous=True, dashboard_address=None)
+
 
     async def stop_extension(self):
         """


### PR DESCRIPTION
## Description

(note: this only affects Jupyter AI v2. Dask is no longer used in Jupyter AI v3)

By default, Dask serves a dashboard on `localhost:8787` when starting. This feature was intended to be optional by default, but was left enabled by accident. This PR addresses this bug by disabling the Dask dashboard by default, making it an opt-in feature.

## Code changes

- Adds a new `AiExtension.enable_dask_dashboard` trait, which defaults to `False`.
- If `False`, we disable the Dask dashboard and prevent a server from being started on port `8787` instead.
- For some reason, passing `dashboard_address=None` alone still starts a Tornado web server on port `8787` (even though it serves nothing). The `dask.config.set()` call is required to stop the server from starting entirely.

## User-facing changes

See below.

## Backwards-incompatible changes

The Dask dashboard is now opt in. Pass the `--AiExtension.enable_dask_dashboard=True` trait to enable the Dask dashboard on port `8787`.

## Reviewer instructions

1. Start `jupyter lab`
2. Verify that `localhost:8787` returns nothing
3. Restart `jupyter lab --AiExtension.enable_dask_dashboard=True`
4. Verify that `localhost:8787` shows a Dask dashboard (or a page asking you to install `bokeh` dependency to view it).
