### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/source/users/jupyternaut/index.md
+++ b/docs/source/users/jupyternaut/index.md
@@ -111,6 +111,8 @@ Jupyternaut enables use of language models accessible through [OpenRouter](https
 
 Likewise, for many models, you may directly choose the OpenAI provider in Jupyter AI instead of OpenRouter in the same way. In the `Chat model` area in `Jupyternaut settings` choose `openai/` to see all the models from this provider.
 
+> **Tip:** The same `base_url` / `base_api` client pattern works with any OpenAI-compatible multi-model gateway when you are not self-hosting — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=jupyter-ai&utm_content=openai) at `https://api.daoxe.com/v1`.
+
 ### Ollama usage
 
 To get started, follow the instructions on the [Ollama website](https://ollama.com/) to set up `ollama` and download the models locally. To select a model, enter the model name in the settings panel, for example `deepseek-coder-v2`. You can see all locally available models with `ollama list` in any terminal.


### PR DESCRIPTION
## Summary

Clarify that the OpenAI / OpenRouter client pattern works with Jupyter AI, and also with other OpenAI-compatible multi-model gateways when you are not self-hosting, using [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=jupyter-ai&utm_content=openai) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Docs render correctly
- [ ] Existing OpenRouter / OpenAI provider text unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>