### PR TITLE
Distinguish `latest` v.s. `stable` docs

### DIFF
--- a/.github/workflows/update-submodule-docs.yml
+++ b/.github/workflows/update-submodule-docs.yml
@@ -1,18 +1,24 @@
 name: Update submodule documentation
 
-# Manually-triggered wrapper around scripts/update-doc-submodules.sh. It
-# re-pins every documentation submodule to the latest tag matching its version
-# range in pyproject.toml (PEP 440 semantics via the `packaging` library) and
-# opens a PR with the result. This is the same script that seeded the submodules
-# originally, so a manual run and the seed PR stay consistent.
+# Refreshes the documentation submodules so the `latest` docs (built from this
+# repo's `main`) always track each subpackage's newest docs. It runs
+# scripts/update-doc-submodules.sh in its default `main` mode — pinning every
+# submodule to its default-branch HEAD — and commits the result directly to
+# `main`. No subpackage release is required for its docs to appear on `latest`.
 #
-# The branch push and PR are created with the built-in `gh` CLI using the
-# ephemeral GITHUB_TOKEN, so no third-party action ever holds write credentials.
+# (Release tags get a frozen snapshot instead, via the after-bump-version hook
+# in pyproject.toml; see scripts/freeze-doc-submodules.sh.)
+#
+# Runs on a daily schedule and on demand. The commit is pushed with the built-in
+# ephemeral GITHUB_TOKEN, so no third-party action holds write credentials.
 
 on:
   workflow_dispatch:
+  schedule:
+    # Daily at 06:00 UTC.
+    - cron: "0 6 * * *"
 
-# Only one repin run at a time; a newer dispatch supersedes an in-flight one.
+# Only one repin run at a time; a newer run supersedes an in-flight one.
 concurrency:
   group: update-submodule-docs
   cancel-in-progress: true
@@ -21,18 +27,17 @@ permissions: {}
 
 jobs:
   update-submodules:
-    name: Re-pin documentation submodules and open PR
+    name: Re-pin documentation submodules to subpackage main
     runs-on: ubuntu-latest
     permissions:
-      contents: write # push the update branch to this repo
-      pull-requests: write # open the PR with the updated pins
+      contents: write # commit the refreshed pins to main
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # We need a full checkout with submodule config so the script can move
-          # the gitlinks. We do NOT persist the checkout credentials; the push
-          # below authenticates explicitly with the ephemeral GITHUB_TOKEN.
+          # Full checkout with submodule config so the script can move the
+          # gitlinks. Credentials are not persisted; the push below authenticates
+          # explicitly with the ephemeral GITHUB_TOKEN.
           persist-credentials: false
           submodules: true
           fetch-depth: 0
@@ -45,42 +50,24 @@ jobs:
       - name: Install resolver dependencies
         run: pip install packaging
 
-      - name: Re-pin documentation submodules
-        run: bash scripts/update-doc-submodules.sh
+      - name: Re-pin documentation submodules to subpackage main
+        run: bash scripts/update-doc-submodules.sh --mode main
 
-      - name: Open pull request
+      - name: Commit to main
         env:
           GH_TOKEN: ${{ github.token }}
-          BRANCH: update-submodule-docs
         run: |
           set -euo pipefail
 
-          # Nothing changed → nothing to open.
           if git diff --quiet && git diff --cached --quiet; then
-            echo "No submodule pin changes; skipping PR."
+            echo "No submodule pin changes; nothing to commit."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "docs: refresh submodule documentation to subpackage main"
 
