### PR TITLE
docs: add a "Full changelog" section and link to the releases page

### DIFF
--- a/docs/tests/test_release_notes.py
+++ b/docs/tests/test_release_notes.py
@@ -161,6 +161,20 @@ See [our definition of contributors](https://github-activity.readthedocs.io/).
 @a ([activity](https://x)) | @b ([activity](https://y))"""
 
 
+def test_demote_headings_shifts_all_levels():
+    text = "## `repo`\n\nsome prose\n\n### Enhancements made\n\n- a bullet"
+    out = gen.demote_headings(text)
+    assert "### `repo`" in out
+    assert "#### Enhancements made" in out
+    # Non-heading lines untouched.
+    assert "some prose" in out
+    assert "- a bullet" in out
+
+
+def test_demote_headings_caps_at_h6():
+    assert gen.demote_headings("###### deep") == "###### deep"
+
+
 def test_strip_to_pr_groups_drops_heading_link_and_contributors():
     out = gen.strip_to_pr_groups(_ENTRY)
     # PR groups kept
@@ -197,7 +211,7 @@ def test_submodule_section_format(monkeypatch):
     assert lines[0] == "## `repo`"
     assert (
         "Upgraded from `v0.2.5` → `v0.3.0`. "
-        "([See full changelog](https://github.com/org/repo/releases/tag/v0.3.0))"
+        "([See full changelog](https://github.com/org/repo/releases))"
     ) in section
     # PR groups present; contributors footer gone.
     assert "- Add a thing [#10]" in section
@@ -330,8 +344,14 @@ def test_build_page_header(monkeypatch, tmp_path):
     assert page.count(gen.AUTO_END) == 2
     assert page.count(gen.SUMMARY_BEGIN) == 1
     assert page.count(gen.SUMMARY_END) == 1
-    # The router section sits inside the second (changelog) auto region.
-    assert "## `jupyter-ai-router`" in page
+    # The changelog sits inside the second auto region under a "## Full
+    # changelog" heading, after the summary. Subpackage headings are demoted one
+    # level (## -> ###) so they nest under it.
+    assert "## Full changelog" in page
+    assert "### `jupyter-ai-router`" in page
+    assert page.index("## Full changelog") > page.index(gen.SUMMARY_END)
+    # Only one H1 (the version title); Full changelog is H2, not a second H1.
+    assert page.count("\n# ") + page.startswith("# ") == 1
 
     # The explanatory blurb lives inside the editable SUMMARY region (so a
     # contributor can trim it), NOT in an auto region.

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -253,6 +253,26 @@ def window_start(org_repo: str, prev_tag: str, new_tag: str, auth: str | None) -
     return merge_base_sha
 
 
+def demote_headings(text: str, by: int = 1) -> str:
+    """Add ``by`` levels to every ATX heading in ``text`` (capped at H6).
+
+    Used so the whole changelog can sit under a single ``## Full changelog``
+    heading: each subpackage's ``## `repo` `` becomes ``###``, its ``###`` PR
+    groups become ``####``, and so on. Only lines that start with ``#`` markers
+    are touched; fenced code and prose are left alone (release-notes bodies have
+    no indented code blocks that could be mistaken for headings).
+    """
+    out: list[str] = []
+    for line in text.splitlines():
+        m = re.match(r"^(#{1,6}) (.*)$", line)
+        if m:
+            level = min(len(m.group(1)) + by, 6)
+            out.append(f"{'#' * level} {m.group(2)}")
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
 def strip_to_pr_groups(entry: str) -> str:
     """Keep only the label-grouped PR bullets from a ``get_version_entry`` block.
 
@@ -298,7 +318,7 @@ def submodule_section(
     window ``since_ref..new_floor_tag`` (same label grouping the releaser uses;
     ``since_ref`` is the merge-base — see ``window_start``). We wrap them in our
     own heading — the package name in a code span — with a version-change line
-    and a link to the subpackage's GitHub release page for the new tag.
+    and a link to the subpackage's GitHub releases page.
 
     ``is_optional`` marks packages that ship only under an extra (see
     ``optional_only_names``); their section carries a note saying so.
@@ -314,7 +334,7 @@ def submodule_section(
     )
     pr_groups = strip_to_pr_groups(entry.strip())
 
-    releases_url = f"https://github.com/{org_repo}/releases/tag/{new_floor_tag}"
+    releases_url = f"https://github.com/{org_repo}/releases"
     changelog_link = f"([See full changelog]({releases_url}))"
     if prev_floor:
         summary = f"Upgraded from `v{prev_floor}` → `v{new_floor}`. {changelog_link}"
@@ -469,26 +489,30 @@ def build_page(
     summary_seed = default_summary(version, target_branch, prev_tag)
     summary_region = f"{SUMMARY_BEGIN}\n{summary_seed}\n{SUMMARY_END}"
 
-    # AUTO region 2: the per-subpackage changelog.
-    changelog: list[str] = []
+    # AUTO region 2: the per-subpackage changelog. Assemble the body with its
+    # natural heading levels (## per subpackage), then demote everything one
+    # level so it can nest under a single "## Full changelog" heading.
+    body: list[str] = []
     if sections:
-        changelog.append("\n\n".join(sections))
+        body.append("\n\n".join(sections))
     else:
-        changelog.append("_No subpackage version floors advanced in this release._")
+        body.append("_No subpackage version floors advanced in this release._")
     if unchanged:
-        changelog.append(
+        body.append(
             "## Unchanged subpackages\n\n"
             "The following subpackages did not advance their version floor in "
             "this release:\n\n" + "\n".join(f"- {u}" for u in sorted(unchanged))
         )
     if skipped:
-        changelog.append(
+        body.append(
             "## Not resolved\n\n"
             "These subpackages could not be resolved to a release window "
             "(see the generation log):\n\n"
             + "\n".join(f"- `{s}`" for s in sorted(skipped))
         )
-    changelog_auto = wrap_auto("\n\n".join(changelog))
+    changelog_auto = wrap_auto(
+        "## Full changelog\n\n" + demote_headings("\n\n".join(body))
+    )
 
     return "\n\n".join([header_auto, summary_region, changelog_auto]).strip() + "\n"
 


### PR DESCRIPTION
## Motivation

Two refinements to the generated release-notes pages:

- The auto-generated changelog had no heading of its own, so it ran straight into the contributor summary.
- Each subpackage's "See full changelog" link pointed at a specific release tag, which isn't always the most useful landing spot — the repo's releases page shows that release in context alongside its neighbors.

## Summary

The auto-generated changelog now sits under a `## Full changelog` heading. Each subpackage's headings are demoted one level so they nest cleanly under it — `### <repo>` per subpackage, `#### <PR group>` beneath — and the page keeps a single H1 (the version title).

Each subpackage's "See full changelog" link now points at the repo's releases page (`/releases`) rather than a specific tag.

## Testing

Unit tests cover the new link target, the `## Full changelog` heading placement, heading demotion (including the H6 cap), and that the page has exactly one H1. `pytest docs/tests` passes and `sphinx-build -W` is clean.