### PR TITLE
Auto-insert release-notes preamble into the changelog

### DIFF
--- a/.github/workflows/verify-changelog-build.yml
+++ b/.github/workflows/verify-changelog-build.yml
@@ -1,0 +1,38 @@
+name: "Verify changelog build"
+
+# Fast, self-contained tests for scripts/after_build_changelog.py — the
+# jupyter-releaser "after-build-changelog" hook that inserts the release-notes
+# preamble during "Step 1: Prep Release". Runs only when the hook script (or
+# its test, or this workflow) changes, so it stays out of the way of unrelated
+# PRs.
+
+on:
+  push:
+    paths:
+      - "scripts/*changelog*.py"
+      - ".github/workflows/verify-changelog-build.yml"
+  pull_request:
+    paths:
+      - "scripts/*changelog*.py"
+      - ".github/workflows/verify-changelog-build.yml"
+
+permissions: {}
+
+jobs:
+  verify:
+    name: Run changelog-hook tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run tests
+        run: pytest scripts/test_after_build_changelog.py -v

--- a/.github/workflows/verify-changelog-build.yml
+++ b/.github/workflows/verify-changelog-build.yml
@@ -23,7 +23,7 @@ jobs:
     name: Run changelog-hook tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,8 @@ jupyter_ai = "jupyter_ai:DEFAULT_JUPYTER_SERVER_MCP_TOOLS"
 # site); the release tag captures a frozen snapshot for the `stable` site. See
 # scripts/freeze-doc-submodules.sh.
 after-bump-version = ["bash scripts/freeze-doc-submodules.sh"]
+
+# After "Step 1: Prep Release" builds the changelog entry, insert the standard
+# release-notes preamble under the version heading, pointing readers to the
+# full notes on the docs site. See scripts/after_build_changelog.py.
+after-build-changelog = ["python scripts/after_build_changelog.py"]

