### PR TITLE
Switch from Gemini to Antigravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><i>An open source extension that connects AI agents to computational notebooks in JupyterLab.</i></p>
 
-Jupyter AI brings agentic AI to JupyterLab. It provides a native chat UI where you can collaborate with frontier AI agents — including Claude, Codex, GitHub Copilot, Gemini, Goose, Kiro, Mistral Vibe, and OpenCode — all integrated through the [Agent Client Protocol (ACP)](https://agentclientprotocol.com). Agents are automatically detected when their dependencies are installed, so getting started is as simple as installing Jupyter AI and the agent of your choice.
+Jupyter AI brings agentic AI to JupyterLab. It provides a native chat UI where you can collaborate with frontier AI agents — including Antigravity, Claude, Codex, GitHub Copilot, Goose, Kiro, Mistral Vibe, and OpenCode — all integrated through the [Agent Client Protocol (ACP)](https://agentclientprotocol.com). Agents are automatically detected when their dependencies are installed, so getting started is as simple as installing Jupyter AI and the agent of your choice.
 
 Agents in Jupyter AI can read and write files, run terminal commands, and interact with notebooks through a built-in [Jupyter MCP server](https://github.com/jupyter-ai-contrib/jupyter-server-mcp). A permission system gives you guardrails over agent actions — agents request approval before writing files or executing commands. You can also create multiple concurrent chats, drag and drop files or notebook cells as context, and collaborate in real time with other users connected to the same server.
 

--- a/docs/source/_templates/hero-icon.html
+++ b/docs/source/_templates/hero-icon.html
@@ -159,7 +159,7 @@
         <!-- Copy 1 (buffer above viewport — prevents rendering glitch) -->
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/openai.svg" alt="OpenAI" loading="eager" />
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/anthropic.svg" alt="Anthropic" loading="eager" />
-        <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/gemini.svg" alt="Gemini" loading="eager" />
+        <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/antigravity.svg" alt="Antigravity" loading="eager" />
         <img src="_static/copilot-icon.svg" alt="GitHub Copilot" loading="eager" />
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/goose.svg" alt="Goose" loading="eager" />
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/opencode.svg" alt="OpenCode" loading="eager" />
@@ -168,7 +168,7 @@
         <!-- Copy 2 (middle — this is where the visible window starts) -->
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/openai.svg" alt="OpenAI" loading="eager" />
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/anthropic.svg" alt="Anthropic" loading="eager" />
-        <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/gemini.svg" alt="Gemini" loading="eager" />
+        <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/antigravity.svg" alt="Antigravity" loading="eager" />
         <img src="_static/copilot-icon.svg" alt="GitHub Copilot" loading="eager" />
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/goose.svg" alt="Goose" loading="eager" />
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/opencode.svg" alt="OpenCode" loading="eager" />
@@ -177,7 +177,7 @@
         <!-- Copy 3 (buffer below viewport — for seamless loop continuity) -->
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/openai.svg" alt="OpenAI" loading="eager" />
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/anthropic.svg" alt="Anthropic" loading="eager" />
-        <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/gemini.svg" alt="Gemini" loading="eager" />
+        <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/antigravity.svg" alt="Antigravity" loading="eager" />
         <img src="_static/copilot-icon.svg" alt="GitHub Copilot" loading="eager" />
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/goose.svg" alt="Goose" loading="eager" />
         <img src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/opencode.svg" alt="OpenCode" loading="eager" />

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -61,9 +61,9 @@ least one agent to get started:
 To install agents, follow the official documentation for the agents you wish to
 use:
 
+- [Antigravity CLI](https://antigravity.google/docs/cli-getting-started)
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/quickstart)
 - [Codex CLI](https://developers.openai.com/codex/cli)
-- [Gemini CLI](https://geminicli.com/docs/get-started/installation/)
 - [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli)
 - [Goose](https://block.github.io/goose/docs/getting-started/installation)
 - [Kiro CLI](https://kiro.dev/docs/cli/installation/)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -31,7 +31,7 @@ Collaborate with AI personas and other humans in shared chats. Drag-and-drop att
 :::
 
 :::{grid-item-card} 🤖 Frontier Agents
-Use Claude, Codex, GitHub Copilot, Gemini, Goose, Kiro, Mistral Vibe, OpenCode, or other agents directly in JupyterLab.
+Use Antigravity, Claude, Codex, GitHub Copilot, Goose, Kiro, Mistral Vibe, OpenCode, or other agents directly in JupyterLab.
 :::
 
 :::{grid-item-card} ⚡ Real-Time UI

--- a/docs/source/users/troubleshooting.md
+++ b/docs/source/users/troubleshooting.md
@@ -17,6 +17,12 @@ OpenCode, will also require you to select an LLM before usage.
 
 ````{tabs}
 
+```{tab} Antigravity
+
+    agy
+
+```
+
 ```{tab} Claude
 
     claude login
@@ -32,12 +38,6 @@ OpenCode, will also require you to select an LLM before usage.
 ```{tab} GitHub Copilot
 
     copilot login
-
-```
-
-```{tab} Gemini
-
-    gemini auth login
 
 ```
 


### PR DESCRIPTION

## Description

Follow the official statement from Google: ﻿https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/

Gemini will be phased out on June 18, 2026

## Code changes

- [x] Update the documentation to reflect the change

## User-facing changes

Documentation changes:

<img width="1056" height="486" alt="image" src="https://github.com/user-attachments/assets/cd381473-4b5f-4efc-8330-d5d101dd6795" />



## Backwards-incompatible changes

None