### PR TITLE
Update upstream source of Claude ACP to reflect recent NPM org change.

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -77,7 +77,7 @@ need to install the corresponding package:
 
 ```{tab} Claude Code
 
-    npm install -g @zed-industries/claude-agent-acp
+    npm install -g @agentclientprotocol/claude-agent-acp
 
 ```
 


### PR DESCRIPTION
## Description

NPM now issues a deprecation warning b/c upstream source org for Claude ACP changed, this fixes the docs as per the NPM error message:

```
npm warn deprecated @zed-industries/claude-agent-acp@0.23.1: This package has been renamed to @agentclientprotocol/claude-agent-acp. Please migrate to continue receiving updates.
```