### PR TITLE
docs: move the release-notes blurb into the editable summary region

### DIFF
--- a/docs/tests/test_release_notes.py
+++ b/docs/tests/test_release_notes.py
@@ -270,12 +270,7 @@ def test_build_page_header(monkeypatch, tmp_path):
     )
     assert "# v3.1.0" in page
     assert "*Published on July 22, 2026.*" in page
-    assert (
-        "auto-generated release notes for Jupyter AI **v3.1.0** from the `main` branch"
-        in page
-    )
-    assert "floor at the previous release (v3.0.1)" in page
-    assert gen.DEFAULT_SUMMARY in page
+    assert gen.CONTRIBUTORS_NOTE in page
     # Two AUTO regions (header + changelog) and one SUMMARY region.
     assert page.count(gen.AUTO_BEGIN) == 2
     assert page.count(gen.AUTO_END) == 2
@@ -283,6 +278,24 @@ def test_build_page_header(monkeypatch, tmp_path):
     assert page.count(gen.SUMMARY_END) == 1
     # The router section sits inside the second (changelog) auto region.
     assert "## `jupyter-ai-router`" in page
+
+    # The explanatory blurb lives inside the editable SUMMARY region (so a
+    # contributor can trim it), NOT in an auto region.
+    summary = page.split(gen.SUMMARY_BEGIN, 1)[1].split(gen.SUMMARY_END, 1)[0]
+    assert (
+        "auto-generated release notes for Jupyter AI **v3.1.0** from the `main` branch"
+        in summary
+    )
+    assert "floor at the previous release (v3.0.1)" in summary
+    assert gen.CONTRIBUTORS_NOTE in summary
+
+
+def test_default_summary_omits_window_line_without_prev_tag():
+    # No previous release ⇒ no "PRs between floors" sentence, but the note stays.
+    s = gen.default_summary("v3.1.0", "main", prev_tag=None)
+    assert "auto-generated release notes" in s
+    assert "floor at the previous release" not in s
+    assert gen.CONTRIBUTORS_NOTE in s
 
 
 # Floors: router advanced 0.0.5 -> 0.0.6, so it gets a section.
@@ -319,7 +332,7 @@ def test_regenerate_auto_regions_preserves_summary_and_out_of_band_edits():
         )
         + "\n\n> a note a contributor added outside the auto regions\n"
     )
-    fresh = _page("# v3.1.0\nnew date", gen.DEFAULT_SUMMARY, "new changelog")
+    fresh = _page("# v3.1.0\nnew date", gen.CONTRIBUTORS_NOTE, "new changelog")
 
     merged = gen.regenerate_auto_regions(existing, fresh)
 
@@ -332,13 +345,13 @@ def test_regenerate_auto_regions_preserves_summary_and_out_of_band_edits():
     assert "## Highlights\n\n- edited by a human" in merged
     assert "a note a contributor added outside the auto regions" in merged
     # Default summary is NOT reintroduced when a human already replaced it.
-    assert gen.DEFAULT_SUMMARY not in merged
+    assert gen.CONTRIBUTORS_NOTE not in merged
 
 
 def test_regenerate_auto_regions_aborts_on_region_count_mismatch():
     # Contributor removed one AUTO region's markers -> counts differ -> abort.
     existing = f"{gen.AUTO_BEGIN}\nonly one region\n{gen.AUTO_END}\n\nsummary text"
-    fresh = _page("h", gen.DEFAULT_SUMMARY, "c")
+    fresh = _page("h", gen.CONTRIBUTORS_NOTE, "c")
     with pytest.raises(gen.MarkerError):
         gen.regenerate_auto_regions(existing, fresh)
 

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -78,11 +78,34 @@ SUMMARY_BEGIN = (
 )
 SUMMARY_END = "<!-- END SUMMARY -->"
 
-DEFAULT_SUMMARY = (
+CONTRIBUTORS_NOTE = (
     "CONTRIBUTORS: **Please replace this text with a human-readable summary of "
     "the changes. See `AGENTS.md` in the `jupyterlab/jupyter-ai` repo for more "
     "information.**"
 )
+
+
+def default_summary(version: str, target_branch: str, prev_tag: str | None) -> str:
+    """Seed text for the contributor-owned SUMMARY region on a first run.
+
+    This is written verbatim only when the page doesn't exist yet; on re-runs the
+    whole region is preserved, so a contributor can edit or delete any of it —
+    including the "auto-generated notes" explanation, which is boilerplate they
+    may not want once they've written a real summary.
+    """
+    blurb = (
+        f"These are the auto-generated release notes for Jupyter AI "
+        f"**{version}** from the `{target_branch}` branch, aggregated from the "
+        f"subpackages whose version floors advanced in this release."
+    )
+    if prev_tag is not None:
+        blurb += (
+            f" Each subpackage section covers the pull requests merged between "
+            f"its floor at the previous release ({prev_tag}) and its floor at "
+            f"{version}."
+        )
+    return f"{blurb}\n\n{CONTRIBUTORS_NOTE}"
+
 
 # One auto region: the begin/end markers and everything between them.
 _AUTO_RE = re.compile(
@@ -417,25 +440,17 @@ def build_page(
             )
         )
 
-    blurb = (
-        f"These are the auto-generated release notes for Jupyter AI "
-        f"**{version}** from the `{target_branch}` branch, aggregated from the "
-        f"subpackages whose version floors advanced in this release."
-    )
-    if prev_tag is not None:
-        blurb += (
-            f" Each subpackage section covers the pull requests merged between "
-            f"its floor at the previous release ({prev_tag}) and its floor at "
-            f"{version}."
-        )
-
-    # AUTO region 1: title + publication date + blurb.
+    # AUTO region 1: title + publication date. These are always accurate, so
+    # they stay auto-generated. The explanatory blurb lives in the editable
+    # summary below, not here, so contributors can trim it.
     header_auto = wrap_auto(
-        "\n".join([f"# {version}", "", f"*Published on {published_date}.*", "", blurb])
+        "\n".join([f"# {version}", "", f"*Published on {published_date}.*"])
     )
 
-    # Contributor-owned region: the human summary, preserved across re-runs.
-    summary_region = f"{SUMMARY_BEGIN}\n{DEFAULT_SUMMARY}\n{SUMMARY_END}"
+    # Contributor-owned region: seeded with the blurb + call-to-action on a first
+    # run, then preserved (and freely editable) across re-runs.
+    summary_seed = default_summary(version, target_branch, prev_tag)
+    summary_region = f"{SUMMARY_BEGIN}\n{summary_seed}\n{SUMMARY_END}"
 
     # AUTO region 2: the per-subpackage changelog.
     changelog: list[str] = []


### PR DESCRIPTION
## Motivation

The explanatory blurb ("These are the auto-generated release notes for Jupyter AI…") sat inside the always-regenerated AUTO region of a release-notes page, so a contributor could never remove it — it came back on every re-run. That boilerplate is useful as a default but shouldn't be permanent once someone writes a real summary.

## Summary

The blurb is now seeded into the contributor-owned SUMMARY region alongside the "please write a summary" note, so it's present by default on a first run but editable and removable like the rest of the summary. Only the title and publication date stay auto-generated.

## Testing

Unit tests assert the blurb lands inside the SUMMARY region (not an AUTO region) and that a re-run preserves contributor edits. `sphinx-build` clean; the whole `docs/tests` suite passes.