### PR TITLE
Add plausible stats

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,3 +75,11 @@ html_theme_options = {
         },
     ],
 }
+
+def setup(app):
+    # Enable Plausible.io stats
+    app.add_js_file("https://plausible.io/js/pa-UHxbx3cCjgiU99DP3Pn5X.js", loading_method="async")
+    app.add_js_file(
+        filename=None,
+        body="window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init({hashBasedRouting:true})",
+    )


### PR DESCRIPTION
## Description

This adds Plausible stats to the jupyter-ai docs. Metrics are shown at https://plausible.io/jupyter-documentation

## Code changes

Adds Plausible.io metrics

## User-facing changes

None

## Backwards-incompatible changes

None
