### PR TITLE
fix: push the target-branch merge on release-docs re-run even when the page is unchanged

### DIFF
--- a/.github/workflows/prep-release-docs.yml
+++ b/.github/workflows/prep-release-docs.yml
@@ -133,18 +133,27 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # Commit the regenerated page if it changed. This is separate from the
+          # push decision below: even with no page change, the branch may still
+          # be ahead of its remote because of the target-branch merge made during
+          # checkout (e.g. picking up unrelated docs that landed on the target).
           git add docs/source/releases
-
-          # Nothing new since the branch's last state ⇒ don't push an empty
-          # commit. A first run always has changes; a re-run only commits if the
-          # regenerated page actually differs.
           if git diff --cached --quiet; then
-            echo "No release-notes changes since the last run; nothing to commit."
+            echo "No release-notes changes since the last run."
           else
             git commit -m "docs: add release notes for ${V}"
-            # Plain push (no force): on an existing branch this appends a commit,
-            # preserving run-to-run history. We only ever push to the dedicated
-            # release-docs branch, never to $TARGET_BRANCH.
+          fi
+
+          # Push whenever the local branch is ahead of the remote — which covers
+          # both a new release-notes commit and the merge commit from checkout.
+          # Gating the push on the page diff alone would strip the merge, leaving
+          # the branch missing changes that landed on the target branch. Plain
+          # push (no force) appends to the branch; we only ever push to the
+          # dedicated release-docs branch, never to $TARGET_BRANCH.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1 \
+            && [ -z "$(git rev-list "origin/${BRANCH}..HEAD")" ]; then
+            echo "Branch ${BRANCH} is already up to date on the remote; nothing to push."
+          else
             git push \
               "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
               "HEAD:${BRANCH}"


### PR DESCRIPTION
## Motivation

On a re-run, the Step 0 workflow merges the target branch into the release-docs branch (so it picks up docs that landed on the target since the branch was cut) and then regenerates the release-notes page. But the push was gated on a staged diff under `docs/source/releases` — and the merge commit lives *outside* that path. So when the regenerated page was unchanged, the step logged "nothing to commit" and skipped the push entirely, silently dropping the merge. The release-docs branch then stayed behind the target branch.

This is exactly what happened re-running for v3.1.0 after unrelated docs (the Gemini→Kilo swap) merged to main: the run merged them in but never pushed, so the release-docs PR kept the stale content.

## Summary

Separate the commit decision from the push decision. Still only commit a regenerated page when it actually changed, but push whenever the local branch is ahead of its remote — which covers both a new release-notes commit and the merge commit from checkout.

## Testing

Workflow YAML parses. Verified by re-running Step 0 after the fix: the release-docs branch picks up target-branch changes even when the generated page is unchanged.