### PR TITLE
Limit submodule updates to upstream repository

### DIFF
--- a/.github/workflows/update-submodule-docs.yml
+++ b/.github/workflows/update-submodule-docs.yml
@@ -28,6 +28,8 @@ permissions: {}
 jobs:
   update-submodules:
     name: Re-pin documentation submodules to subpackage main
+    # Forks inherit this workflow, but must not update their default branches.
+    if: github.repository == 'jupyterlab/jupyter-ai'
     runs-on: ubuntu-latest
     permissions:
       contents: write # commit the refreshed pins to main


### PR DESCRIPTION


## Description

As noticed in https://github.com/jupyterlab/jupyter-ai/pull/1601#discussion_r3636256989 

## Code changes

GitHub Action workflow update.

## User-facing changes

None

## Backwards-incompatible changes

None