--- a/scripts/after_build_changelog.py
+++ b/scripts/after_build_changelog.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""Insert the standard Jupyter AI release-notes preamble into CHANGELOG.md.
+
+Runs as a jupyter-releaser ``after-build-changelog`` hook (see the
+``[tool.jupyter-releaser.hooks]`` table in pyproject.toml). During "Step 1:
+Prep Release", ``build-changelog`` writes the new version's entry into
+CHANGELOG.md between the START/END markers; this script adds a fixed blurb just
+under the ``## <version>`` heading, pointing readers to the full release notes
+published on the docs site.
+
+Only final releases get the blurb: the docs ``releases/vX.Y.Z.html`` page and
+the ``stable`` docs alias exist only for finals, so linking to them from a
+prerelease changelog would 404.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+CHANGELOG = Path("CHANGELOG.md")
+START = "<!-- <START NEW CHANGELOG ENTRY> -->"
+END = "<!-- <END NEW CHANGELOG ENTRY> -->"
+
+# Substring unique to the blurb, used to make re-runs idempotent.
+SENTINEL = "for the complete v"
+
+
+def build_preamble(version: str) -> str:
+    """Return the release-notes preamble for a final ``version`` (no leading v)."""
+    return (
+        f"**[Click here](https://jupyter-ai.readthedocs.io/en/stable/releases/"
+        f"v{version}.html) for the complete v{version} release notes, now "
+        "published on our official documentation site.**\n\n"
+        "The changelog that follows is specific to the `jupyterlab/jupyter-ai` "
+        "repo - they mostly include updates to documentation, version ranges, "
+        "and GitHub workflows. All source code now lives in Jupyter AI's "
+        "various subpackages, whose changes are reported in the official "
+        "documentation linked above.\n\n"
+        "---\n"
+    )
+
+
+def main() -> int:
+    text = CHANGELOG.read_text(encoding="utf-8")
+    if START not in text or END not in text:
+        print("error: changelog markers not found", file=sys.stderr)
+        return 1
+
+    start, end = text.index(START), text.index(END)
+    block = text[start:end]
+
+    match = re.search(r"^## (\S+)", block, flags=re.MULTILINE)
+    if not match:
+        print("error: no version heading in new changelog entry", file=sys.stderr)
+        return 1
+    version = match.group(1)
+
+    # Skip prereleases (e.g. 3.2.0rc1, 3.2.0a1): no stable docs page exists.
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        print(f"Skipping preamble for prerelease {version}.")
+        return 0
+
+    if SENTINEL in block:
+        print("Preamble already present; nothing to do.")
+        return 0
+
+    insert_at = start + match.end()
+    text = text[:insert_at] + "\n\n" + build_preamble(version) + text[insert_at:]
+    CHANGELOG.write_text(text, encoding="utf-8")
+    print(f"Inserted release-notes preamble for v{version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_after_build_changelog.py
+++ b/scripts/test_after_build_changelog.py
@@ -1,0 +1,93 @@
+"""Tests for scripts/after_build_changelog.py (the after-build-changelog hook).
+
+Self-contained and fast: no network, no jupyter-releaser. Verifies the two
+properties that matter for the hook — it touches only the newest entry, and it
+does nothing for prereleases — plus idempotency and the exact layout
+(``## <version>`` heading kept, blurb, ``---``, then the rest of the entry).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent / "after_build_changelog.py"
+
+spec = importlib.util.spec_from_file_location("after_build_changelog", SCRIPT)
+assert spec and spec.loader
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+# A changelog with a fresh entry between the markers and an older entry below
+# the END marker. The older entry doubles as a tripwire: the hook must not
+# touch anything outside the new-entry block.
+FINAL = """\
+# Changelog
+
+<!-- <START NEW CHANGELOG ENTRY> -->
+
+## 3.4.5
+
+([Full Changelog](https://github.com/jupyterlab/jupyter-ai/compare/v3.4.4...abc))
+
+### Bugs fixed
+
+- Fix a thing [#42](https://github.com/jupyterlab/jupyter-ai/pull/42) ([@x](https://github.com/x))
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
+## 3.4.4
+
+Older entry, must not change.
+"""
+
+PRERELEASE = FINAL.replace("## 3.4.5", "## 3.5.0rc1")
+
+
+def _run(tmp_path, monkeypatch, text):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(text, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    rc = mod.main()
+    return rc, changelog.read_text(encoding="utf-8")
+
+
+def test_touches_only_the_new_entry(tmp_path, monkeypatch):
+    rc, out = _run(tmp_path, monkeypatch, FINAL)
+    assert rc == 0
+
+    # Everything below the END marker is byte-for-byte unchanged.
+    tail = out[out.index(mod.END) :]
+    assert tail == FINAL[FINAL.index(mod.END) :]
+
+    # The blurb is inserted exactly once, inside the new-entry block.
+    block = out[out.index(mod.START) : out.index(mod.END)]
+    assert out.count("for the complete v3.4.5 release notes") == 1
+    assert "for the complete v3.4.5 release notes" in block
+
+
+def test_layout_keeps_h2_then_blurb_then_separator_then_changelog(tmp_path, monkeypatch):
+    _, out = _run(tmp_path, monkeypatch, FINAL)
+    block = out[out.index(mod.START) : out.index(mod.END)]
+
+    heading = block.index("## 3.4.5")
+    blurb = block.index("for the complete v3.4.5 release notes")
+    separator = block.index("\n---\n")
+    full_changelog = block.index("([Full Changelog]")
+
+    # ## <version>  ->  blurb  ->  ---  ->  (Full Changelog)
+    assert heading < blurb < separator < full_changelog
+
+
+def test_prerelease_is_a_noop(tmp_path, monkeypatch):
+    rc, out = _run(tmp_path, monkeypatch, PRERELEASE)
+    assert rc == 0
+    assert out == PRERELEASE
+
+
+def test_idempotent(tmp_path, monkeypatch):
+    _, first = _run(tmp_path, monkeypatch, FINAL)
+    # Re-running against already-processed content changes nothing.
+    (tmp_path / "CHANGELOG.md").write_text(first, encoding="utf-8")
+    assert mod.main() == 0
+    assert (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8") == first


### PR DESCRIPTION
## Motivation

Jupyter AI's source code lives in the various subpackages, and the full release notes are published on the docs site. The changelog in this repo now only covers docs, version-range, and workflow changes, so each release we've manually pasted a preamble at the top of the entry pointing readers to the complete notes on the docs site (see the v3.1.3 entry). It's an easy step to forget.

## Summary

Step 1: Prep Release now inserts that preamble automatically, just under the version heading, so every stable release gets it without hand-editing. Prereleases are left untouched, since they have no `stable` docs page to link to.

## Technical details

jupyter-releaser's `build-changelog` has no template or preamble option, so the injection point is an `after-build-changelog` hook (this repo already uses `after-bump-version`). The hook runs `scripts/after_build_changelog.py`, which finds the freshly-written entry between the changelog markers, and for a final `X.Y.Z` version inserts the blurb under the heading. It skips prereleases and is idempotent on re-runs. The blurb carries no PR links, so `check-changelog` is unaffected.