### PR TITLE
Prep Jupyter AI v3.0.1

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -258,6 +258,7 @@ configured MCP servers will be available to every ACP agent in your session.
 ```{toctree}
 :hidden:
 
+versioning
 troubleshooting
 magic_commands/index
 jupyternaut/index

--- a/docs/source/users/versioning.md
+++ b/docs/source/users/versioning.md
@@ -1,0 +1,86 @@
+# Versioning and upgrading
+
+Jupyter AI is built from many smaller subpackages (for example
+`jupyter_ai_router`, `jupyter_ai_persona_manager`, and `jupyter_ai_tools`).
+These subpackages follow [SemVer](https://semver.org/), and because this is a
+fast-moving field, most are still on `0.x` versions, where we treat **every
+minor release as potentially breaking**.
+
+We apply the same convention to Jupyter AI itself:
+
+- **Patch releases** (e.g. `3.0.0` → `3.0.1`) only raise dependency **floors**
+  to require API-compatible patches of subpackages.
+- **Minor releases** (e.g. `3.0.x` → `3.1.0`) raise dependency **ceilings** to
+  introduce new features with API-breaking changes.
+
+To keep subpackages from silently breaking installed environments, `jupyter_ai`
+puts a **version ceiling** on each subpackage dependency that blocks its next
+breaking version — for example `jupyter_ai_tools>=0.5.2,<0.6.0`. This lets
+subpackages ship breaking changes on their own schedule without breaking your
+`jupyter_ai` installation.
+
+We currently do not have the bandwidth to support older versions of Jupyter AI.
+We will only backport patches in exceptional circumstances (e.g. a major
+security vulnerability), using community feedback as a reference point.
+
+## For users
+
+### Upgrade frequently
+
+Because Jupyter AI moves fast, **we recommend upgrading as frequently as
+possible** to pull in the latest changes. Most users should stay on the newest
+release.
+
+We recommend **not** upgrading with `pip` directly — its dependency solver is
+not very good and may pull in incompatible versions. Prefer an environment
+manager such as `conda`, `mamba`, `micromamba`, `uv`, or `pixi`.
+
+````{tabs}
+
+```{tab} micromamba (recommended)
+
+    micromamba update -c conda-forge jupyter-ai
+
+```
+
+```{tab} uv
+
+    uv pip install -U jupyter-ai
+
+```
+
+```{tab} venv / pip
+
+    source .venv/bin/activate
+    pip install -U jupyter-ai
+
+```
+
+````
+
+### Chat files are not forwards-compatible
+
+We do **not** promise that chat files are fully forwards-compatible — a chat
+created in an older version of Jupyter AI may not work in a newer one. If you
+need to carry context forward across an upgrade, we recommend asking an agent to
+read the old chat file and summarize its context for re-use in a new chat.
+
+## For extension developers
+
+If you build an extension on top of Jupyter AI and import directly from one of
+its subpackages, **add a version range around each specific subpackage whose
+API you consume.** This prevents your environment solver from pulling in an
+API-breaking release of that subpackage (as long as you are not using native
+`pip`, whose solver does not enforce this reliably).
+
+```toml
+# your extension's pyproject.toml
+dependencies = [
+  "jupyter_ai_tools>=0.5.2,<0.6.0",  # or ==0.5.2 for an exact pin
+]
+```
+
+Don't rely on the range that `jupyter_ai` declares — it exists to keep
+`jupyter_ai` working, not to guarantee the specific API you import stays the
+same. When you upgrade past a breaking boundary, review the subpackage's
+changelog and update your pin after confirming your code still works.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,21 +28,21 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-  "jupyterlab_chat>=0.21.0",
-  "jupyter_server_documents>=0.1.2",
-  "jupyter_ai_router>=0.0.3",
-  "jupyter_ai_persona_manager>=0.0.8",
-  "jupyter_ai_chat_commands>=0.0.4",
-  "jupyter_ai_acp_client>=0.1.0",
-  "jupyter_server_mcp>=0.1.2",
-  "jupyter_ai_tools>=0.4.1",
-  "jupyterlab_notebook_awareness>=0.2.0",
-  "jupyterlab_commands_toolkit>=0.1.4",
+  "jupyterlab_chat>=0.22.1,<0.23.0",
+  "jupyter_server_documents>=0.2.5,<0.3.0",
+  "jupyter_ai_router>=0.0.5,<0.1.0",
+  "jupyter_ai_persona_manager>=0.0.11,<0.1.0",
+  "jupyter_ai_chat_commands>=0.0.4,<0.1.0",
+  "jupyter_ai_acp_client>=0.1.5,<0.2.0",
+  "jupyter_server_mcp>=0.2.1,<0.3.0",
+  "jupyter_ai_tools>=0.5.2,<0.6.0",
+  "jupyterlab_notebook_awareness>=0.2.0,<0.3.0",
+  "jupyterlab_commands_toolkit>=0.1.6,<0.2.0",
 ]
 
 [project.optional-dependencies]
-magics = ["jupyter_ai_litellm>=0.0.2", "jupyter_ai_magic_commands>=0.0.3"]
-jupyternaut = ["jupyter_ai_litellm>=0.0.2", "jupyter_ai_jupyternaut>=0.0.11"]
+magics = ["jupyter_ai_litellm>=0.0.2,<0.1.0", "jupyter_ai_magic_commands>=0.0.3,<0.1.0"]
+jupyternaut = ["jupyter_ai_litellm>=0.0.2,<0.1.0", "jupyter_ai_jupyternaut>=0.0.11,<0.1.0"]
 
 [project.urls]
 Documentation = "https://jupyter-ai.readthedocs.io/en/v3/"


### PR DESCRIPTION

## Summary

Adds **version ceilings** to all of `jupyter_ai`'s subpackage dependencies. We
are working on new breaking changes for **Jupyter AI v3.1.0**, so we need these
ceilings now: without them, a breaking subpackage release would silently break
installed `jupyter_ai` environments. The ceilings let subpackages ship breaking
changes on their own schedule while keeping existing `jupyter_ai` installs
working.

## Changes

- **`pyproject.toml`** — for every existing subpackage dependency (in both
  `dependencies` and the `magics`/`jupyternaut` extras), raised the floor to the
  latest released (non-prerelease) version on PyPI and added a ceiling blocking
  the next breaking version. Per SemVer, the next breaking version of a `0.x`
  package is the next minor (`0.5.2` → `>=0.5.2,<0.6.0`). No new dependencies
  were added.
- **`docs/source/users/versioning.md`** (new) — documents the versioning and
  upgrade strategy: we follow SemVer (patch releases raise floors, minor
  releases raise ceilings), recommend upgrading frequently via an environment
  manager rather than native `pip`, note that chat files are not forwards-
  compatible, and tell extension developers to pin the specific subpackage APIs
  they consume. Wired into the users guide toctree.

## Notes

- The package version (`jupyter_ai/__init__.py`) is intentionally **not** bumped
  here — that is handled by `jupyter-releaser` at release time.