### PR TITLE
Prep v3.1.2: bump version floors, add release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,14 @@ sees before the raw changelog. Edit only between the SUMMARY markers; a re-run o
 the release-notes workflow regenerates everything else and preserves your
 summary.
 
+The changelog covers every repo in `submodules/manifest.json` plus
+`EXTRA_CHANGELOG_REPOS` in `scripts/generate_release_notes.py`. The manifest is
+the doc-submodule registry, so a dependency whose docs we don't aggregate
+(`jupyterlab_chat`, whose developer docs live on its own site) goes in
+`EXTRA_CHANGELOG_REPOS` instead — its PRs then reach the release notes without
+pulling its docs into this site. A dependency whose changelog is missing from a
+generated page is registered in neither.
+
 ### Generating the page (Step 0 workflow)
 
 The page is produced by the **"Step 0: Prep release documentation"** workflow

--- a/docs/source/releases/index.md
+++ b/docs/source/releases/index.md
@@ -11,6 +11,7 @@ from the version floors declared in `pyproject.toml`.
 
 ```{toctree}
 :maxdepth: 1
+v3.1.2
 v3.1.1
 v3.1.0
 ```

--- a/docs/source/releases/v3.1.2.md
+++ b/docs/source/releases/v3.1.2.md
@@ -7,7 +7,7 @@
 <!-- BEGIN SUMMARY (contributors: edit freely; preserved on re-run) -->
 ## Highlights
 
-You can now call an AI persona from the `%%ai` magic command, giving the same agents you talk to in the chat panel to notebook and IPython users. Pass a persona's name where you would normally pass a model ID; the persona has to be installed and active. See the [magic commands documentation](../users/magic_commands/index.md) for the syntax. Thanks to [@joequant](https://github.com/joequant) and [@srdas](https://github.com/srdas) for building this.
+You can now call an AI persona from the `%%ai` magic command, giving notebook and IPython users the same agents available in the chat panel. Pass a persona's name where you would normally pass a model ID; the persona has to be installed and active. See the [magic commands documentation](../users/magic_commands/index.md) for the syntax. Thanks to [@joequant](https://github.com/joequant) and [@srdas](https://github.com/srdas) for building this.
 
 Magic command arguments are also parsed with `shlex` now, so quoted arguments hold together instead of splitting on every space.
 
@@ -20,6 +20,14 @@ Real-time collaboration now works in deployments served behind a reverse proxy. 
 
 <!-- BEGIN AUTO-GENERATED (do not edit; regenerated on each run) -->
 ## Full changelog