-          git checkout -B "$BRANCH"
-          git commit -am "docs: update submodule documentation pins"
-
-          # Authenticate the push with the ephemeral workflow token.
-          git push --force-with-lease \
+          git push \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "HEAD:refs/heads/${BRANCH}"
-
-          # Create the PR if one is not already open for this branch.
-          if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
-            gh pr create \
-              --head "$BRANCH" \
-              --title "docs: update submodule documentation pins" \
-              --label documentation \
-              --body "Automated update of the documentation submodule pins by the **Update submodule documentation** workflow.
-
-          Each submodule under \`submodules/\` has been re-pinned to the latest git tag matching its version range in \`pyproject.toml\` (see \`scripts/update-doc-submodules.sh\`)."
-          else
-            echo "PR for $BRANCH already open; pushed updated pins to it."
-          fi
+            "HEAD:${GITHUB_REF_NAME}"

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Jupyter AI is designed to be flexible and extensible. You can add custom [MCP se
 
 ## Quick Links
 
-- [Getting Started](https://jupyter-ai.readthedocs.io/en/latest/getting-started.html) — installation, agent setup, and first chat
-- [User Guide](https://jupyter-ai.readthedocs.io/en/latest/users/index.html) — chat features, notebook tools, and custom MCP servers
-- [Contributor Guide](https://jupyter-ai.readthedocs.io/en/latest/contributors/index.html) — how to contribute to Jupyter AI
-- [Developer Guide](https://jupyter-ai.readthedocs.io/en/latest/developers/index.html) — building custom agents and MCP servers
-- [Troubleshooting](https://jupyter-ai.readthedocs.io/en/latest/users/troubleshooting.html) — common issues and solutions
+- [Getting Started](https://jupyter-ai.readthedocs.io/en/stable/getting-started.html) — installation, agent setup, and first chat
+- [User Guide](https://jupyter-ai.readthedocs.io/en/stable/users/index.html) — chat features, notebook tools, and custom MCP servers
+- [Contributor Guide](https://jupyter-ai.readthedocs.io/en/stable/contributors/index.html) — how to contribute to Jupyter AI
+- [Developer Guide](https://jupyter-ai.readthedocs.io/en/stable/developers/index.html) — building custom agents and MCP servers
+- [Troubleshooting](https://jupyter-ai.readthedocs.io/en/stable/users/troubleshooting.html) — common issues and solutions
 
 ## Governance
 

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -315,14 +315,6 @@ yet. See `jupyter-ai-persona-manager` for a complete example.
   synthesized fixtures to verify the aggregation, and the **Docs build system**
   CI workflow runs them on any change to the docs build system.
 
-```{note}
-Serving `stable` by default is a one-time setting in the Read the Docs project
-dashboard (not the repo): set **Admin → Settings → Default version** to `stable`,
-and add an **Admin → Automation Rules** rule matching *SemVer versions* with the
-*Activate version* action so each release tag builds on its own. Read the Docs
-computes `stable` from the tags automatically thereafter.
-```
-
 
 ## Testing
 

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -284,12 +284,23 @@ yet. See `jupyter-ai-persona-manager` for a complete example.
   to `docs/` only. The registry of submodules lives in
   `submodules/manifest.json` (a `"pypi_name": "org/repo"` map), which also serves
   as a visible map of what Jupyter AI is composed of.
-- Submodules are pinned to the **latest release tag matching each package's
-  version range** in `jupyter-ai`'s `pyproject.toml`, following pip / PEP 440
-  semantics. Repinning is done by `scripts/update-doc-submodules.sh`, wrapped by
-  the **Update submodule documentation** GitHub workflow (`workflow_dispatch`),
-  which opens a PR with the updated pins. Maintainers run it when subpackages cut
-  releases with new docs.
+- How submodules are pinned depends on which version of the site is building,
+  so the docs move the way you'd expect:
+  - On **`main`** (the `latest` docs), each submodule tracks its subpackage's
+    **`main`** branch. The **Update submodule documentation** workflow refreshes
+    these pins daily (and on demand) and commits straight to `main`, so a
+    subpackage's newest docs appear on `latest` without waiting for a release.
+  - On a **release tag** (the `stable` docs), each submodule is frozen to the
+    **released tag matching that package's version range** in `pyproject.toml`
+    (pip / PEP 440 semantics), so a release captures a coherent snapshot. This
+    freeze runs automatically during `jupyter-releaser`'s prep step, via the
+    `after-bump-version` hook (`scripts/freeze-doc-submodules.sh`), and lands in
+    the release commit.
+
+  Both paths share one script, `scripts/update-doc-submodules.sh` (`--mode main`
+  vs `--mode release`). Read the Docs is configured to serve **`stable`** — the
+  highest non-prerelease tag — by default, so users see the latest released docs
+  and pre-releases never become the default.
 - On Read the Docs, `scripts/rtd-post-checkout.sh` (wired via
   `build.jobs.post_checkout` in `.readthedocs.yaml`) initialises each submodule
   sparsely to `docs/`. RTD's native `submodules:` support is intentionally not
@@ -303,6 +314,14 @@ yet. See `jupyter-ai-persona-manager` for a complete example.
 - Integration tests in `docs/tests/` run a real `sphinx-build` against
   synthesized fixtures to verify the aggregation, and the **Docs build system**
   CI workflow runs them on any change to the docs build system.
+
+```{note}
+Serving `stable` by default is a one-time setting in the Read the Docs project
+dashboard (not the repo): set **Admin → Settings → Default version** to `stable`,
+and add an **Admin → Automation Rules** rule matching *SemVer versions* with the
+*Activate version* action so each release tag builds on its own. Read the Docs
+computes `stable` from the tags automatically thereafter.
+```
 
 
 ## Testing

--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -15,7 +15,7 @@ The developer API allows other packages to modify both the frontend & the backen
 
 - The Lumino plugin API allows packages to add to, modify, or even override parts of Jupyter AI's frontend. This is only available to labextension packages.
 
-In v3, `jupyter-ai` is no longer a monorepo. Instead it comprises components that can be composed together to support a wide range of AI-assisted workflows, from code generation and data analysis to interactive learning and research. These components are located in the `jupyter-ai-contrib` org with multiple repositories, each representing a submodule that is installed along with `jupyter-ai`. For details, refer to the documentation on [Development Setup](https://jupyter-ai.readthedocs.io/en/v3/contributors/index.html#development-setup). Also refer to the related repositories' README files for overview.
+In v3, `jupyter-ai` is no longer a monorepo. Instead it comprises components that can be composed together to support a wide range of AI-assisted workflows, from code generation and data analysis to interactive learning and research. These components are located in the `jupyter-ai-contrib` org with multiple repositories, each representing a submodule that is installed along with `jupyter-ai`. For details, refer to the documentation on [Development Setup](https://jupyter-ai.readthedocs.io/en/stable/contributors/index.html#development-setup). Also refer to the related repositories' README files for overview.
 
 ```{toctree}
 :hidden:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ docs = [
 ]
 
 [project.urls]
