### PR TITLE
docs: update Codex ACP package name

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -84,7 +84,7 @@ install the corresponding package:
 
 ```{tab} Codex
 
-    npm install -g @zed-industries/codex-acp
+    npm install -g @agentclientprotocol/codex-acp
 
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Jupyter AI! Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://jupyter-ai.readthedocs.io/en/latest/contributors/
-->

## Description

"Getting Started" lists the following package to be installed for Codex:

```
npm install -g @zed-industries/codex-acp
```

This package has been deprecated (see https://github.com/zed-industries/codex-acp) and does not work with GPT-5.6-Sol. Instead, `@agentclientprotocol/codex-acp` should be used (see https://github.com/agentclientprotocol/codex-acp).

## Code changes

Replace package name in documentation.

## User-facing changes

Before:

<img width="1678" height="428" alt="CleanShot-2026-08-24-11-53-13" src="https://github.com/user-attachments/assets/4f369148-628c-4dff-bd30-4b9e99b84655" />

After:

<img width="1680" height="422" alt="CleanShot-2026-08-24-11-53-40" src="https://github.com/user-attachments/assets/ddf72be4-f01c-4b24-9516-ba8902c3448e" />

## Backwards-incompatible changes

None
