### PR TITLE
docs(contributors): fix wrong URL on jupyter-ai-magic-commands link

### DIFF
--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -25,7 +25,7 @@ The following repositories are stable, i.e., this means the repos are, or are qu
 - [jupyter-server-documents](https://github.com/jupyter-ai-contrib/jupyter-server-documents) - Server side document handling with improved output handling and kernel management/status.
 - [jupyter-server-mcp](https://github.com/jupyter-ai-contrib/jupyter-server-mcp) - An MCP interface/extension for Jupyter Server
 - [jupyterlab-diff](https://github.com/jupyter-ai-contrib/jupyterlab-diff) - JupyterLab commands to show cell and file diffs
-- [jupyter-ai-magic-commands](https://github.com/jupyter-ai-contrib/jupyter-ai-chat-commands) - The code for handling the `%ai` and `%%ai` magic commands in Jupyter notebooks.
+- [jupyter-ai-magic-commands](https://github.com/jupyter-ai-contrib/jupyter-ai-magic-commands) - The code for handling the `%ai` and `%%ai` magic commands in Jupyter notebooks.
 - [jupyter-ai-acp-client](https://github.com/jupyter-ai-contrib/jupyter-ai-acp-client) - A client implementation of the Agent Client Protocol (ACP) as well as helper classes for other developers to use when custom AI personas wrapping ACP agents.
 - [jupyterlab-commands-toolkit](https://github.com/jupyter-ai-contrib/jupyterlab-commands-toolkit) - JupyterLab commands as an AI Toolkit
 


### PR DESCRIPTION
## Summary

`docs/source/contributors/index.md` line 28 contains a copy-paste error in the stable-repos list:

```diff
- - [jupyter-ai-magic-commands](https://github.com/jupyter-ai-contrib/jupyter-ai-chat-commands) - The code for handling the `%ai` and `%%ai` magic commands in Jupyter notebooks.
+ - [jupyter-ai-magic-commands](https://github.com/jupyter-ai-contrib/jupyter-ai-magic-commands) - The code for handling the `%ai` and `%%ai` magic commands in Jupyter notebooks.
```

The link text says **jupyter-ai-magic-commands** but the URL points at the **jupyter-ai-chat-commands** repo (which is already correctly linked two lines earlier). Anyone clicking through expecting the magic-commands code lands on the chat-commands repo instead.

The correct repo at `https://github.com/jupyter-ai-contrib/jupyter-ai-magic-commands` exists (verified HTTP 200), so this PR just fixes the URL to match the link text.

## Why

Contributor onboarding — folks who want to read the `%ai` / `%%ai` magic-command code follow this link and end up in the wrong repo, which is confusing for first-time contributors.

## How to test

Render `docs/source/contributors/index.md` and click the `jupyter-ai-magic-commands` link — it should now land on `jupyter-ai-contrib/jupyter-ai-magic-commands`.

No code or runtime change.