### PR TITLE
Declare doc requirements as optional dependency group

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Install docs + test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r docs/requirements.txt
-          pip install sphinx pytest packaging
+          # The `docs` extra is the single source of truth for docs build deps.
+          pip install ".[docs]" pytest packaging
 
       - name: Run aggregation integration tests
         run: pytest docs/tests -v

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,4 +23,10 @@ sphinx:
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    # Install jupyter-ai with its `docs` extra — the single source of truth for
+    # documentation build dependencies (see [project.optional-dependencies] in
+    # pyproject.toml).
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-myst_parser
-shibuya
-sphinx-copybutton
-sphinx-design
-sphinx-tabs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,17 @@ dependencies = [
 [project.optional-dependencies]
 magics = ["jupyter_ai_litellm>=0.0.2,<0.1.0", "jupyter_ai_magic_commands>=0.0.3,<0.1.0"]
 jupyternaut = ["jupyter_ai_litellm>=0.0.2,<0.1.0", "jupyter_ai_jupyternaut>=0.0.11,<0.1.0"]
+# Everything needed to build the documentation (`sphinx-build docs/source`).
+# This is the single source of truth for docs dependencies, used by both Read
+# the Docs (see .readthedocs.yaml) and the docs CI workflow.
+docs = [
+  "sphinx",
+  "myst_parser",
+  "shibuya",
+  "sphinx-copybutton",
+  "sphinx-design",
+  "sphinx-tabs",
+]
 
 [project.urls]
 Documentation = "https://jupyter-ai.readthedocs.io/en/v3/"


### PR DESCRIPTION
## Summary

Documentation build dependencies were split across two places: `docs/requirements.txt` (the theme + Sphinx extensions) and the build environment (which provided `sphinx` itself, since `requirements.txt` didn't list it). This consolidates them into a single `docs` extra in `pyproject.toml`, so there's one source of truth and the docs are buildable with a standard `pip install ".[docs]"`.

## Changes

- **`pyproject.toml`** — add a `docs` extra under `[project.optional-dependencies]` containing `sphinx` + the theme/extensions that were in `docs/requirements.txt`.
- **`.readthedocs.yaml`** — install the package with its `[docs]` extra (`method: pip`, `extra_requirements: [docs]`) instead of `-r docs/requirements.txt`.
- **`.github/workflows/docs-build.yml`** — `pip install ".[docs]"` instead of `-r docs/requirements.txt` plus a separate `sphinx` install.
- **Remove `docs/requirements.txt`.**

## Notes

- `sphinx` is now explicitly declared (previously implied by the build environment), so `pip install ".[docs]" && sphinx-build docs/source docs/_build/html` works from a bare venv.
- Dependencies are left unpinned, matching the previous `docs/requirements.txt`.
- Verified locally: `pip install ".[docs]"` provides everything, `sphinx-build` succeeds, and the docs aggregation integration tests (`docs/tests`) still pass.