### PR TITLE
[Maintenance] Add jupyterlab_commands_toolkit as required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "jupyter_server_mcp>=0.1.2",
   "jupyter_ai_tools>=0.4.1",
   "jupyterlab_notebook_awareness",
+  "jupyterlab_commands_toolkit",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Adds jupyterlab_commands_toolkit as a required dependency. This package is needed for opening files, running cells, and other core operations. It was accidentally missed in the recent RC.