+
+### `jupyter-chat`
+
+Upgraded from `v0.23.0` → `v0.23.1`. ([See full changelog](https://github.com/jupyterlab/jupyter-chat/releases))
+
+#### Maintenance and upkeep improvements
+
+- Revert dependency bumps to support jupyterlab <4.6 [#472](https://github.com/jupyterlab/jupyter-chat/pull/472) ([@brichet](https://github.com/brichet), [@dlqqq](https://github.com/dlqqq), [@krassowski](https://github.com/krassowski))
 
 ### `jupyter-server-documents`
 

--- a/docs/source/releases/v3.1.2.md
+++ b/docs/source/releases/v3.1.2.md
@@ -1,0 +1,50 @@
+<!-- BEGIN AUTO-GENERATED (do not edit; regenerated on each run) -->
+# v3.1.2
+
+*Published on July 29, 2026.*
+<!-- END AUTO-GENERATED -->
+
+<!-- BEGIN SUMMARY (contributors: edit freely; preserved on re-run) -->
+These are the auto-generated release notes for Jupyter AI **v3.1.2** from the `main` branch, aggregated from the subpackages whose version floors advanced in this release. Each subpackage section covers the pull requests merged between its floor at the previous release (v3.1.1) and its floor at v3.1.2.
+
+CONTRIBUTORS: **Please replace this text with a human-readable summary of the changes. See `AGENTS.md` in the `jupyterlab/jupyter-ai` repo for more information.**
+<!-- END SUMMARY -->
+
+<!-- BEGIN AUTO-GENERATED (do not edit; regenerated on each run) -->
+## Full changelog
+
+### `jupyter-server-documents`
+
+Upgraded from `v0.3.1` → `v0.3.2`. ([See full changelog](https://github.com/jupyter-ai-contrib/jupyter-server-documents/releases))
+
+#### Enhancements made
+
+- Follow Jupyter Server conventions on Same-Origin and auth checks, fix reverse proxy deployments [#285](https://github.com/jupyter-ai-contrib/jupyter-server-documents/pull/285) ([@bsundaram1](https://github.com/bsundaram1), [@dlqqq](https://github.com/dlqqq))
+
+### `jupyter-ai-router`
+
+Upgraded from `v0.0.5` → `v0.0.6`. ([See full changelog](https://github.com/jupyter-ai-contrib/jupyter-ai-router/releases))
+
+#### Bugs fixed
+
+- Fix the collaboration event URI when jupyter-server-ydoc is not installed [#38](https://github.com/jupyter-ai-contrib/jupyter-ai-router/pull/38) ([@brichet](https://github.com/brichet), [@dlqqq](https://github.com/dlqqq))
+
+#### Maintenance and upkeep improvements
+
+- Add README badges [#28](https://github.com/jupyter-ai-contrib/jupyter-ai-router/pull/28) ([@jtpio](https://github.com/jtpio))
+
+### Unchanged subpackages
+
+The following subpackages did not advance their version floor in this release:
+
+- `jupyter-ai-acp-client` (`v0.2.1`)
+- `jupyter-ai-chat-commands` (`v0.0.4`)
+- `jupyter-ai-jupyternaut` (`v0.1.0b0`)
+- `jupyter-ai-litellm` (`v0.0.2`)
+- `jupyter-ai-magic-commands` (`v0.0.3`)
+- `jupyter-ai-persona-manager` (`v0.1.2`)
+- `jupyter-ai-tools` (`v0.6.1`)
+- `jupyter-server-mcp` (`v0.2.1`)
+- `jupyterlab-commands-toolkit` (`v0.1.6`)
+- `jupyterlab-notebook-awareness` (`v0.2.0`)
+<!-- END AUTO-GENERATED -->

--- a/docs/source/releases/v3.1.2.md
+++ b/docs/source/releases/v3.1.2.md
@@ -5,17 +5,23 @@
 <!-- END AUTO-GENERATED -->
 
 <!-- BEGIN SUMMARY (contributors: edit freely; preserved on re-run) -->
-## Highlights
 
-You can now call an AI persona from the `%%ai` magic command, giving notebook and IPython users the same agents available in the chat panel. Pass a persona's name where you would normally pass a model ID; the persona has to be installed and active. See the [magic commands documentation](../users/magic_commands/index.md) for the syntax. Thanks to [@joequant](https://github.com/joequant) and [@srdas](https://github.com/srdas) for building this.
+## Summary
 
-Magic command arguments are also parsed with `shlex` now, so quoted arguments hold together instead of splitting on every space.
+### JupyterLab v4.4 and v4.5 support is fixed
 
-## Major bugs fixed
+This patch fixes Jupyter AI support for JupyterLab v4.4 and v4.5. JupyterLab v4.6 and above are still supported as well. Thank you [@brichet](https://github.com/brichet) for help fixing this! 
 
-Jupyter AI works with JupyterLab versions below 4.6 again. A dependency bump in the previous release quietly raised the JupyterLab requirement and broke installs on older versions; that bump has been reverted.
+### New magic command features
 
-Real-time collaboration now works in deployments served behind a reverse proxy. Same-origin and authentication checks follow Jupyter Server's own conventions, which fixes the connection failures these deployments were seeing. A related fix repairs the collaboration event URI when `jupyter-server-ydoc` isn't installed.
+You can also now call an AI persona from the `%%ai` magic command, giving notebook and IPython users the same agents available in the chat panel. Pass a persona's name where you would normally pass a model ID; the persona has to be installed and active. See the updated [magic commands documentation](../users/magic_commands/index.md) for more info. Magic command arguments are also parsed with `shlex` now, so quoted arguments hold together instead of splitting on every space. Thanks to [@joequant](https://github.com/joequant) and [@srdas](https://github.com/srdas) for building this!
+
+### Other fixes
+
+- `jupyter-server-documents` now works in deployments served behind a reverse proxy. Same-origin and authentication checks follow Jupyter Server's own conventions, which fixes the connection failures these deployments were seeing. Thank you [@bsundaram1](https://github.com/bsundaram1) for the patch!
+
+- `jupyter-ai-router` now works even when `jupyter-server-ydoc` isn't installed. It is supposed to work with either `jupyter-server-documents` or `jupyter-server-ydoc`, but previous versions were only importing the event URI from the latter. Thank you [@brichet](https://github.com/brichet) for the patch! 
+
 <!-- END SUMMARY -->
 
 <!-- BEGIN AUTO-GENERATED (do not edit; regenerated on each run) -->

--- a/docs/source/releases/v3.1.2.md
+++ b/docs/source/releases/v3.1.2.md
@@ -5,9 +5,17 @@
 <!-- END AUTO-GENERATED -->
 
 <!-- BEGIN SUMMARY (contributors: edit freely; preserved on re-run) -->
-These are the auto-generated release notes for Jupyter AI **v3.1.2** from the `main` branch, aggregated from the subpackages whose version floors advanced in this release. Each subpackage section covers the pull requests merged between its floor at the previous release (v3.1.1) and its floor at v3.1.2.
+## Highlights
 
-CONTRIBUTORS: **Please replace this text with a human-readable summary of the changes. See `AGENTS.md` in the `jupyterlab/jupyter-ai` repo for more information.**
+You can now call an AI persona from the `%%ai` magic command, giving the same agents you talk to in the chat panel to notebook and IPython users. Pass a persona's name where you would normally pass a model ID; the persona has to be installed and active. See the [magic commands documentation](../users/magic_commands/index.md) for the syntax. Thanks to [@joequant](https://github.com/joequant) and [@srdas](https://github.com/srdas) for building this.
+
+Magic command arguments are also parsed with `shlex` now, so quoted arguments hold together instead of splitting on every space.
+
+## Major bugs fixed
+
+Jupyter AI works with JupyterLab versions below 4.6 again. A dependency bump in the previous release quietly raised the JupyterLab requirement and broke installs on older versions; that bump has been reverted.
+
+Real-time collaboration now works in deployments served behind a reverse proxy. Same-origin and authentication checks follow Jupyter Server's own conventions, which fixes the connection failures these deployments were seeing. A related fix repairs the collaboration event URI when `jupyter-server-ydoc` isn't installed.
 <!-- END SUMMARY -->
 
 <!-- BEGIN AUTO-GENERATED (do not edit; regenerated on each run) -->
@@ -33,6 +41,19 @@ Upgraded from `v0.0.5` → `v0.0.6`. ([See full changelog](https://github.com/ju
 
 - Add README badges [#28](https://github.com/jupyter-ai-contrib/jupyter-ai-router/pull/28) ([@jtpio](https://github.com/jtpio))
 
+### `jupyter-ai-magic-commands`
+
+Upgraded from `v0.0.3` → `v0.0.4`. ([See full changelog](https://github.com/jupyter-ai-contrib/jupyter-ai-magic-commands/releases))
+
+:::{note}
+This is an optional package, installed only with the corresponding `jupyter-ai` extra.
+:::
+
+#### Enhancements made
+
+- use shlex to split up line [#11](https://github.com/jupyter-ai-contrib/jupyter-ai-magic-commands/pull/11) ([@joequant](https://github.com/joequant), [@srdas](https://github.com/srdas))
+- add magic command [#10](https://github.com/jupyter-ai-contrib/jupyter-ai-magic-commands/pull/10) ([@joequant](https://github.com/joequant), [@srdas](https://github.com/srdas))
+
 ### Unchanged subpackages
 
 The following subpackages did not advance their version floor in this release:
@@ -41,7 +62,6 @@ The following subpackages did not advance their version floor in this release:
 - `jupyter-ai-chat-commands` (`v0.0.4`)
 - `jupyter-ai-jupyternaut` (`v0.1.0b0`)
 - `jupyter-ai-litellm` (`v0.0.2`)
-- `jupyter-ai-magic-commands` (`v0.0.3`)
 - `jupyter-ai-persona-manager` (`v0.1.2`)
 - `jupyter-ai-tools` (`v0.6.1`)
 - `jupyter-server-mcp` (`v0.2.1`)

--- a/docs/tests/test_release_notes.py
+++ b/docs/tests/test_release_notes.py
@@ -11,6 +11,7 @@ Run with: ``pytest docs/tests/test_release_notes.py`` (or the whole
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 
@@ -362,6 +363,75 @@ def test_build_page_header(monkeypatch, tmp_path):
     )
     assert "floor at the previous release (v3.0.1)" in summary
     assert gen.CONTRIBUTORS_NOTE in summary
+
+
+def test_build_page_covers_extra_changelog_repos(monkeypatch, tmp_path):
+    # A changelog-only repo (not a doc submodule, so absent from the manifest)
+    # still gets a section, so its PRs aren't dropped from the release notes.
+    monkeypatch.setattr(gen, "previous_release_tag", lambda *a, **k: "v3.0.1")
+    monkeypatch.setattr(
+        gen,
+        "show_file_at",
+        lambda *a, **k: (
+            '[project]\nname = "jupyter_ai"\ndependencies = ['
+            '"jupyter_ai_router>=0.0.5,<0.1.0", "extra_pkg>=0.1.0,<0.2.0"]\n'
+        ),
+    )
+    monkeypatch.setattr(
+        gen, "list_tags", lambda url: ["v0.0.5", "v0.0.6", "v0.1.0", "v0.2.0"]
+    )
+    monkeypatch.setattr(gen, "default_branch", lambda url: "main")
+    monkeypatch.setattr(gen, "window_start", lambda *a, **k: "v0.1.0")
+    monkeypatch.setattr(
+        gen,
+        "submodule_section",
+        lambda org_repo, repo, *a, **k: f"## `{repo}`\n\nUpgraded stub.",
+    )
+    monkeypatch.setattr(
+        gen, "EXTRA_CHANGELOG_REPOS", {"extra_pkg": "some-org/extra-pkg"}
+    )
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        '{"jupyter_ai_router": "org/jupyter-ai-router"}', encoding="utf-8"
+    )
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "jupyter_ai"\ndependencies = ['
+        '"jupyter_ai_router>=0.0.6,<0.1.0", "extra_pkg>=0.2.0,<0.3.0"]\n',
+        encoding="utf-8",
+    )
+
+    page = gen.build_page(
+        version="v3.1.0",
+        repo_root=str(tmp_path),
+        manifest_path=str(manifest),
+        pyproject_path=str(pyproject),
+        target_branch="main",
+        auth="tok",
+        published_date="July 22, 2026",
+    )
+    # Both the manifest repo and the changelog-only repo are covered.
+    assert "### `extra-pkg`" in page
+    assert "### `jupyter-ai-router`" in page
+    # Extras lead, so the most user-facing package heads the changelog.
+    assert page.index("### `extra-pkg`") < page.index("### `jupyter-ai-router`")
+
+
+def test_extra_changelog_repos_disjoint_from_manifest():
+    # A repo in both places would be pinned as a doc submodule AND listed here;
+    # the manifest is the right home for that, so the two must not overlap.
+    manifest_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "..",
+        "submodules",
+        "manifest.json",
+    )
+    with open(manifest_path, encoding="utf-8") as f:
+        manifest = json.load(f)
+    overlap = set(manifest) & set(gen.EXTRA_CHANGELOG_REPOS)
+    assert not overlap, f"registered as both doc submodule and extra: {overlap}"
 
 
 def test_default_summary_omits_window_line_without_prev_tag():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-  "jupyterlab_chat>=0.23.0,<0.24.0",
-  "jupyter_server_documents>=0.3.1,<0.4.0",
-  "jupyter_ai_router>=0.0.5,<0.1.0",
+  "jupyterlab_chat>=0.23.1,<0.24.0",
+  "jupyter_server_documents>=0.3.2,<0.4.0",
+  "jupyter_ai_router>=0.0.6,<0.1.0",
   "jupyter_ai_persona_manager>=0.1.2,<0.2.0",
   "jupyter_ai_chat_commands>=0.0.4,<0.1.0",
   "jupyter_ai_acp_client>=0.2.1,<0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-magics = ["jupyter_ai_litellm>=0.0.2,<0.1.0", "jupyter_ai_magic_commands>=0.0.3,<0.1.0"]
+magics = ["jupyter_ai_litellm>=0.0.2,<0.1.0", "jupyter_ai_magic_commands>=0.0.4,<0.1.0"]
 jupyternaut = ["jupyter_ai_litellm>=0.0.2,<0.1.0", "jupyter_ai_jupyternaut>=0.1.0b0,<0.2.0"]
 # Everything needed to build the documentation (`sphinx-build docs/source`).
 # This is the single source of truth for docs dependencies, used by both Read

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -35,6 +35,14 @@ and the contributors list match the releaser exactly — no hand-rolled variant.
 The new version's floors are read from the **working-tree** ``pyproject.toml``
 (Step 0 runs before the release is tagged, once the floors have been bumped);
 the previous version's floors are read from ``git show <prev_tag>:pyproject.toml``.
+
+Which repos are covered
+-----------------------
+The repo list is ``submodules/manifest.json`` plus ``EXTRA_CHANGELOG_REPOS``
+below. The manifest exists to register **doc submodules**, so a dependency whose
+docs we don't aggregate has no reason to be in it — but its PRs still belong in
+the release notes. ``EXTRA_CHANGELOG_REPOS`` covers exactly that case, keeping
+changelog coverage independent of doc aggregation.
 """
 
 from __future__ import annotations
@@ -72,6 +80,20 @@ from jupyter_releaser import changelog  # noqa: E402
 # regenerated, and *everything else* on the page — the summary block and any prose
 # a contributor added outside the auto regions — is preserved verbatim. This lets
 # a re-run pick up a newly-merged subpackage PR without clobbering hand edits.
+# Dependencies to include in the changelog that are NOT doc submodules.
+#
+# ``submodules/manifest.json`` drives doc aggregation: every entry is checked out
+# as a submodule and its ``docs/source/{contributors,developers}/`` are copied
+# into this site. Adding a repo there purely to get its changelog would also pull
+# its docs in, which is a separate editorial decision — so changelog-only repos
+# live here instead. Same ``"pypi_name": "org/repo"`` shape as the manifest; the
+# repo must use ``v``-prefixed release tags like every other subpackage.
+EXTRA_CHANGELOG_REPOS = {
+    # Lives under jupyterlab/, not jupyter-ai-contrib/, and its developer docs
+    # are published on its own site rather than aggregated here.
+    "jupyterlab_chat": "jupyterlab/jupyter-chat",
+}
+
 AUTO_BEGIN = "<!-- BEGIN AUTO-GENERATED (do not edit; regenerated on each run) -->"
 AUTO_END = "<!-- END AUTO-GENERATED -->"
 SUMMARY_BEGIN = (
@@ -383,6 +405,11 @@ def build_page(
     with open(manifest_path, encoding="utf-8") as f:
         manifest: dict[str, str] = json.load(f)
 
+    # Changelog coverage is the doc submodules plus the changelog-only repos.
+    # Manifest entries win on conflict, so promoting a repo to a real doc
+    # submodule later needs no change here.
+    repos: dict[str, str] = {**EXTRA_CHANGELOG_REPOS, **manifest}
+
     with open(pyproject_path, encoding="utf-8") as f:
         pyproject_text = f.read()
     new_floors = load_floors_from_text(pyproject_text)
@@ -406,7 +433,7 @@ def build_page(
     unchanged: list[str] = []
     skipped: list[str] = []
 
-    for pypi_name, org_repo in manifest.items():
+    for pypi_name, org_repo in repos.items():
         key = _norm(pypi_name)
         repo = org_repo.split("/", 1)[1]
         url = f"https://github.com/{org_repo}.git"


### PR DESCRIPTION
This PR prepares the v3.1.2 release and adds its release notes. Brings some important fixes, see the notes for more info.


## Update to the docs engine

*note this is AI-generated, obviously, who talks like this...*

While writing the notes I hit a gap in the generator: it only covers repos in `submodules/manifest.json`, which is the **doc submodule** registry. `jupyterlab_chat` isn't in it (it lives under `jupyterlab/`, and its developer docs are published on its own site), so its PRs have been silently dropped from every release page generated so far. That mattered here — the JupyterLab `<4.6` compatibility fix is a jupyter-chat change, and it's arguably the most important thing in this release.

Teaches the generator about changelog-only dependencies via a new `EXTRA_CHANGELOG_REPOS` map, so `jupyterlab_chat` now appears in the changelog. Coverage of a repo's changelog is now independent of whether we aggregate its docs.


### Technical details

`EXTRA_CHANGELOG_REPOS` is deliberately separate from `submodules/manifest.json` rather than just adding a manifest entry. The manifest drives submodule checkout and doc aggregation, so listing jupyter-chat there would also pull its `docs/source/developers/` into this site — a separate editorial decision, and not one this PR should make. Manifest entries win on conflict, so promoting a repo to a real doc submodule later needs no change to the new map.

The page was generated by running `scripts/generate_release_notes.py` locally rather than through the "Step 0" workflow, which always cuts its own `release-docs/<version>` branch and whose `GITHUB_TOKEN` can't push to a fork. We'll probably remove that in a future PR.

### Testing

Two new unit tests: one asserting a changelog-only repo gets a section (verified it fails without the fix), one asserting the manifest and the new map stay disjoint. `pytest docs/tests/test_release_notes.py` is green, and `sphinx-build` is clean for the new page. Also confirmed the generator stays re-runnable: the hand-written summary survives regeneration and the toctree stays idempotent.