### PR TITLE
Prep Jupyter AI v3.1.0b2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,12 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-  "jupyterlab_chat>=0.22.1,<0.23.0",
+  "jupyterlab_chat>=0.23.0a3,<0.24.0",
   "jupyter_server_documents>=0.3.0,<0.4.0",
   "jupyter_ai_router>=0.0.5,<0.1.0",
-  "jupyter_ai_persona_manager>=0.1.0b0,<0.3.0",
+  "jupyter_ai_persona_manager>=0.1.0b1,<0.3.0",
   "jupyter_ai_chat_commands>=0.0.4,<0.1.0",
-  "jupyter_ai_acp_client>=0.2.0b0,<0.3.0",
+  "jupyter_ai_acp_client>=0.2.0b1,<0.3.0",
   "jupyter_server_mcp>=0.2.1,<0.3.0",
   "jupyter_ai_tools>=0.6.0,<0.7.0",
   "jupyterlab_notebook_awareness>=0.2.0,<0.3.0",


### PR DESCRIPTION
## Motivation

The 3.1 line brings in new subpackage work (metadata-based routing, the awareness API, and related changes). To pull those in, `jupyter-ai`'s dependency floors need to move up to the pre-releases that carry them.

## Summary

Raises the floors on the persona manager and ACP client to their latest pre-releases, and moves `jupyterlab_chat` onto the 0.23 line to satisfy the ACP client. `jupyter_server_documents` was already at its intended floor and is left as-is. Ceilings are unchanged except for `jupyterlab_chat`, whose ceiling moves with its floor.

## Technical details

- `jupyter_ai_persona_manager` → `>=0.1.0b1`
- `jupyter_ai_acp_client` → `>=0.2.0b1`
- `jupyter_ai_acp_client` 0.2.0b1 requires `jupyterlab-chat>=0.23.0a3`, so `jupyterlab_chat` moves to `>=0.23.0a3,<0.24.0`.

No package version bump here — `jupyter-releaser` handles that at release time.

## Testing

`uv sync` resolves cleanly and `import jupyter_ai` works in the resulting environment.