### PR TITLE
Fix: show subpackage docs in sidebar

### DIFF
--- a/docs/source/_ext/subpackage_docs.py
+++ b/docs/source/_ext/subpackage_docs.py
@@ -14,9 +14,10 @@ Sphinx build as versioned subpages::
     submodules/<repo>/docs/source/developers/    ->  developers/<repo>/
 
 The full subtree is copied (so a subpackage may ship nested pages + images),
-and each subpackage's own ``index`` H1 becomes its subpage title. A hidden
+and each subpackage's own ``index`` H1 becomes its subpage title. A
 ``{toctree}`` entry is then injected into the matching aggregation page
-(``contributors/index`` or ``developers/index``).
+(``contributors/index`` or ``developers/index``) so the subpage appears in that
+section's sidebar navigation.
 
 Rollout is gradual: most subpackages do not define these docs yet, so most
 submodules contribute nothing and the build renders no new pages. A subpackage
@@ -106,12 +107,13 @@ def _stage_subpackage_docs(app: Sphinx) -> None:
 
 
 def _inject_subpackage_toctrees(app: Sphinx, docname: str, source: list[str]) -> None:
-    """Append a hidden toctree of staged subpages to each aggregation index.
+    """Append a toctree of staged subpages to each aggregation index.
 
     Runs on ``source-read``. When Sphinx reads ``contributors/index`` or
-    ``developers/index``, append a hidden ``{toctree}`` listing the subpages
-    staged for that section. Each subpackage's own ``index`` H1 supplies the
-    nav title.
+    ``developers/index``, append a ``{toctree}`` listing the subpages staged for
+    that section. Each subpackage's own ``index`` H1 supplies the nav title. The
+    toctree is not ``:hidden:`` so the subpackages surface both in the section's
+    sidebar navigation and as a "Subpackages" list on the index page itself.
     """
     staged = getattr(app, "_subpackage_docs_staged", {})
     for section in AGGREGATION_SECTIONS:
@@ -122,7 +124,8 @@ def _inject_subpackage_toctrees(app: Sphinx, docname: str, source: list[str]) ->
             return
         entries = "\n".join(f"{repo}/index" for repo in repos)
         source[0] += (
-            "\n\n```{toctree}\n:hidden:\n:caption: Subpackages\n\n" f"{entries}\n```\n"
+            "\n\n```{toctree}\n:caption: Subpackages\n:maxdepth: 1\n\n"
+            f"{entries}\n```\n"
         )
 
 

--- a/docs/tests/conftest.py
+++ b/docs/tests/conftest.py
@@ -19,6 +19,7 @@ extension locates ``submodules/`` exactly as it does in the real build
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -30,8 +31,11 @@ _TESTS_DIR = Path(__file__).resolve().parent
 _REAL_SOURCE = _TESTS_DIR.parent / "source"
 _EXT_DIR = _REAL_SOURCE / "_ext"
 
-# A minimal conf.py that loads only what the aggregation needs: MyST (for the
-# Markdown fixtures) and the subpackage_docs extension under test.
+# A minimal conf.py for the fixtures. It uses the real site theme (shibuya) so
+# the tests exercise the actual sidebar-navigation rendering — a page-local
+# toctree can render in the page body while still failing to appear in the
+# global nav, so a body-only assertion (e.g. under the "basic" theme) would miss
+# that regression.
 _CONF_PY = """
 import os
 import sys
@@ -42,7 +46,7 @@ project = "Test Site"
 extensions = ["myst_parser", "subpackage_docs"]
 myst_enable_extensions = ["colon_fence"]
 exclude_patterns = []
