### PR TITLE
Prep v3.1.0b0 : new UI + JSD v0.3 beta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ dynamic = ["version"]
 
 dependencies = [
   "jupyterlab_chat>=0.22.1,<0.23.0",
-  "jupyter_server_documents>=0.2.5,<0.3.0",
+  "jupyter_server_documents>=0.3.0b0,<0.4.0",
   "jupyter_ai_router>=0.0.5,<0.1.0",
-  "jupyter_ai_persona_manager>=0.0.11,<0.1.0",
+  "jupyter_ai_persona_manager>=0.1.0b0,<0.3.0",
   "jupyter_ai_chat_commands>=0.0.4,<0.1.0",
-  "jupyter_ai_acp_client>=0.1.5,<0.2.0",
+  "jupyter_ai_acp_client>=0.2.0b0,<0.3.0",
   "jupyter_server_mcp>=0.2.1,<0.3.0",
   "jupyter_ai_tools>=0.5.2,<0.6.0",
   "jupyterlab_notebook_awareness>=0.2.0,<0.3.0",


### PR DESCRIPTION

## Summary

Preps the **Jupyter AI v3.1.0b0** release by refreshing the version ranges on
three fast-moving subpackages. Because this is a beta release, the floors are
intentionally pinned to prerelease (`b0`) versions.

## Changes

Updated `pyproject.toml` `[project] dependencies`:

| Package | Before | After |
|---|---|---|
| `jupyter_ai_persona_manager` | `>=0.0.11,<0.1.0` | `>=0.1.0b0,<0.3.0` |
| `jupyter_ai_acp_client` | `>=0.1.5,<0.2.0` | `>=0.2.0b0,<0.3.0` |
| `jupyter_server_documents` | `>=0.2.5,<0.3.0` | `>=0.3.0b0,<0.4.0` |

No new dependencies were added and no other ranges were changed. `__version__`
is untouched (jupyter-releaser bumps it at release time). The versioning-strategy
doc is already present and wired into the toctree.

## Notes

- `jupyter_ai_acp_client==0.2.0b0` is **not yet released on PyPI**, so CI will
  fail to resolve it until it's published. This is expected — re-run CI (close &
  re-open) once the package is available.