### PR TITLE
Bump `jupyter-releaser` action pin to `1.11.2`

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -39,7 +39,7 @@ jobs:
           python_version: "3.11.x"
 
       - name: Check Release
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af # v2 (1.11.2, pins fastcore<2)
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: "12.34.56"

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -39,7 +39,7 @@ jobs:
           python_version: "3.11.x"
 
       - name: Check Release
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af # v2 (1.11.2, pins fastcore<2)
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@70e58c50c736ad496cca11fe4f2446033b68b027 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: "12.34.56"

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Prep Release
         id: prep-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af # v2 (1.11.2, pins fastcore<2)
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Prep Release
         id: prep-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af # v2 (1.11.2, pins fastcore<2)
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@70e58c50c736ad496cca11fe4f2446033b68b027 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Populate Release
         id: populate-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af # v2 (1.11.2, pins fastcore<2)
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.event.inputs.branch }}
@@ -41,7 +41,7 @@ jobs:
         id: finalize-release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af # v2 (1.11.2, pins fastcore<2)
         with:
           token: ${{ steps.app-token.outputs.token }}
           release_url: ${{ steps.populate-release.outputs.release_url }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Populate Release
         id: populate-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af # v2 (1.11.2, pins fastcore<2)
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@70e58c50c736ad496cca11fe4f2446033b68b027 # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.event.inputs.branch }}
@@ -41,7 +41,7 @@ jobs:
         id: finalize-release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af # v2 (1.11.2, pins fastcore<2)
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@70e58c50c736ad496cca11fe4f2446033b68b027 # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           release_url: ${{ steps.populate-release.outputs.release_url }}


### PR DESCRIPTION
Fixes the release workflows, blocked since Jul 9: Step 1: Prep Release fails with `AttributeError: 'list' object has no attribute 'starmap'` (run 29057711558). `fastcore` 2.0 broke `ghapi` inside `jupyter-releaser` (jupyter-server/jupyter_releaser#659), and the releaser actions install from their own pinned checkout, so re-runs cannot pick up the upstream fix.

Advances the pinned releaser action SHA in `check-release`, `prep-release`, and `publish-release` to the commit the `v2` tag resolves to, which includes the `fastcore<2` pin (jupyter-server/jupyter_releaser#661).