-html_theme = "basic"
+html_theme = "shibuya"
 """
 
 # Root index tying the two aggregation pages into the doctree.
@@ -85,6 +89,18 @@ class Build:
 
     def exists(self, docpath: str) -> bool:
         return (self.outdir / f"{docpath}.html").is_file()
+
+    def nav_hrefs(self, docpath: str) -> list[str]:
+        """Return the sidebar navigation (toctree) hrefs on a rendered page.
+
+        These are the links the theme renders in its `toctree-l*` nav tree — i.e.
+        what a reader can actually click to navigate, as opposed to links that
+        merely appear in the page body or in `<head>` rel-links.
+        """
+        html = self.html(docpath)
+        return re.findall(
+            r'class="toctree-l\d[^"]*"[^>]*>\s*<a[^>]*href="([^"]+)"', html
+        )
 
 
 @pytest.fixture

--- a/docs/tests/test_subpackage_docs.py
+++ b/docs/tests/test_subpackage_docs.py
@@ -41,14 +41,15 @@ def test_contributors_only(make_site):
     # Subpage rendered and its H1 present.
     assert build.exists("contributors/my-contrib/index")
     assert "My Contrib Guide" in build.html("contributors/my-contrib/index")
-    # Nav entry injected into the Contributing index (links to the subpage).
-    assert "my-contrib/index.html" in build.html("contributors/index")
+    # The subpage must be reachable from the Contributing index via the sidebar
+    # navigation (not merely present in the body / <head> rel-links) — this is
+    # what makes it clickable from contributors/index.
+    assert "my-contrib/index.html" in build.nav_hrefs("contributors/index")
 
-    # Not staged under Developers, and the Developers index has no toctree link
-    # to it. (The title may appear in the global nav sidebar on every page; we
-    # assert on the staged path, which is unambiguous.)
+    # It must not be staged under Developers. (The global sidebar shows every
+    # section on every page, so we check it was not aggregated into the
+    # developers/ tree, i.e. no developers/my-contrib page exists.)
     assert not build.exists("developers/my-contrib/index")
-    assert "developers/my-contrib" not in build.html("developers/index")
 
 
 def test_developers_only(make_site):
@@ -62,10 +63,9 @@ def test_developers_only(make_site):
 
     assert build.exists("developers/my-dev/index")
     assert "My Dev API" in build.html("developers/my-dev/index")
-    assert "my-dev/index.html" in build.html("developers/index")
+    assert "my-dev/index.html" in build.nav_hrefs("developers/index")
 
     assert not build.exists("contributors/my-dev/index")
-    assert "contributors/my-dev" not in build.html("contributors/index")
 
 
 def test_both_sections(make_site):
@@ -81,9 +81,9 @@ def test_both_sections(make_site):
     assert build.returncode == 0, build.stderr
 
     assert "Full Pkg Contributing" in build.html("contributors/full-pkg/index")
-    assert "full-pkg/index.html" in build.html("contributors/index")
+    assert "full-pkg/index.html" in build.nav_hrefs("contributors/index")
     assert "Full Pkg Developing" in build.html("developers/full-pkg/index")
-    assert "full-pkg/index.html" in build.html("developers/index")
+    assert "full-pkg/index.html" in build.nav_hrefs("developers/index")
 
 
 def test_neither_and_missing_index_skipped(make_site):
@@ -144,8 +144,10 @@ def test_full_subtree_with_nested_page_and_image(make_site):
     assert "Nested Page" in build.html("contributors/rich-pkg/subdir/nested")
     # The image was copied into the build output.
     assert (build.outdir / "_images").is_dir()
-    # Nav entry for the subpackage present on the aggregation index.
-    assert "rich-pkg/index.html" in build.html("contributors/index")
+    # Nav entry for the subpackage present in the aggregation index sidebar,
+    # and the nested page reachable from the subpackage's own index sidebar.
+    assert "rich-pkg/index.html" in build.nav_hrefs("contributors/index")
+    assert "subdir/nested.html" in build.nav_hrefs("contributors/rich-pkg/index")
 
 
 def test_baseline_no_submodules(make_site):


### PR DESCRIPTION
## Summary

Follow-up bug fix to the subpackage-docs aggregation ([#1595](https://github.com/jupyterlab/jupyter-ai/pull/1595)). The aggregation injected a **`:hidden:`** `{toctree}` into `contributors/index` and `developers/index`. With the site's `shibuya` theme, a hidden toctree's entries weren't surfaced in the section's sidebar on the index page itself — so a reader on `contributors/index.html` had **no clickable link** to an aggregated subpackage's pages (only the prev/next `<head>` rel-links pointed there). The pages built and were reachable by URL, just not navigable.

## Fix

Drop `:hidden:` from the injected toctree. The subpackage now appears both in the section's **sidebar navigation** and as a "Subpackages" list on the index page, matching how the hand-authored `developers/index` toctree (`entry_points_api`) already behaves.

## Why the tests didn't catch it

The integration tests used the `basic` theme and asserted on raw body HTML. A page-local toctree renders in the body under `basic` regardless of whether it threads into the real theme's sidebar, so the regression was invisible.

This PR:
- Switches the fixture build to the **real theme (`shibuya`)**.
- Adds a `Build.nav_hrefs()` helper that extracts the rendered **sidebar `toctree-l*` links**, and asserts subpages are reachable from there — not merely present in the body.

Verified by building the real docs with a subpackage's docs overlaid: the subpackage and its nested pages now show under Contributor Guide in the sidebar. All 6 integration tests pass.