### PR TITLE
docs: document OrcaRouter as a Jupyternaut model provider

### DIFF
--- a/docs/source/users/jupyternaut/index.md
+++ b/docs/source/users/jupyternaut/index.md
@@ -111,6 +111,21 @@ Jupyternaut enables use of language models accessible through [OpenRouter](https
 
 Likewise, for many models, you may directly choose the OpenAI provider in Jupyter AI instead of OpenRouter in the same way. In the `Chat model` area in `Jupyternaut settings` choose `openai/` to see all the models from this provider.
 
+### OrcaRouter usage
+
+Jupyternaut can also route language models through [OrcaRouter](https://www.orcarouter.ai)'s unified interface. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents: like OpenRouter, it exposes a single `https://api.orcarouter.ai/v1` endpoint that fronts models from many providers (e.g. Anthropic, Google, Mistral, and OpenAI-compatible open models), so you can pick the best model per task without managing separate accounts. It also adds adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. It runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+To use OrcaRouter in Jupyternaut:
+
+1. Create an account and API key at [https://www.orcarouter.ai](https://www.orcarouter.ai). Keys start with `sk-orca-`.
+2. Add a custom model in the `Jupyternaut settings` panel with:
+   - **Model ID**: `openai/orcarouter/auto` (the `auto` route sends each prompt to the best model automatically) or a concrete model such as `openai/orcarouter/fusion-mini`.
+   - **API key**: your OrcaRouter key (the `OPENAI_API_KEY` field or the `OPENAI_API_KEY` environment variable, since OrcaRouter speaks the OpenAI protocol).
+   - **`api_base` model parameter**: `https://api.orcarouter.ai/v1`.
+3. Select the custom model from the model picker and start chatting.
+
+The `openai/` prefix tells LiteLLM to treat OrcaRouter as an OpenAI-compatible endpoint, and the `api_base` parameter points it at OrcaRouter's gateway. Because OrcaRouter is OpenAI-compatible, every model it exposes is available through this single custom-model entry.
+
 ### Ollama usage
 
 To get started, follow the instructions on the [Ollama website](https://ollama.com/) to set up `ollama` and download the models locally. To select a model, enter the model name in the settings panel, for example `deepseek-coder-v2`. You can see all locally available models with `ollama list` in any terminal.


### PR DESCRIPTION
## Description

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Jupyternaut already surfaces language models through LiteLLM, and its user guide shows how OpenRouter and OpenAI models are picked from the `Chat model` area in `Jupyternaut settings`. This PR adds a "OrcaRouter usage" section right after the existing OpenRouter/OpenAI section, so users who want OrcaRouter's routing, failover, and guardrails can configure it as a custom model in the same settings panel.

## Code changes

Docs only — no Python/TypeScript changes.

- `docs/source/users/jupyternaut/index.md`: new "OrcaRouter usage" subsection mirroring the existing "OpenRouter and OpenAI Interface Usage" section. It explains how to add OrcaRouter as a custom model in Jupyternaut settings:
  - model ID `openai/orcarouter/auto` (adaptive routing) or a concrete model such as `openai/orcarouter/fusion-mini`,
  - the `OPENAI_API_KEY` field (OrcaRouter speaks the OpenAI protocol, keys start with `sk-orca-`),
  - `api_base` model parameter `https://api.orcarouter.ai/v1`.

## User-facing changes

Users can now follow step-by-step instructions to route Jupyternaut through OrcaRouter's unified endpoint from the same `Jupyternaut settings` panel used for OpenRouter, without treating OrcaRouter as an anonymous base URL.

## Verification

- `sphinx-build -b html docs/source docs/_build/html` builds cleanly (same 14 pre-existing warnings as `main`; none from this change).
- `pytest docs/tests` — 38 passed.
- L3 live test: constructed `ChatLiteLLM(model="openai/orcarouter/auto", api_base="https://api.orcarouter.ai/v1", api_key=...)` (the same call path Jupyternaut's persona uses) and confirmed an OK completion response from OrcaRouter.

## Backwards-incompatible changes

None.

---

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