-Documentation = "https://jupyter-ai.readthedocs.io/en/v3/"
+Documentation = "https://jupyter-ai.readthedocs.io/en/stable/"
 Source = "https://github.com/jupyterlab/jupyter-ai"
 Tracker = "https://github.com/jupyterlab/jupyter-ai/issues"
 
@@ -69,3 +69,12 @@ path = "jupyter_ai/__init__.py"
 
 [project.entry-points."jupyter_server_mcp.tools"]
 jupyter_ai = "jupyter_ai:DEFAULT_JUPYTER_SERVER_MCP_TOOLS"
+
+[tool.jupyter-releaser.hooks]
+# During "Step 1: Prep Release", after the version is bumped and before the
+# release is committed and tagged, freeze the documentation submodules to the
+# released tags matching this version's dependency ranges. Between releases the
+# submodules track each subpackage's `main` (freshest docs on the `latest`
+# site); the release tag captures a frozen snapshot for the `stable` site. See
+# scripts/freeze-doc-submodules.sh.
+after-bump-version = ["bash scripts/freeze-doc-submodules.sh"]

--- a/scripts/_resolve_doc_submodules.py
+++ b/scripts/_resolve_doc_submodules.py
@@ -2,24 +2,34 @@
 """Resolve the pin target for each documentation submodule.
 
 Given the submodule manifest and jupyter-ai's ``pyproject.toml``, this script
-decides which git ref every submodule should be pinned to, following pip /
-PEP 440 semantics.
+decides which git ref every submodule should be pinned to. It has two modes,
+matching how the docs are meant to move:
 
-For each ``"pypi_name": "org/repo"`` entry in the manifest:
+``main`` (default)
+    Pin every submodule to its **default-branch HEAD**. This is what the routine
+    "update submodule documentation" job uses so the ``latest`` docs (built from
+    jupyter-ai's ``main``) always show each subpackage's newest, possibly
+    unreleased docs — no release required.
 
-* The submodule path is ``submodules/<repo>`` (the part after the ``/``).
-* The version range is looked up from ``pyproject.toml`` by ``pypi_name``,
-  searching both ``[project].dependencies`` and every
-  ``[project.optional-dependencies]`` group (so the ``magics`` / ``jupyternaut``
-  extras are covered).
-* The repo's tags are listed with ``git ls-remote`` over anonymous HTTPS.
-  Tags are uniformly ``v``-prefixed PEP 440 versions; the ``v`` is stripped
-  before parsing and non-PEP-440 tags are ignored.
-* ``SpecifierSet(range).filter(versions)`` selects the candidates (this is the
-  library pip itself uses, so pre-release handling matches pip exactly), and
-  the maximum is the winner.
-* If no tag matches (e.g. the package has not cut a matching release yet), the
-  submodule is pinned to its default-branch HEAD and a warning is emitted.
+``release``
+    Pin each submodule to the latest git tag satisfying that package's version
+    range in ``pyproject.toml``, following pip / PEP 440 semantics. This is what
+    the release hook uses so a release tag captures a **coherent, frozen**
+    snapshot of the subpackage docs that ship with that jupyter-ai version.
+
+    * The version range is looked up by ``pypi_name`` across
+      ``[project].dependencies`` and every ``[project.optional-dependencies]``
+      group (so the ``magics`` / ``jupyternaut`` extras are covered).
+    * Tags are listed with ``git ls-remote`` over anonymous HTTPS. They are
+      uniformly ``v``-prefixed PEP 440 versions; the ``v`` is stripped before
+      parsing and non-PEP-440 tags are ignored.
+    * ``SpecifierSet(range).filter(versions)`` selects the candidates (the same
+      library pip uses, so pre-release handling matches pip exactly); the max
+      wins. If nothing matches, that submodule falls back to its default-branch
+      HEAD with a warning.
+
+For each ``"pypi_name": "org/repo"`` entry the submodule path is
+``submodules/<repo>`` (the part after the ``/``).
 
 Output: one tab-separated row per submodule on stdout::
 
@@ -31,6 +41,7 @@ machine-parseable plan for the calling shell script.
 
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 import sys
@@ -129,14 +140,25 @@ def resolve_tag(spec_string: str, tags: list[str]) -> str | None:
 
 
 def main() -> int:
-    if len(sys.argv) != 3:
-        log("usage: _resolve_doc_submodules.py <manifest.json> <pyproject.toml>")
-        return 2
-    manifest_path, pyproject_path = sys.argv[1], sys.argv[2]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", help="path to submodules/manifest.json")
+    parser.add_argument("pyproject", help="path to pyproject.toml")
+    parser.add_argument(
+        "--mode",
+        choices=("main", "release"),
+        default="main",
+        help=(
+            "main: pin every submodule to its default-branch HEAD (freshest "
+            "docs, for the routine update job). release: pin to the latest tag "
+            "matching each package's pyproject range (frozen snapshot, for the "
+            "release hook). Default: main."
+        ),
+    )
+    args = parser.parse_args()
 
-    with open(manifest_path) as f:
+    with open(args.manifest) as f:
         manifest = json.load(f)
-    ranges = load_ranges(pyproject_path)
+    ranges = load_ranges(args.pyproject) if args.mode == "release" else {}
 
     rows: list[str] = []
     for pypi_name, org_repo in manifest.items():
@@ -144,11 +166,18 @@ def main() -> int:
         path = f"submodules/{repo}"
         url = f"https://github.com/{org_repo}.git"
 
+        if args.mode == "main":
+            branch = default_branch(url)
+            log(f"  {pypi_name}: main -> {branch} HEAD")
+            rows.append(f"{path}\t{url}\t{branch}\tbranch")
+            continue
+
+        # release mode: resolve the tag matching this package's version range.
         spec_string = ranges.get(_norm(pypi_name))
         if spec_string is None:
             log(
                 f"warning: {pypi_name} is in the manifest but not a dependency "
-                f"in {pyproject_path}; skipping"
+                f"in {args.pyproject}; skipping"
             )
             continue
 

--- a/scripts/freeze-doc-submodules.sh
+++ b/scripts/freeze-doc-submodules.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# freeze-doc-submodules.sh
+#
+# Release-time hook: pin every documentation submodule to the released tag that
+# matches its version range in pyproject.toml, and stage the moved gitlinks.
+#
+# Between releases the doc submodules track each subpackage's `main` (so the
+# `latest` docs show the freshest, possibly-unreleased subpackage docs). At
+# release time we want the opposite: the release tag should capture a coherent,
+# *frozen* snapshot of the subpackage docs that ship with this jupyter-ai
+# version. This script performs that freeze by delegating to
+# `update-doc-submodules.sh --mode release`.
+#
+# It is wired as a jupyter-releaser `after-bump-version` hook (see
+# [tool.jupyter-releaser.hooks] in pyproject.toml): during "Step 1: Prep
+# Release" the releaser bumps the version, runs this hook, then commits the
+# working tree (including the re-pinned gitlinks staged here) and tags it. So
+# the release tag — and therefore the `stable` docs Read the Docs serves — gets
+# the frozen pins, while `main` keeps tracking the subpackage `main` branches.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "Freezing documentation submodules to release tags for this version…"
+bash scripts/update-doc-submodules.sh --mode release
+
+# update-doc-submodules.sh already `git add`s the moved gitlinks and
+# .gitmodules; jupyter-releaser's changelog/commit step sweeps them into the
+# release commit. Nothing else to do here.
+echo "Documentation submodules frozen and staged."

--- a/scripts/update-doc-submodules.sh
+++ b/scripts/update-doc-submodules.sh
@@ -1,33 +1,36 @@
 #!/usr/bin/env bash
 #
-# update-doc-submodules.sh
+# update-doc-submodules.sh [--mode main|release]
 #
-# Pins every documentation submodule listed in submodules/manifest.json to the
-# latest git tag that satisfies the corresponding package's version range in
-# jupyter-ai's pyproject.toml, and sparse-checks-out each submodule to docs/.
+# Pins every documentation submodule listed in submodules/manifest.json and
+# sparse-checks-out each to docs/. Has two modes (see
+# scripts/_resolve_doc_submodules.py for the full rationale):
 #
-# This is the single source of truth for submodule pinning. It is run:
-#   * once, to seed the submodules in the infrastructure PR, and
-#   * on demand via the "Update submodule documentation" GitHub workflow
-#     (workflow_dispatch), which runs it and opens a PR with the result.
+#   --mode main (default)
+#       Pin every submodule to its default-branch HEAD. Used by the routine
+#       "update submodule documentation" workflow so the `latest` docs (built
+#       from jupyter-ai's main) always show each subpackage's newest docs — no
+#       subpackage release required.
 #
-# Version resolution follows pip / PEP 440 semantics via the `packaging`
-# library (SpecifierSet.filter), so pre-releases are excluded for a stable
-# range like ">=0.6.0,<0.7.0" but included for a pre-release range like
-# ">=0.23.0a2,<0.24". Tags across the jupyter-ai-contrib repos are uniformly
-# "v"-prefixed PEP 440 versions (e.g. v0.6.0, v0.2.0b0); the leading "v" is
-# stripped before parsing.
+#   --mode release
+#       Pin each submodule to the latest tag matching that package's version
+#       range in pyproject.toml (pip / PEP 440 semantics). Used by the release
+#       hook (see scripts/freeze-doc-submodules.sh) so a jupyter-ai release tag
+#       captures a coherent, frozen snapshot of the subpackage docs.
 #
-# A submodule whose range matches no published tag (e.g. a package that has
-# not cut a release yet) is pinned to its default branch HEAD instead, and a
-# warning is emitted. The build still succeeds; docs simply track the tip until
-# a matching tag exists.
+# This is the single source of truth for submodule pinning; it also seeded the
+# submodules originally.
 #
 # Requirements: git, python3 with the `packaging` library (and `tomllib` on
 # Python 3.11+, or `tomli` on 3.10). All of these are available in the docs /
 # CI environment.
 
 set -euo pipefail
+
+MODE="main"
+if [[ "${1:-}" == "--mode" ]]; then
+  MODE="${2:-main}"
+fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
@@ -40,11 +43,10 @@ if [[ ! -f "$MANIFEST" ]]; then
   exit 1
 fi
 
-# Resolve the pin plan in Python: for each manifest entry, read the package's
-# range from pyproject.toml, list the remote's tags, and pick the winning ref.
-# Emits one tab-separated row per submodule: path <TAB> url <TAB> ref <TAB> kind
-# where kind is "tag" or "branch". Human-readable progress goes to stderr.
-PLAN="$(python3 scripts/_resolve_doc_submodules.py "$MANIFEST" "$PYPROJECT")"
+# Resolve the pin plan in Python. Emits one tab-separated row per submodule:
+# path <TAB> url <TAB> ref <TAB> kind  (kind is "tag" or "branch"). Human-
+# readable progress goes to stderr.
+PLAN="$(python3 scripts/_resolve_doc_submodules.py "$MANIFEST" "$PYPROJECT" --mode "$MODE")"
 
 if [[ -z "$PLAN" ]]; then
   echo "error: resolver produced no plan" >&2


### PR DESCRIPTION
## Motivation

The subpackage docs aggregated into this site (#1595) were pinned to each subpackage's latest released tag, refreshed by a workflow that opened a PR. That means a subpackage's new docs don't show up until it cuts a release and someone merges the repin — annoying when you just want the current docs on the site. But we still want a released version of jupyter-ai to show a stable, coherent snapshot rather than whatever happens to be on a subpackage's main today.

## Summary

The docs now move in the way you'd expect from each version:

The latest docs (built from main) track each subpackage's main branch, so a subpackage's newest docs appear as soon as they merge — no release needed. The update workflow refreshes these pins daily and commits straight to main instead of opening a PR.

A released version freezes the submodules to the tags matching that release's dependency ranges, captured in the release commit, so stable shows a coherent snapshot. Doc links now point at /en/stable, which Read the Docs computes from the highest non-prerelease tag, so the default site is the latest official release and betas never become the default.

## Technical details

Both pinning modes share one script through a `--mode` flag (`main` pins to each subpackage's default branch; `release` resolves the PEP 440 tag as before). The freeze runs automatically as a `jupyter-releaser` `after-bump-version` hook, so it lands in the release commit with no extra step.

Serving `stable` by default is a one-time setting in the Read the Docs project dashboard (default version + a SemVer activate automation rule); it can't be set from the repo, so it's noted in the contributor guide.