### PR TITLE
Update banner and roadmap to reflect v3.2.0 release

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,8 +55,8 @@ html_theme_options = {
     # differently per page depth. Use an absolute URL, pinned to /en/stable so it
     # tracks the latest released docs rather than /en/latest (unreleased main).
     "announcement": (
-        "Jupyter AI v3.1.0 is now released! 🎉 "
-        '<a href="https://jupyter-ai.readthedocs.io/en/stable/releases/v3.1.0.html">'
+        "Jupyter AI v3.2.0 is now released! 🎉 "
+        '<a href="https://jupyter-ai.readthedocs.io/en/stable/releases/v3.2.0.html">'
         "See the release notes</a>."
     ),
     "nav_links": [

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -35,7 +35,7 @@ Use Claude, Codex, GitHub Copilot, Goose, Kilo, Kiro, Mistral Vibe, OpenCode, or
 :::
 
 :::{grid-item-card} ⚡ Real-Time UI
-Watch other humans or agents edit files in real-time, powered by a new RTC backend.
+Watch agents edit files, run notebooks, and fix cell errors in real-time.
 :::
 
 :::{grid-item-card} 🛡️ Guardrails By Default

--- a/docs/source/releases/v3.1.3.md
+++ b/docs/source/releases/v3.1.3.md
@@ -9,7 +9,7 @@
 ## Summary
 
 :::{note}
-We are beginning development on Jupyter AI v3.2, which will make RTC optional by default. This will greatly improve the stability of the default experience and address compatibility issues raised by users. Please share feedback on the [proposal](../roadmap/decouple-rtc.md)!
+We are beginning development on Jupyter AI v3.2, which will make RTC optional by default. This will greatly improve the stability of the default experience and address compatibility issues raised by users. Please share feedback on the [proposal](../roadmap/completed/decouple-rtc.md)!
 :::
 
 #### ACP slash commands fixed
@@ -24,7 +24,7 @@ In some remotely deployed environments, saves made through the Jupyter Server Co
 
 This issue should have been prevented by Jupyter Server, which applies atomic writes via `fsync` by default to guard against this. However, it is also possible that there are some platforms or filesystems that cause data loss when a file-writing `jupyter-lab` process is forcibly terminated even if atomic writes are applied. The root cause remains under active investigation.
 
-This issue does not impact most users, but is extremely concerning regardless. The reports surrounding this issue have motivated the upcoming Jupyter AI v3.2 release, which will decouple RTC as a dependency and make RTC optional in Jupyter AI. For users who do not need RTC, this will guarantee stability in their environments. Please see the [proposal](../roadmap/decouple-rtc.md) for more details.
+This issue does not impact most users, but is extremely concerning regardless. The reports surrounding this issue have motivated the upcoming Jupyter AI v3.2 release, which will decouple RTC as a dependency and make RTC optional in Jupyter AI. For users who do not need RTC, this will guarantee stability in their environments. Please see the [proposal](../roadmap/completed/decouple-rtc.md) for more details.
 
 #### Jupyter Chat rename bug fix
 

--- a/docs/source/roadmap/completed/decouple-rtc.md
+++ b/docs/source/roadmap/completed/decouple-rtc.md
@@ -1,11 +1,5 @@
 # Decouple RTC
 
-:::{note}
-This will be released as part of Jupyter AI v3.2.0 as it addresses a major bug, and both maintainers and users have reached a general consensus on accepting this.
-
-Please join the discussion on [this GitHub issue](https://github.com/jupyterlab/jupyter-ai/issues/1644), or the [Zulip thread](https://jupyter.zulipchat.com/#narrow/channel/475130-jupyter-ai/topic/Decoupling.20RTC.20from.20Jupyter.20AI/with/615991875)!
-:::
-
 ## Context
 
 Jupyter AI brings AI agents into JupyterLab: a chat interface for talking to agents, and the ability for those agents to read and edit notebooks and files directly. For agent edits to feel live, Jupyter AI currently relies on real-time collaboration (RTC). RTC is the same technology that lets multiple humans co-edit a document. RTC models documents as conflict-free replicated data types (CRDT) replicated between the server and each web client over WebSockets. RTC in Jupyter uses YATA CRDTs powered by `yjs` and `yrs` libraries. Today Jupyter AI depends on RTC for two reasons: the chat itself is modeled as a shared document powered by RTC (`YChat`), and RTC allows agent edits to update the UI in real-time for every file or notebook you have open. Because of this, RTC has been a required dependency since Jupyter AI v3.0.

--- a/docs/source/roadmap/completed/index.md
+++ b/docs/source/roadmap/completed/index.md
@@ -5,5 +5,6 @@ Roadmap proposals that have shipped. See the [Releases](../../releases/index) se
 ```{toctree}
 :hidden:
 
+decouple-rtc
 jupyter-ai-3.1
 ```

--- a/docs/source/roadmap/index.md
+++ b/docs/source/roadmap/index.md
@@ -5,7 +5,6 @@ This section contains the roadmap for major API improvements and new features in
 ```{toctree}
 :hidden:
 
-decouple-rtc
 new-persona-api
 completed/index
 ```


### PR DESCRIPTION
Updates the docs banner, landing page, and roadmap ahead of the v3.2.0 release.

- Bump the site-wide announcement banner from v3.1.0 to v3.2.0 (`docs/source/conf.py`), pointing at the v3.2.0 release notes.
- Reword the "Real-Time UI" card on the landing page (`docs/source/index.md`) to describe what agents do (edit files, run notebooks, fix cell errors) and drop the "new RTC backend" framing, since RTC is now optional in v3.2.0.
- Move the **Decouple RTC** proposal from the active roadmap into `roadmap/completed/`, since it ships in v3.2.0. Removed the top note (discussion/consensus callout) as it is no longer pending.
- Update the roadmap and completed `toctree`s accordingly, and fix the two links in the v3.1.3 release notes that referenced the old proposal path.
