### PR TITLE
Bump versions for Jupyter AI v3.1.3 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-  "jupyterlab_chat>=0.23.1,<0.24.0",
-  "jupyter_server_documents>=0.3.2,<0.4.0",
-  "jupyter_ai_router>=0.0.6,<0.1.0",
+  "jupyterlab_chat>=0.23.2,<0.24.0",
+  "jupyter_server_documents>=0.3.3,<0.4.0",
+  "jupyter_ai_router>=0.0.7,<0.1.0",
   "jupyter_ai_persona_manager>=0.1.2,<0.2.0",
   "jupyter_ai_chat_commands>=0.0.4,<0.1.0",
   "jupyter_ai_acp_client>=0.2.1,<0.3.0",
@@ -41,8 +41,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-magics = ["jupyter_ai_litellm>=0.0.2,<0.1.0", "jupyter_ai_magic_commands>=0.0.4,<0.1.0"]
-jupyternaut = ["jupyter_ai_litellm>=0.0.2,<0.1.0", "jupyter_ai_jupyternaut>=0.1.0b0,<0.2.0"]
+magics = ["jupyter_ai_litellm>=0.0.3,<0.1.0", "jupyter_ai_magic_commands>=0.0.4,<0.1.0"]
+jupyternaut = ["jupyter_ai_litellm>=0.0.3,<0.1.0", "jupyter_ai_jupyternaut>=0.1.0b0,<0.2.0"]
 # Everything needed to build the documentation (`sphinx-build docs/source`).
 # This is the single source of truth for docs dependencies, used by both Read
 # the Docs (see .readthedocs.yaml) and the docs CI workflow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 
 [project.optional-dependencies]
 magics = ["jupyter_ai_litellm>=0.0.3,<0.1.0", "jupyter_ai_magic_commands>=0.0.4,<0.1.0"]
-jupyternaut = ["jupyter_ai_litellm>=0.0.3,<0.1.0", "jupyter_ai_jupyternaut>=0.1.0b0,<0.2.0"]
+jupyternaut = ["jupyter_ai_litellm>=0.0.3,<0.1.0", "jupyter_ai_jupyternaut>=0.1.0b1,<0.2.0"]
 # Everything needed to build the documentation (`sphinx-build docs/source`).
 # This is the single source of truth for docs dependencies, used by both Read
 # the Docs (see .readthedocs.yaml) and the docs CI workflow.


### PR DESCRIPTION
Prep for the 3.1.3 release. Raises subpackage dependency floors to their latest stable PyPI releases; ceilings and `__version__` unchanged (version bump handled by jupyter-releaser at release time).

- jupyterlab_chat 0.23.1 -> 0.23.2
- jupyter_server_documents 0.3.2 -> 0.3.3
- jupyter_ai_router 0.0.6 -> 0.0.7
- jupyter_ai_litellm 0.0.2 -> 0.0.3 (magics + jupyternaut extras)

All other subpackages already at their latest stable floor.