### PR TITLE
Add release process documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,6 +19,9 @@ extensions = [
     "sphinx_design",
     "sphinx_tabs.tabs",
     "sphinx_copybutton",
+    # Renders {mermaid} directives (e.g. the subpackage dependency graph in the
+    # contributor release docs).
+    "sphinxcontrib.mermaid",
     # Aggregates each subpackage's docs/source/{contributors,developers}/ from
     # its submodule under submodules/<repo>/ into this build. See
     # docs/source/_ext/subpackage_docs.py.

--- a/docs/source/contributors/index.md
+++ b/docs/source/contributors/index.md
@@ -4,6 +4,13 @@ This page is intended for people interested in building new or modified function
 
 If you would like to build applications that enhance Jupyter AI, please see the {doc}`developer's guide </developers/index>`.
 
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+release-process
+```
+
 ## Development Setup
 
 ### Overview

--- a/docs/source/contributors/release-process.md
+++ b/docs/source/contributors/release-process.md
@@ -91,6 +91,7 @@ from a package to the packages it depends on). Release from the bottom up:
 flowchart TD
     ja[jupyter-ai]
 
+    ja --> chat[jupyterlab-chat]
     ja --> router[jupyter-ai-router]
     ja --> pm[jupyter-ai-persona-manager]
     ja --> cc[jupyter-ai-chat-commands]
@@ -103,7 +104,7 @@ flowchart TD
     acp --> pm
     cc --> pm
     pm --> router
-    router --> chat[jupyterlab-chat]
+    router --> chat
 ```
 
 `jupyter-ai` is the metapackage and pins every package shown. `jupyterlab-chat`

--- a/docs/source/contributors/release-process.md
+++ b/docs/source/contributors/release-process.md
@@ -20,19 +20,40 @@ subpackage repos under the
 In v3, Jupyter AI is a metapackage that pins a working set of independently
 released subpackages. A full release therefore happens in two layers: first the
 subpackages are released, then `jupyter-ai` itself is released once its version
-floors point at those new subpackage versions.
+ranges point at those new subpackage versions.
+
+The version-range model is what keeps this manageable, and it is worth reading
+{doc}`Versioning and upgrading </users/versioning>` before a release:
+
+- **None of the subpackages put version ceilings on each other.** A subpackage
+  can require `>=` a floor of another subpackage, but never caps it. This is why
+  publishing an official patch of a subpackage automatically reaches existing
+  installs.
+- **Only the `jupyter-ai` metapackage enforces version ceilings** on its
+  subpackage dependencies (for example `jupyter_ai_tools>=0.5.2,<0.6.0`). These
+  ceilings are bumped each minor release, which is how a subpackage's breaking
+  changes reach users.
+
+```{note}
+Because subpackages have no ceilings on each other, an official **patch** of a
+subpackage updates new installs on its own. A matching patch release of
+`jupyter-ai` itself is **not strictly necessary**; we mainly cut one to
+communicate that bug fixes or security fixes shipped. Informally this happens
+each Monday if there are new patches.
+```
 
 The order of operations for an official release is:
 
 1. [Release all subpackages](#step-1-release-the-subpackages)
-2. [Bump version floors in `jupyter-ai` and merge](#step-2-bump-version-floors)
+2. [Bump subpackage version ranges in `jupyter-ai` and merge](#step-2-bump-version-ranges)
 3. [Run "Step 0: Prep release documentation"](#step-3-prep-release-documentation-step-0)
 4. [Edit the generated changelog in the PR that Step 0 opens](#step-4-edit-and-merge-the-changelog)
 5. [Merge the changelog PR](#step-4-edit-and-merge-the-changelog)
 6. [Run "Step 1" and "Step 2" to publish `jupyter-ai`](#step-5-publish-jupyter-ai-steps-1-and-2)
 
 Releasing on conda-forge is a separate, downstream process covered
-[at the end of this page](#releasing-on-conda-forge).
+[at the end of this page](#releasing-on-conda-forge). Common one-off questions
+are answered in the [FAQ](#faq).
 
 (step-1-release-the-subpackages)=
 ## 1. Release the subpackages
@@ -46,22 +67,49 @@ as simple as running its two manual GitHub Actions workflows in order:
 - **Step 2: Publish Release** publishes the release to PyPI (and npm, where
   applicable) and creates the GitHub release.
 
-```{note}
-TODO: document how to decide which subpackages need a new release, and any
-ordering constraints between subpackages that depend on one another.
+```{important}
+When running Step 1 for any **official** release, check the "use PRs since the
+last stable tag" option (`since_last_stable`) so the changelog covers everything
+since the last stable release rather than since the last pre-release. Leave it
+**unchecked only for pre-releases**.
 ```
 
-(step-2-bump-version-floors)=
-## 2. Bump version floors
+### Release ordering
 
-Once the subpackages are published, bump their version floors in the
-`jupyter-ai` metapackage so it pins the newly released versions.
-
-- Update the dependency floors in `pyproject.toml`.
-- Open a PR with the floor bumps and merge it into the target branch.
+- **Independent upgrade** (the subpackage does not require a new version of any
+  other subpackage): just release it. No ordering needed.
+- **Dependent upgrade** (for example a change to `jupyter-ai-router` that
+  `jupyter-ai-persona-manager` must then adopt): release in **topological
+  order**. Release `jupyter-ai-router` first, then bump
+  `jupyter-ai-persona-manager`'s floor on it and release that, and so on up the
+  dependency chain.
 
 ```{note}
-The floors must be bumped in the target branch **before** Step 0 runs. The
+When bumping one subpackage's dependency on another, update **both**
+`pyproject.toml` and `package.json` (if the subpackage ships a JavaScript
+package). A floor bumped in only one of the two will pass CI but ship an
+inconsistent dependency set.
+```
+
+(step-2-bump-version-ranges)=
+## 2. Bump subpackage version ranges
+
+Once the subpackages are published, bump their version ranges in the
+`jupyter-ai` metapackage so it points at the newly released versions.
+
+- Update the subpackage dependency ranges in `pyproject.toml`.
+- Open a PR with the range bumps and merge it into the target branch.
+
+Which end of the range you bump depends on the release type (see
+{doc}`Versioning and upgrading </users/versioning>`):
+
+- **Patch release** (e.g. `3.0.0` → `3.0.1`): bump the **floor** only, to require
+  API-compatible patches of subpackages.
+- **Minor release** (e.g. `3.0.x` → `3.1.0`): bump the **floor and the ceiling**,
+  to pull in subpackages' new (potentially breaking) features.
+
+```{note}
+The ranges must be bumped in the target branch **before** Step 0 runs. The
 release-notes generator reads each subpackage's floor from `pyproject.toml` to
 compute the PR window for that subpackage.
 ```
@@ -104,15 +152,21 @@ grouping, what to trim from the auto-generated list).
 (step-5-publish-jupyter-ai-steps-1-and-2)=
 ## 5. Publish `jupyter-ai` (Steps 1 and 2)
 
-With the floors bumped and the changelog merged, release `jupyter-ai` itself
+With the ranges bumped and the changelog merged, release `jupyter-ai` itself
 using the same Jupyter Releaser workflows the subpackages use:
 
 - **Step 1: Prep Release** (`prep-release.yml`)
 - **Step 2: Publish Release** (`publish-release.yml`)
 
-```{note}
-TODO: document the input values typically used for Step 1 (version specifier,
-target branch, `since_last_stable`) and any post-publish verification.
+As with the subpackages, check the "use PRs since the last stable tag"
+(`since_last_stable`) option in Step 1 for an official release, and leave it
+unchecked only for a pre-release.
+
+```{seealso}
+The repo's [`AGENTS.md`](https://github.com/jupyterlab/jupyter-ai/blob/main/AGENTS.md)
+documents the release tooling in more detail (including the "Writing release
+notes" workflow and the `scripts/generate_release_notes.py` script behind
+Step 0), and is the reference for agents driving a release.
 ```
 
 (releasing-on-conda-forge)=
@@ -150,3 +204,20 @@ including
 and
 [`open-feedstock-pr`](https://github.com/dlqqq/conda-forge-skills/blob/main/skills/open-feedstock-pr).
 ```
+
+(faq)=
+## FAQ
+
+### How do I publish a pre-release?
+
+Use [PyPI pre-release version syntax](https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases)
+for the version specifier: `0.2.0a0` (alpha), `0.2.0b0` (beta), or `0.2.0rc0`
+(release candidate) instead of `0.2.0`. For a pre-release, leave the "use PRs
+since the last stable tag" (`since_last_stable`) option **unchecked** in Step 1.
+
+### How do I update the release notes generated by Step 0?
+
+Re-run the "Step 0: Prep release documentation" workflow. It is safe to run
+again even if the notes were already generated: each run merges the target
+branch back into the release-docs branch, so re-running after merging the
+version-range bump into `main` picks up the new updates.

--- a/docs/source/contributors/release-process.md
+++ b/docs/source/contributors/release-process.md
@@ -1,0 +1,152 @@
+# Release Process
+
+This page documents how maintainers cut an official release of Jupyter AI.
+
+```{note}
+This is a high-level scaffold. Each section captures the overall shape of the
+process; step-by-step commands, screenshots, and edge cases still need to be
+filled in.
+```
+
+## Audience
+
+This guide is for Jupyter AI **maintainers** with release permissions on the
+[`jupyterlab/jupyter-ai`](https://github.com/jupyterlab/jupyter-ai) repo and the
+subpackage repos under the
+[`jupyter-ai-contrib`](https://github.com/jupyter-ai-contrib) org.
+
+## Overview
+
+In v3, Jupyter AI is a metapackage that pins a working set of independently
+released subpackages. A full release therefore happens in two layers: first the
+subpackages are released, then `jupyter-ai` itself is released once its version
+floors point at those new subpackage versions.
+
+The order of operations for an official release is:
+
+1. [Release all subpackages](#step-1-release-the-subpackages)
+2. [Bump version floors in `jupyter-ai` and merge](#step-2-bump-version-floors)
+3. [Run "Step 0: Prep release documentation"](#step-3-prep-release-documentation-step-0)
+4. [Edit the generated changelog in the PR that Step 0 opens](#step-4-edit-and-merge-the-changelog)
+5. [Merge the changelog PR](#step-4-edit-and-merge-the-changelog)
+6. [Run "Step 1" and "Step 2" to publish `jupyter-ai`](#step-5-publish-jupyter-ai-steps-1-and-2)
+
+Releasing on conda-forge is a separate, downstream process covered
+[at the end of this page](#releasing-on-conda-forge).
+
+(step-1-release-the-subpackages)=
+## 1. Release the subpackages
+
+Every Jupyter AI subpackage (for example `jupyter-ai-persona-manager`,
+`jupyter-ai-router`, `jupyter-ai-tools`) uses
+[Jupyter Releaser](https://jupyter-releaser.readthedocs.io/). Releasing one is
+as simple as running its two manual GitHub Actions workflows in order:
+
+- **Step 1: Prep Release** builds the changelog and opens a release PR.
+- **Step 2: Publish Release** publishes the release to PyPI (and npm, where
+  applicable) and creates the GitHub release.
+
+```{note}
+TODO: document how to decide which subpackages need a new release, and any
+ordering constraints between subpackages that depend on one another.
+```
+
+(step-2-bump-version-floors)=
+## 2. Bump version floors
+
+Once the subpackages are published, bump their version floors in the
+`jupyter-ai` metapackage so it pins the newly released versions.
+
+- Update the dependency floors in `pyproject.toml`.
+- Open a PR with the floor bumps and merge it into the target branch.
+
+```{note}
+The floors must be bumped in the target branch **before** Step 0 runs. The
+release-notes generator reads each subpackage's floor from `pyproject.toml` to
+compute the PR window for that subpackage.
+```
+
+(step-3-prep-release-documentation-step-0)=
+## 3. Prep release documentation (Step 0)
+
+Run the **"Step 0: Prep release documentation"** workflow
+(`prep-release-docs.yml`) on `jupyterlab/jupyter-ai`.
+
+This workflow generates the docs "Releases" page for the new version and opens
+it as a draft PR against the target branch. The docs
+{doc}`Releases </releases/index>` section, not Jupyter Releaser's changelog and
+not the GitHub release, is the source of truth for Jupyter AI release notes.
+
+Inputs:
+
+- **version**: the new version being released, for example `v3.2.0`.
+- **target-branch**: the branch to target (`main` by default; patch releases of
+  older minors are cut from maintenance branches such as `3.0.x`).
+
+Under the hood it reuses Jupyter Releaser's changelog builder to aggregate PRs
+and contributors across every submodule, resolving each submodule's PR window
+from its version floors at the previous release versus this release.
+
+(step-4-edit-and-merge-the-changelog)=
+## 4. Edit and merge the changelog
+
+The draft PR opened by Step 0 contains the auto-generated release notes page
+(for example `docs/source/releases/v3.2.0.md`).
+
+- Review and edit the generated changelog for accuracy and readability.
+- Merge the changelog PR into the target branch.
+
+```{note}
+TODO: document the editorial conventions for the changelog (highlights,
+grouping, what to trim from the auto-generated list).
+```
+
+(step-5-publish-jupyter-ai-steps-1-and-2)=
+## 5. Publish `jupyter-ai` (Steps 1 and 2)
+
+With the floors bumped and the changelog merged, release `jupyter-ai` itself
+using the same Jupyter Releaser workflows the subpackages use:
+
+- **Step 1: Prep Release** (`prep-release.yml`)
+- **Step 2: Publish Release** (`publish-release.yml`)
+
+```{note}
+TODO: document the input values typically used for Step 1 (version specifier,
+target branch, `since_last_stable`) and any post-publish verification.
+```
+
+(releasing-on-conda-forge)=
+## Releasing on conda-forge
+
+Publishing the release to [conda-forge](https://conda-forge.org/) is a separate,
+downstream process. Unlike the PyPI release above, it is **not** automated by a
+single workflow and requires familiarity with conda-forge feedstocks: you edit a
+feedstock's `recipe/meta.yaml` (or v1 `recipe.yaml`), update the version and
+source hash, rerender with `conda-smithy`, and open a PR against the feedstock.
+
+At a high level:
+
+1. Each Jupyter AI package has its own feedstock under the
+   [conda-forge](https://github.com/conda-forge) org (for example
+   `jupyter-ai-feedstock`).
+2. For each package, open a version-bump PR on its feedstock that updates the
+   version and sha256, resets the build number, and rerenders with the latest
+   `conda-smithy`.
+3. Merge feedstock PRs in dependency order so each package's run requirements
+   resolve against versions already available on the channel.
+
+```{note}
+Pre-releases use the CFEP-05 `rc`/`dev` branch workflow with dedicated channel
+labels, which adds further steps. Do not attempt a conda-forge release without
+understanding the feedstock and channel model.
+```
+
+```{seealso}
+The [`conda-forge-skills`](https://github.com/dlqqq/conda-forge-skills)
+repository collects agent skills that automate much of this feedstock work,
+including
+[`create-recipe`](https://github.com/dlqqq/conda-forge-skills/blob/main/skills/create-recipe),
+[`create-prerelease-branches`](https://github.com/dlqqq/conda-forge-skills/blob/main/skills/create-prerelease-branches),
+and
+[`open-feedstock-pr`](https://github.com/dlqqq/conda-forge-skills/blob/main/skills/open-feedstock-pr).
+```

--- a/docs/source/contributors/release-process.md
+++ b/docs/source/contributors/release-process.md
@@ -84,6 +84,33 @@ since the last stable release rather than since the last pre-release. Leave it
   `jupyter-ai-persona-manager`'s floor on it and release that, and so on up the
   dependency chain.
 
+The current required-dependency graph of the working set is below (arrows point
+from a package to the packages it depends on). Release from the bottom up:
+
+```{mermaid}
+flowchart TD
+    ja[jupyter-ai]
+
+    ja --> router[jupyter-ai-router]
+    ja --> pm[jupyter-ai-persona-manager]
+    ja --> cc[jupyter-ai-chat-commands]
+    ja --> acp[jupyter-ai-acp-client]
+    ja --> tools[jupyter-ai-tools]
+    ja --> mcp[jupyter-server-mcp]
+    ja --> toolkit[jupyterlab-commands-toolkit]
+    ja --> lc[jupyter-live-content]
+
+    acp --> pm
+    cc --> pm
+    pm --> router
+    router --> chat[jupyterlab-chat]
+```
+
+`jupyter-ai` is the metapackage and pins every package shown. `jupyterlab-chat`
+(from `jupyterlab/jupyter-chat`) is the foundation; `jupyter-ai-tools`,
+`jupyter-server-mcp`, `jupyterlab-commands-toolkit`, and `jupyter-live-content`
+have no required dependencies on the others.
+
 ```{note}
 When bumping one subpackage's dependency on another, update **both**
 `pyproject.toml` and `package.json` (if the subpackage ships a JavaScript

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ docs = [
   "sphinx-copybutton",
   "sphinx-design",
   "sphinx-tabs",
+  # Renders the {mermaid} directive (dependency graphs, etc.) in the docs.
+  "sphinxcontrib-mermaid",
   # Auto-generated subpackage API reference. autodoc/napoleon/linkcode are
   # Sphinx core (no dep); autodoc_pydantic is third-party and renders the
   # Pydantic model docs. See docs/source/_ext/autodoc_subpackages.py.


### PR DESCRIPTION
## Motivation

There's no written guide for how maintainers cut an official Jupyter AI release. The process spans the subpackage releases, the metapackage floor bumps, the Step 0 changelog workflow, and the final Step 1/Step 2 publish, plus a separate conda-forge path. New maintainers have to reconstruct it from memory.

## Summary

Adds a high-level "Release Process" page to the Contributor Guide that walks through the official release flow end to end: release the subpackages via Jupyter Releaser (Step 1 + Step 2), bump version floors in `jupyter-ai` and merge, run "Step 0: Prep release documentation" to generate the changelog PR, edit and merge that changelog, then run Step 1/Step 2 to publish `jupyter-ai`. It also gives a high-level overview of the conda-forge feedstock process and links to the conda-forge-skills that automate it.

This is a scaffold: the overall shape is captured, with `TODO` notes marking the spots where step-by-step detail still needs filling in.

## Technical details

- New page at `docs/source/contributors/release-process.md`, wired into the contributors nav via a hidden `{toctree}`.
- Workflow references match the repo (`prep-release-docs.yml`, `prep-release.yml`, `publish-release.yml`).