### PR TITLE
docs: mark optional subpackages in the release notes

### DIFF
--- a/docs/tests/test_release_notes.py
+++ b/docs/tests/test_release_notes.py
@@ -220,6 +220,60 @@ def test_submodule_section_added_when_no_prev_floor(monkeypatch):
     assert "Upgraded from" not in section
 
 
+def test_submodule_section_optional_note(monkeypatch):
+    monkeypatch.setattr(gen.changelog, "get_version_entry", lambda **k: _ENTRY)
+    section = gen.submodule_section(
+        org_repo="org/repo",
+        repo="repo",
+        prev_floor="0.2.5",
+        new_floor="0.3.0",
+        new_floor_tag="v0.3.0",
+        since_ref="v0.2.5",
+        branch="main",
+        auth="tok",
+        is_optional=True,
+    )
+    # Colon-fenced admonition (renders in Sphinx, reads as prose elsewhere) —
+    # NOT a ```-fenced block, which plain Markdown shows as code.
+    assert ":::{note}" in section
+    assert "```{note}" not in section
+    assert "optional package" in section
+
+
+def test_submodule_section_no_optional_note_by_default(monkeypatch):
+    monkeypatch.setattr(gen.changelog, "get_version_entry", lambda **k: _ENTRY)
+    section = gen.submodule_section(
+        org_repo="org/repo",
+        repo="repo",
+        prev_floor="0.2.5",
+        new_floor="0.3.0",
+        new_floor_tag="v0.3.0",
+        since_ref="v0.2.5",
+        branch="main",
+        auth="tok",
+    )
+    assert "optional package" not in section
+
+
+def test_optional_only_names_excludes_core_deps():
+    text = """
+[project]
+name = "jupyter_ai"
+dependencies = ["core_pkg>=1.0", "shared_pkg>=1.0"]
+
+[project.optional-dependencies]
+magics = ["opt_pkg>=0.1", "shared_pkg>=1.0"]
+jupyternaut = ["jupyter_ai_jupyternaut>=0.1.0b0,<0.2.0"]
+"""
+    result = sv.optional_only_names(text)
+    # Optional-only packages are reported...
+    assert "opt_pkg" in result
+    assert "jupyter_ai_jupyternaut" in result
+    # ...but a package that is also a core dep is NOT (it's effectively required).
+    assert "shared_pkg" not in result
+    assert "core_pkg" not in result
+
+
 def test_submodule_section_omits_empty_pr_body(monkeypatch):
     monkeypatch.setattr(
         gen.changelog, "get_version_entry", lambda **k: "## v0.3.0\n\nNo merged PRs"

--- a/scripts/_submodule_versions.py
+++ b/scripts/_submodule_versions.py
@@ -111,6 +111,35 @@ def load_floors_from_text(pyproject_text: str) -> dict[str, str]:
     return floors
 
 
+def optional_only_names(pyproject_text: str) -> set[str]:
+    """Return the normalized names of packages that are optional-only.
+
+    A package is "optional" if it appears in ``[project.optional-dependencies]``
+    but NOT in the core ``[project.dependencies]`` — i.e. installing jupyter-ai
+    without extras does not pull it in. A package listed in both is effectively
+    required, so it is not reported as optional.
+    """
+    data = tomllib.loads(pyproject_text)
+    project = data.get("project", {})
+
+    core: set[str] = set()
+    for req_string in project.get("dependencies", []):
+        try:
+            core.add(_norm(Requirement(req_string).name))
+        except Exception:  # pragma: no cover - defensive
+            continue
+
+    optional: set[str] = set()
+    for group in project.get("optional-dependencies", {}).values():
+        for req_string in group:
+            try:
+                optional.add(_norm(Requirement(req_string).name))
+            except Exception:  # pragma: no cover - defensive
+                continue
+
+    return optional - core
+
+
 def list_tags(url: str) -> list[str]:
     """Return the repo's tag names (``refs/tags/*``, deref peels stripped)."""
     out = subprocess.run(

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -60,6 +60,7 @@ from _submodule_versions import (  # noqa: E402
     list_tags,
     load_floors_from_text,
     log,
+    optional_only_names,
     resolve_floor_tag,
 )
 
@@ -289,6 +290,7 @@ def submodule_section(
     since_ref: str | None,
     branch: str,
     auth: str | None,
+    is_optional: bool = False,
 ) -> str:
     """Build one submodule's section.
 
@@ -297,6 +299,9 @@ def submodule_section(
     ``since_ref`` is the merge-base — see ``window_start``). We wrap them in our
     own heading — the package name in a code span — with a version-change line
     and a link to the subpackage's GitHub release page for the new tag.
+
+    ``is_optional`` marks packages that ship only under an extra (see
+    ``optional_only_names``); their section carries a note saying so.
     """
     entry = changelog.get_version_entry(
         ref=new_floor_tag,
@@ -317,6 +322,15 @@ def submodule_section(
         summary = f"Added at `v{new_floor}`. {changelog_link}"
 
     parts = [f"## `{repo}`", summary]
+    if is_optional:
+        # Colon-fence (not ```) so Sphinx renders an admonition while plain
+        # Markdown renderers (GitHub, previews) show the text, not a code block.
+        parts.append(
+            ":::{note}\n"
+            "This is an optional package, installed only with the corresponding "
+            "`jupyter-ai` extra.\n"
+            ":::"
+        )
     # An advanced floor with no user-facing PRs (e.g. only bot/pre-commit PRs,
     # which get_version_entry filters out) leaves nothing to list.
     if pr_groups and pr_groups != "No merged PRs":
@@ -350,7 +364,9 @@ def build_page(
         manifest: dict[str, str] = json.load(f)
 
     with open(pyproject_path, encoding="utf-8") as f:
-        new_floors = load_floors_from_text(f.read())
+        pyproject_text = f.read()
+    new_floors = load_floors_from_text(pyproject_text)
+    optional = optional_only_names(pyproject_text)
 
     prev_tag = previous_release_tag(repo_root, version, target_branch)
     if prev_tag is None:
@@ -437,6 +453,7 @@ def build_page(
                 since_ref,
                 branch,
                 auth,
+                is_optional=key in optional,
             )
         )
 


### PR DESCRIPTION
## Motivation

Some jupyter-ai subpackages ship only under an extra (e.g. `jupyter-ai-jupyternaut` under the `jupyternaut` extra), so they aren't installed in a default setup. The release-notes page gave no indication of this, so a reader couldn't tell a core change from one that only affects users who opted into an extra.

## Summary

A subpackage's release-notes section now carries a note when the package is optional — present in `[project.optional-dependencies]` but not the core dependencies. The build derives this from `pyproject.toml`, so there's no manual list to maintain: a package that is both a core dep and in an extra is treated as required, and one that is extra-only is marked optional.

The note uses a colon-fenced admonition (`:::{note}`) so Sphinx renders a proper note while plain-Markdown views (GitHub, previews) show the text rather than a code block.

## Testing

Unit tests cover the optional-vs-core detection and that the section renders the colon-fenced note only when optional. Verified end-to-end by bumping the jupyternaut floor locally: it produced a section with the note, and `sphinx-build` rendered it as an admonition. (The floor bump itself is not part of this PR.)