### PR TITLE
Harden the GH actions

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,5 +1,7 @@
 name: Check Release
 
+permissions: {}
+
 on:
   push:
     branches: ["*"]
@@ -9,25 +11,41 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+
+    - name: Run zizmor 🌈
+      uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+
   check_release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup environment
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
         with:
           python_version: "3.11.x"
 
       - name: Check Release
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: "12.34.56"
 
       - name: Upload Distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jupyter-ai-jupyter-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -11,4 +11,4 @@ jobs:
       pull-requests: write
     steps:
       - name: enforce-triage-label
-        uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@95d85449e4f3f352e261221f6529f8ed307f5728 # v1

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -29,11 +29,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
 
       - name: Prep Release
         id: prep-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}
@@ -45,4 +45,6 @@ jobs:
 
       - name: "** Next Step **"
         run: |
-          echo "Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}"
+          echo "Optional): Review Draft Release: ${STEPS_PREP_RELEASE_OUTPUTS_RELEASE_URL}"
+        env:
+          STEPS_PREP_RELEASE_OUTPUTS_RELEASE_URL: ${{ steps.prep-release.outputs.release_url }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,17 +19,18 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
 
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Populate Release
         id: populate-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.event.inputs.branch }}
@@ -40,7 +41,7 @@ jobs:
         id: finalize-release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
@@ -49,10 +50,14 @@ jobs:
         if: ${{ success() }}
         run: |
           echo "Verify the final release"
-          echo ${{ steps.finalize-release.outputs.release_url }}
+          echo ${STEPS_FINALIZE_RELEASE_OUTPUTS_RELEASE_URL}
+        env:
+          STEPS_FINALIZE_RELEASE_OUTPUTS_RELEASE_URL: ${{ steps.finalize-release.outputs.release_url }}
 
       - name: "** Failure Message **"
         if: ${{ failure() }}
         run: |
           echo "Failed to Publish the Draft Release Url:"
-          echo ${{ steps.populate-release.outputs.release_url }}
+          echo ${STEPS_POPULATE_RELEASE_OUTPUTS_RELEASE_URL}
+        env:
+          STEPS_POPULATE_RELEASE_OUTPUTS_RELEASE_URL: ${{ steps.populate-release.outputs.release_url }}


### PR DESCRIPTION
## Description

Closes #1576.

## Code changes

These changes:

- Set the default permissions as conservatively as possible
- Pins all the currently-used github actions to commit hashes
- Changes some places where template expansion can be abused to use environment variables instead, bypassing the problem
- Prevents the git credentials from being persisted beyond checkout
- Adds a new job to the "Check Release" workflow, which runs on every pull request, that runs the zizmor action (so that these types of vulnerabilities can't get into the code base in the future)

For the most part these fixes were auto-generated by zizmor.

## User-facing changes

None

## Backwards-incompatible changes

None